### PR TITLE
docs: pivot to kernel-as-OS; adapters are plugins; add plugin protocol (#9)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -10,15 +10,18 @@
 
 ## 1. Philosophy
 
-yaya is a **lightweight, kernel-style agent that grows itself**. A single
-Python process (`yaya serve`) exposes an event-driven kernel; the default
-surface is a local web UI built on
-[`@mariozechner/pi-web-ui`](https://github.com/badlogic/pi-mono/tree/main/packages/web-ui)
-speaking WebSocket to the kernel. Everything else is a plugin.
-Engineering rigor is non-negotiable: every change small, traceable,
-reviewed, and covered by tests. No spaghetti, no dead code, no
-undocumented public surface. See [GOAL.md](GOAL.md) for the full product
-anchor (North Star · Principles · Non-Goals · Anti-Vision).
+yaya is a **lightweight, kernel-style agent that grows itself**. The
+kernel ships an event bus, a plugin registry, and a fixed agent loop
+(the scheduler). **Every user surface, every LLM provider, every
+tool, every skill, every memory backend, every strategy is a
+plugin** — including the ones we bundle. `yaya serve` boots the
+kernel and loads the bundled `web` adapter plugin; bundled plugins
+load through the **same protocol** as third-party plugins, no
+special case. Engineering rigor is non-negotiable: every change
+small, traceable, reviewed, and covered by tests. See
+[GOAL.md](GOAL.md) for the product anchor and
+[docs/dev/plugin-protocol.md](docs/dev/plugin-protocol.md) for the
+authoritative event and ABI contract.
 
 ## 2. Style Anchors
 
@@ -83,12 +86,13 @@ Read local first, save tokens. Every code/test/scripts folder has its own
 **Folder indexes**:
 
 - [src/yaya/AGENT.md](src/yaya/AGENT.md) · [src/yaya/cli/AGENT.md](src/yaya/cli/AGENT.md) · [src/yaya/cli/commands/AGENT.md](src/yaya/cli/commands/AGENT.md) · [src/yaya/core/AGENT.md](src/yaya/core/AGENT.md)
-- `src/yaya/kernel/AGENT.md` · `src/yaya/web/AGENT.md` · `src/yaya/plugins/AGENT.md` (created when each subpackage lands — see [docs/dev/web-ui.md](docs/dev/web-ui.md) and [docs/dev/architecture.md](docs/dev/architecture.md))
+- `src/yaya/kernel/AGENT.md` · `src/yaya/plugins/AGENT.md` · `src/yaya/plugins/web/AGENT.md` (created when each subpackage lands — see [docs/dev/plugin-protocol.md](docs/dev/plugin-protocol.md), [docs/dev/architecture.md](docs/dev/architecture.md), [docs/dev/web-ui.md](docs/dev/web-ui.md))
 - [tests/AGENT.md](tests/AGENT.md) · [scripts/AGENT.md](scripts/AGENT.md)
 
 **Topic docs** (pull only when needed):
 
 - [docs/dev/architecture.md](docs/dev/architecture.md) · [docs/dev/workflow.md](docs/dev/workflow.md) · [docs/dev/multi-agent.md](docs/dev/multi-agent.md) · [docs/dev/maintaining-agent-md.md](docs/dev/maintaining-agent-md.md)
+- [docs/dev/plugin-protocol.md](docs/dev/plugin-protocol.md) — **authoritative** event catalog + plugin ABI + category table.
 - [docs/dev/cli.md](docs/dev/cli.md) · [docs/dev/agent-friendly-cli.md](docs/dev/agent-friendly-cli.md) · [docs/dev/web-ui.md](docs/dev/web-ui.md) · [docs/dev/testing.md](docs/dev/testing.md) · [docs/dev/agent-spec.md](docs/dev/agent-spec.md) · [docs/dev/code-comments.md](docs/dev/code-comments.md) · [docs/dev/release.md](docs/dev/release.md)
 
 **Org baseline** (canonical, `gh api repos/rararulab/.github/contents/...`):

--- a/GOAL.md
+++ b/GOAL.md
@@ -7,13 +7,14 @@ no longer holds, update `GOAL.md` in the **same** PR and justify it.
 
 ## North Star
 
-yaya is a **lightweight, kernel-style agent that grows itself.** A single
-Python process (`yaya serve`) exposes an event-driven kernel whose
-plugins are the only way features get added. The default entrypoint is a
-local web UI built with
-[`@mariozechner/pi-web-ui`](https://github.com/badlogic/pi-mono/tree/main/packages/web-ui)
-that opens in the browser and speaks WebSocket to the kernel. yaya can
-author and install its own plugins on demand — that is the product.
+yaya is a **lightweight, kernel-style agent that grows itself.** The
+kernel is the product: an event bus, a plugin registry, and a fixed
+agent loop that acts as the scheduler. Everything else — **every user
+surface, every LLM provider, every tool, every skill, every memory
+backend, every next-action strategy** — is a plugin. Running `yaya
+serve` boots the kernel and loads the bundled `web` adapter plugin;
+users interact through a browser at `http://127.0.0.1:<port>`. yaya
+can author and install its own plugins on demand — that is the product.
 
 ## Problem
 
@@ -22,110 +23,164 @@ opinionated, and closed. Adding a capability means forking the product or
 waiting for upstream. **Users adapt to the agent, not the other way around.**
 
 yaya inverts that: when the user asks for a capability yaya does not have,
-yaya writes the plugin, installs it into itself, and the next request uses
-it. Self-hosting growth is the product.
+yaya writes the plugin, installs it, and the next request uses it.
+Self-hosting growth is the product.
 
 ## Users & Jobs
 
 - **Primary**: power users and developers who want an agent they can
   extend in minutes, not quarters.
 - **Typical session (5 minutes)**: run `yaya serve`, browser opens to
-  `http://127.0.0.1:<port>`, describe a task in chat. yaya either handles
-  it with existing plugins or drafts a plugin, installs it, reloads the
-  kernel, and completes the task with the new capability live.
-- **Secondary**: plugin authors who want a minimal, stable kernel to build
-  against without ceremony.
-
-## Product Principles (priority order)
-
-1. **Kernel stays small.** If a feature could be a plugin, it is a plugin.
-   The core ships an event bus, a plugin loader, a web-server shell, and
-   nothing else.
-2. **Self-hosting growth.** yaya ships the machinery to extend yaya.
-   Plugin authoring is a first-class **agent** capability, not an
-   afterthought for humans.
-3. **Single-process, local-first.** One Python process. No required
-   backend, no account. Default bind: `127.0.0.1`. A remote LLM is a
-   plugin, not a dependency.
-4. **Events are the contract.** Plugins subscribe to event types; the
-   kernel routes. The web UI is just another subscriber over WebSocket.
-   No hidden globals, no direct plugin-to-plugin coupling.
-5. **Fail loud, degrade gracefully.** A broken plugin taints only itself;
-   the kernel keeps running. The web UI keeps rendering whatever events
-   still arrive.
-6. **Readable > clever.** A new plugin author understands the kernel in
-   one sitting.
-7. **Ship assets, not toolchains.** The web UI is pre-built to static
-   assets and bundled into the Python wheel. End users install with
-   `pip` and need no Node, npm, or browser plugin.
-
-## Non-Goals (explicit)
-
-- **NOT** an IDE or language server. yaya is an agent with a local web UI.
-- **NOT** a hosted web service. Through 1.0, `yaya serve` binds
-  `127.0.0.1` only. No public-internet deployment, no auth layer, no
-  multi-tenant mode. Anyone who wants that runs it behind their own
-  reverse proxy at their own risk.
-- **NOT** a cloud service. No hosted control plane, no account, no
-  telemetry-by-default.
-- **NOT** a general-purpose LLM-app framework. The scope is "an agent
-  that grows itself", not arbitrary orchestration.
-- **NOT** a Claude Code / Cursor replacement for teams that want a
-  curated product. yaya is for users who want to own their agent.
+  `http://127.0.0.1:<port>`, describe a task. yaya handles it with
+  installed plugins or drafts a new plugin, installs it, reloads, and
+  completes the task with the new capability live.
+- **Secondary**: plugin authors who want a minimal, stable kernel —
+  and a clear plugin protocol — to build against.
 
 ## Runtime shape
 
 ```
-yaya serve
-└── one Python process (uvicorn + FastAPI in-process)
-    ├── GET /             → pre-built UI shell (HTML)
-    ├── GET /assets/*     → static JS/CSS from importlib.resources
-    ├── WS  /ws           → kernel event bus ↔ web UI (the contract)
-    └── API /plugins/*    → list / install / remove / reload
+                ADAPTERS                      TOOLS
+             (plugins)                     (plugins)
+          web / tui / tg                bash / fs / http ...
+                │                             ▲
+                ▼                             │
+        ┌───────────── KERNEL (yaya) ─────────────┐
+        │    event bus  ·  plugin registry        │
+        │    agent loop (the scheduler)           │
+        │    built-in CLI (self-bootstrap only):  │
+        │       serve · version · update · hello  │
+        │       · plugin {list, install, remove}  │
+        └─────┬─────────┬────────────┬────────────┘
+              ▼         ▼            ▼
+         STRATEGIES  SKILLS      MEMORY
+         (plugins)  (plugins)   (plugins)
+         ReAct /    domain-     sqlite / vec / ...
+         plan-exec  specific
+         / ...
+                         │
+                         ▼
+                   LLM PROVIDERS
+                    (plugins)
+                openai / anthropic /
+                ollama / lmstudio / ...
 ```
 
-The web UI is **consumed** as `@mariozechner/pi-web-ui` (npm dependency
-in `src/yaya/web/package.json`). yaya provides its own shell and talks
-to the Python kernel over WebSocket; yaya does **not** embed
-`pi-agent-core` or any JS/TS agent runtime.
+Kernel = OS. Events = syscalls. Plugins = drivers + userland.
 
-## Command surface (minimum)
+## Product Principles (priority order)
+
+1. **Kernel stays small.** The kernel ships only the event bus, the
+   plugin registry, the agent loop, and the minimum CLI required to
+   bootstrap and manage plugins. **If it could be a plugin, it is a
+   plugin** — including every user surface, every LLM provider, every
+   strategy, every memory backend.
+2. **Adapters are plugins from day 1.** Web, TUI, Telegram, Slack —
+   all implement the same adapter contract. `yaya serve` boots the
+   kernel and loads the bundled `web` adapter plugin. We dogfood the
+   protocol so it is never "special" for core.
+3. **Closed event set at 1.0.** A finite, versioned catalog of event
+   kinds (see `docs/dev/plugin-protocol.md`).
+   Plugin-private payloads use the `x.<plugin>.<kind>` extension
+   namespace — they route through the bus but do not pollute the
+   public contract.
+4. **Agent loop is the scheduler.** Loop shape is fixed and lives in
+   the kernel. Per-step decisions (next action, retry, stop condition)
+   are delegated to a `strategy` plugin category. ReAct / plan-execute
+   / reflexion are each a strategy plugin.
+5. **Self-hosting growth.** yaya ships the machinery to extend yaya.
+   Plugin authoring is a first-class **agent** capability, not an
+   afterthought for humans.
+6. **Single-process, local-first.** One Python process. No required
+   backend, no account. Default bind: `127.0.0.1`. A remote LLM is a
+   provider plugin, not a dependency.
+7. **Fail loud, degrade gracefully.** A broken plugin taints only
+   itself; the kernel keeps running. The event bus drops that plugin's
+   subscriptions and surfaces a `plugin.error` event.
+8. **Readable > clever.** A new plugin author understands the kernel
+   and the protocol in one sitting.
+9. **Ship assets, not toolchains.** The bundled web adapter is
+   pre-built to static assets and shipped in the Python wheel. End
+   users install with `pip` — no Node, no npm, no browser extension
+   at install or run time.
+
+## Non-Goals (explicit)
+
+- **NOT** an IDE or language server. yaya is an agent with pluggable
+  surfaces; the default surface is a local web UI.
+- **NOT** a hosted web service. Through 1.0, `yaya serve` binds
+  `127.0.0.1` only. No public bind flag, no auth layer, no multi-tenant
+  mode. Anyone who wants that runs yaya behind their own reverse proxy
+  at their own risk.
+- **NOT** a cloud service. No hosted control plane, no account, no
+  telemetry-by-default.
+- **NOT** a general-purpose LLM-app framework. The scope is "an agent
+  that grows itself"; the plugin protocol serves that scope, not
+  arbitrary orchestration.
+- **NOT** an agent runtime with pluggable loop *shapes*. The loop is
+  fixed; only its *decisions* are pluggable via strategy plugins.
+
+## Command surface (1.0, kernel built-ins only)
 
 | Command | Purpose |
 |---------|---------|
-| `yaya serve` | Default. Starts the single-process server; opens browser. |
-| `yaya version` | Print version. |
-| `yaya plugin list` | List installed plugins. |
-| `yaya plugin install <src>` | Install from path / URL / registry. |
+| `yaya serve` | **Default.** Boot kernel; load bundled `web` adapter plugin; open browser. |
+| `yaya version` | Print kernel + loaded-plugin versions. |
+| `yaya update` | Self-update the yaya binary/wheel. |
+| `yaya hello` | Smoke-test: boot kernel, emit a synthetic event round-trip, print OK. |
+| `yaya plugin list` | List installed plugins with category and status. |
+| `yaya plugin install <src>` | Install a plugin (pip package / path / registry URL). |
 | `yaya plugin remove <name>` | Uninstall. |
 
-Everything else — including `hello` and `update` — ships as a plugin, not
-a built-in subcommand.
+Everything else — adapters, tools, skills, memory, LLM providers,
+strategies — is a plugin. Adding a new built-in subcommand requires a
+GOAL.md amendment.
+
+## Plugin categories (1.0 closed set)
+
+| Category | Subscribes to | Emits |
+|---|---|---|
+| **adapter** | `assistant.message.*`, `tool.call.start` | `user.message.received`, `user.interrupt` |
+| **tool** | `tool.call.request` | `tool.call.result` |
+| **llm-provider** | `llm.call.request` | `llm.call.response`, `llm.call.error` |
+| **strategy** | `strategy.decide.request` | `strategy.decide.response` |
+| **memory** | `memory.query`, `memory.write` | `memory.result` |
+| **skill** | `user.message.received` (filtered) | any of the above via kernel |
+
+Full event catalog lives in
+`docs/dev/plugin-protocol.md` and is the
+authoritative 1.0 contract.
 
 ## Milestones
 
-- **0.1 — kernel live in browser** — event bus, plugin loader, `yaya
-  serve`, web UI shell rendering plugin output. 2–3 seed plugins
-  (`version`, `update`, `hello`) as reference plugins. Each has a
-  `specs/<name>.spec.md` contract.
-- **0.5 — self-authoring plugin** — in the web UI chat, "I want X"
-  produces `specs/<x>.spec.md`, scaffolds a plugin, installs it locally,
-  reloads the kernel, UI picks up the new capability without restart.
-- **1.0 — stable ABIs frozen** — plugin Python ABI (event shapes,
-  lifecycle, permissions) and WebSocket UI protocol are both frozen.
-  Plugins and UIs written against 1.0 keep working across 1.x.
-- **2.0 — plugin registry + sandboxing** — discovery, install, share;
-  plugins run in a capability-restricted sandbox by default.
+- **0.1 — kernel live end-to-end**: kernel (event bus + registry +
+  fixed agent loop), plugin protocol v0, bundled plugins covering one
+  of each category (web adapter · one LLM provider · one tool · one
+  strategy · one memory), `yaya serve` opens a browser chat that
+  round-trips a real LLM call through the bus.
+- **0.5 — self-authoring plugin**: in the web UI, "I want X" produces
+  a `specs/<x>.spec.md`, scaffolds a plugin (correct category,
+  subscribes to the right events), installs it locally, reloads the
+  kernel, UI picks up the new capability without restart.
+- **1.0 — protocol freeze**: event taxonomy, plugin ABI, strategy
+  interface, adapter contract, and the web↔kernel WS schema are all
+  frozen. Plugins written against 1.0 keep working across 1.x.
+- **2.0 — marketplace + sandbox**: plugin registry (discovery + install
+  from a curated index), signed plugins, capability-restricted sandbox
+  execution by default.
 
 ## Success Metrics
 
-- **Time-to-first-plugin** for a new user: ≤5 minutes from `pip install`
-  to a working custom plugin authored through the web UI.
-- **Kernel size budget** (Python LOC outside plugins and web shell):
-  stays under <!-- TODO: confirm target, e.g. 2000 LOC --> through 1.0.
-  Enforced in CI.
+- **Time-to-first-plugin** for a new user: ≤5 minutes from `pip install
+  yaya` to a working custom plugin authored through the web UI.
+- **Seed release (0.1) plugin count**: exactly one of each category
+  (web adapter + 1 LLM provider + 1 tool + 1 strategy + 1 memory).
+  Deliberately minimal to prove the protocol.
+- **Kernel size budget** (Python LOC in `src/yaya/kernel/` +
+  `src/yaya/cli/`, excluding plugins and the web shell): stays under
+  <!-- TODO: confirm target, e.g. 2000 LOC --> through 1.0. Enforced in CI.
 - **Self-authoring rate**: ≥30% of plugins in the wild authored through
-  yaya's own self-authoring loop (health metric for principle #2).
+  yaya's own self-authoring loop (health metric for principle #5).
 - **Cold start**: `yaya serve` to interactive chat in the browser in
   ≤<!-- TODO: confirm, e.g. 500ms cold, 150ms warm -->.
 - **Wheel size**: bundled web assets + Python package stays under
@@ -135,7 +190,11 @@ a built-in subcommand.
 
 - A monolith where features accumulate in the kernel to "avoid plugin
   boilerplate".
-- An agent locked to one LLM vendor or one runtime.
+- A kernel with special cases for the bundled plugins. Bundled plugins
+  load through the **same protocol** as third-party plugins.
+- An agent with a fork of the event bus for "internal events" that
+  third-party plugins cannot subscribe to.
+- An agent locked to one LLM vendor, one runtime, or one UI.
 - A hosted SaaS with accounts, billing, and a control plane.
 - A polyglot dual-runtime beast that needs Node **at run time** on the
   user's machine.
@@ -143,10 +202,11 @@ a built-in subcommand.
 
 ## Governance of this document
 
-- Changing North Star, Principles, Non-Goals, or Anti-Vision requires
-  owner review and a dedicated issue labelled `governance`.
-- Milestones and Success Metrics may be refined in ordinary PRs with
-  justification in the PR body.
+- Changing North Star, Principles, Non-Goals, Anti-Vision, or the
+  closed event taxonomy requires owner review and a dedicated issue
+  labelled `governance`.
+- Milestones, Success Metrics, and the plugin category table may be
+  refined in ordinary PRs with justification in the PR body.
 - Every `docs/dev/*.md` and folder-local `AGENT.md` must be consistent
-  with `GOAL.md`. When they conflict, `GOAL.md` wins — fix the downstream
-  doc in the same PR that introduced the conflict.
+  with `GOAL.md`. When they conflict, `GOAL.md` wins — fix the
+  downstream doc in the same PR that introduced the conflict.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Full site: **<https://rararulab.github.io/yaya/>**
 ### Development (for contributors and coding agents)
 
 - [AGENT.md](AGENT.md) — agent entry index.
-- [docs/dev/architecture.md](docs/dev/architecture.md)
+- [docs/dev/architecture.md](docs/dev/architecture.md) — kernel + plugins layout.
+- [docs/dev/plugin-protocol.md](docs/dev/plugin-protocol.md) — event catalog + plugin ABI (authoritative).
 - [docs/dev/workflow.md](docs/dev/workflow.md) — issue → worktree → PR.
 - [docs/dev/multi-agent.md](docs/dev/multi-agent.md)
 - [docs/dev/cli.md](docs/dev/cli.md)

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,61 +1,87 @@
 # Architecture
 
-Clean-architecture layering. Outer layers depend on inner, never the reverse.
+yaya is a small kernel with plugins orbiting it. The kernel owns the
+event bus, the plugin registry, and a fixed agent loop. **Every user
+surface, every LLM provider, every tool, every skill, every memory
+backend, every strategy is a plugin** — including the ones we bundle.
+See [GOAL.md](../goal.md) for the product anchor and
+[plugin-protocol.md](plugin-protocol.md) for the authoritative contract.
 
-## Runtime
+## Runtime shape
 
 ```
-yaya serve   (one Python process)
-└── uvicorn + FastAPI in-process
-    ├── HTTP  /           → pre-built web UI shell
-    ├── HTTP  /assets/*   → static JS/CSS (importlib.resources)
-    ├── WS    /ws         → kernel event bus ↔ UI (the contract)
-    └── API   /plugins/*  → list / install / remove / reload
+                ADAPTERS                      TOOLS
+             (plugins)                     (plugins)
+          web / tui / tg                bash / fs / http ...
+                │                             ▲
+                ▼                             │
+        ┌───────────── KERNEL (yaya) ─────────────┐
+        │    event bus  ·  plugin registry        │
+        │    agent loop (the scheduler)           │
+        │    built-in CLI: serve / version /      │
+        │      update / hello / plugin {...}      │
+        └─────┬─────────┬────────────┬────────────┘
+              ▼         ▼            ▼
+         STRATEGIES  SKILLS      MEMORY
+         (plugins)  (plugins)   (plugins)
+                         │
+                         ▼
+                   LLM PROVIDERS
+                    (plugins)
 ```
 
-Single process. Default bind `127.0.0.1`. No Node at install or run time —
-the web UI is pre-built and bundled in the wheel. See [GOAL.md](../goal.md).
+`yaya serve` = kernel boots → loads bundled `web` adapter plugin →
+opens browser at `http://127.0.0.1:<port>`. One Python process.
+Default bind `127.0.0.1`. No Node at install or run time — the web
+adapter's UI assets are pre-built and shipped in the wheel.
 
 ## Source layout
 
 ```
 src/yaya/
-  __init__.py       # versioned public API
-  __main__.py       # python -m yaya → cli.app
-  cli/              # Typer entrypoints: serve / version / plugin
-    commands/       # one file per subcommand
-    output.py       # shared rendering helpers (for CLI, not the web UI)
-  kernel/           # event bus, plugin loader, event schemas (events.py)
-  web/              # FastAPI app + WebSocket bridge + static/ (built assets)
-    package.json    # consumes @mariozechner/pi-web-ui from npm
-    src/            # TypeScript shell (dev-time only)
-    static/         # build output — ships in the wheel
-  plugins/          # seed plugins shipped in-tree (version, update, hello)
-  core/             # shared pure-logic helpers (updater, etc.)
-tests/              # mirrors src/ one-to-one
-specs/              # BDD contracts (agent-spec) per feature
+  __init__.py         # versioned public API
+  __main__.py         # python -m yaya → cli.app
+  cli/                # Typer entrypoints: serve / version / update / hello / plugin
+    commands/         # one file per subcommand
+    output.py         # shared rendering helpers (CLI only — not web UI)
+  kernel/             # the kernel — the entire product core lives here
+    bus.py            # event bus: pub/sub, ordering, backpressure
+    registry.py       # plugin discovery, lifecycle, failure accounting
+    loop.py           # fixed agent loop; calls out to strategy / llm / tool / memory
+    plugin.py         # Plugin ABI (Protocol), KernelContext, Category enum
+    events.py         # closed event-kind catalog + TypedDict payloads (authoritative)
+  plugins/            # bundled plugins — load through the same protocol as third-party
+    web/              # web adapter (FastAPI WS bridge + pi-web-ui static assets)
+      package.json    # npm: consumes @mariozechner/pi-web-ui
+      src/            # TypeScript shell (dev-time only)
+      static/         # build output — ships in the wheel
+    llm_openai/       # seed llm-provider plugin
+    tool_bash/        # seed tool plugin
+    strategy_react/   # seed strategy plugin
+    memory_sqlite/    # seed memory plugin
+  core/               # shared pure-logic helpers (updater, etc.)
+tests/                # mirrors src/ one-to-one
+specs/                # BDD contracts (agent-spec) per feature
 ```
 
 ## Layering rules
 
-- `core/` and `kernel/` have **zero** imports from `cli/` or `web/`.
-  Verified by ruff's import rules and tests.
-- `kernel/` is the innermost layer. `web/` and `cli/` are both adapters
-  that drive the kernel; `plugins/` are subscribers to kernel events.
-- Every subpackage under `src/yaya/` has its own `AGENT.md` describing
-  its purpose, invariants, and "do not" list
-  (see `rararulab/.github/docs/agent-md.md`).
-- Every public (non-underscore) callable/class has a docstring explaining
-  **why**, not **what**. Private helpers document only non-obvious invariants.
-- `src/yaya/__init__.py` exposes the versioned public API; nothing else
-  is importable from outside the package.
+- `kernel/` has **zero** imports from `cli/`, `plugins/`, or `core/`.
+  It defines the protocol; everything else depends on it.
+- `plugins/*` import from `kernel/` only. Cross-plugin communication
+  **must** go through events — no direct Python imports between plugin
+  subpackages.
+- `cli/` imports from `kernel/` (to boot it) and from `core/` (shared
+  helpers). Never from `plugins/*`.
+- `core/` is the shared utility layer; it has no kernel knowledge.
+- Every subpackage under `src/yaya/` has its own `AGENT.md`.
 
-## Kernel ↔ UI contract
+## Kernel ↔ adapter contract
 
-The WebSocket event protocol is the **only** coupling between Python and
-the browser. Python is authoritative; the TS types in `web/src/events.ts`
-mirror `kernel/events.py` and CI fails on drift. See
-[web-ui.md](web-ui.md) for the event catalog.
+Adapters speak the public event set (see
+[plugin-protocol.md](plugin-protocol.md)). The web adapter layers a
+WebSocket protocol on top of those events — the WS schema is a thin
+serialization of the event catalog, and mismatches fail CI.
 
 ## Specs live next to code
 
@@ -71,6 +97,6 @@ Python follows the [Google Python Style Guide](https://google.github.io/stylegui
 with yaya overlays in [code-comments.md](code-comments.md). Enforced by
 `ruff` (lint + format) and `mypy --strict`.
 
-TypeScript under `src/yaya/web/` follows `vendor/pi-mono/AGENTS.md`
-conventions (no `any`, no dynamic imports for types, biome for
-lint/format). Enforced by `just web-check`.
+TypeScript under `src/yaya/plugins/web/` follows
+`vendor/pi-mono/AGENTS.md` conventions (no `any`, no dynamic imports
+for types, biome for lint/format). Enforced by `just web-check`.

--- a/docs/dev/cli.md
+++ b/docs/dev/cli.md
@@ -1,40 +1,49 @@
 # CLI Conventions
 
-yaya's default experience is the web UI (`yaya serve`). The CLI stays
-minimal and scripting-friendly. Canonical org spec:
-`rararulab/.github/docs/agent-friendly-cli.md` — yaya follows it strictly.
+yaya's default experience is the web adapter (`yaya serve`). The CLI is
+minimal — it exists only to bootstrap the kernel and manage plugins.
+Canonical org spec: `rararulab/.github/docs/agent-friendly-cli.md`.
 This file captures yaya-specific mechanics.
 
-## Command surface (1.0)
+## Command surface (1.0, kernel built-ins only)
 
 | Command | Purpose |
 |---------|---------|
-| `yaya serve` | **Default.** Start the single-process web server; open browser. |
-| `yaya version` | Print version. |
-| `yaya plugin list` | List installed plugins. |
-| `yaya plugin install <src>` | Install from path / URL / registry. |
+| `yaya serve` | **Default.** Boot kernel; load bundled `web` adapter plugin; open browser. |
+| `yaya version` | Print kernel + loaded-plugin versions. |
+| `yaya update` | Self-update the yaya binary/wheel. |
+| `yaya hello` | Smoke-test: boot kernel, emit a synthetic event round-trip, print OK. |
+| `yaya plugin list` | List installed plugins with category and status. |
+| `yaya plugin install <src>` | Install a plugin (pip package / path / registry URL). |
 | `yaya plugin remove <name>` | Uninstall. |
 
-Everything else — `hello`, `update`, future integrations — ships as a
-plugin. Adding a built-in subcommand requires a GOAL.md amendment.
+Everything else — adapters (other than `web`), tools, skills, memory,
+LLM providers, strategies — is a plugin.
+
+**Adding a new built-in CLI subcommand requires a GOAL.md amendment.**
+The built-ins above are the self-bootstrap surface; new capability
+belongs in plugins.
 
 ## Pattern
 
 Every CLI subcommand:
 
-1. Builds a result in `core/` or `kernel/` (pure logic, no printing, no `sys.exit`).
-2. Calls `emit_ok` / `emit_error` from `yaya.cli.output` — never `print`,
-   `typer.echo`, or `Console().print` directly.
+1. Builds a result by calling into `kernel/` (for `serve`, `hello`,
+   `plugin *`) or `core/` (for `version`, `update`). Pure logic, no
+   printing, no `sys.exit`.
+2. Calls `emit_ok` / `emit_error` from `yaya.cli.output` — never
+   `print`, `typer.echo`, or `Console().print` directly.
 3. Exits non-zero on failure; `fatal()` is the one-liner helper.
 
 ## `yaya serve` specifics
 
 ```bash
 yaya serve                       # bind 127.0.0.1:<auto>, open browser
-yaya serve --port 7456            # fixed port
-yaya serve --no-open              # do not launch browser
-yaya serve --dev                  # proxy to `vite dev` for UI HMR
-yaya serve --json                 # JSON lifecycle events on stdout (addr, pid, shutdown)
+yaya serve --port 7456           # fixed port
+yaya serve --no-open             # do not launch browser
+yaya serve --dev                 # proxy to `vite dev` for UI HMR
+yaya serve --strategy <id>       # pick the active strategy plugin (default: react)
+yaya serve --json                # JSON lifecycle events on stdout (addr, pid, shutdown)
 ```
 
 - Bind is always `127.0.0.1` through 1.0 (see [GOAL.md](../goal.md)).
@@ -42,28 +51,49 @@ yaya serve --json                 # JSON lifecycle events on stdout (addr, pid, 
 - Exit cleanly on `SIGINT` / `SIGTERM`; emit a final
   `{"ok": true, "action": "shutdown", ...}` under `--json`.
 - Kernel startup errors exit non-zero with a `suggestion` field.
+- Plugin load failures surface as `plugin.error` events but do NOT
+  fail the serve command — the kernel keeps running (see
+  [plugin-protocol.md](plugin-protocol.md#plugin-failure-model)).
+
+## `yaya plugin` specifics
+
+```bash
+yaya plugin list                       # all discovered plugins, category, status
+yaya plugin install yaya-tool-bash     # pip resolve from PyPI
+yaya plugin install ./my-plugin        # editable install from path
+yaya plugin install --json <src>       # machine-readable output
+yaya plugin remove yaya-tool-bash
+```
+
+- `install` shells to `pip install` under the hood and refreshes the
+  registry without requiring a `yaya serve` restart for third-party
+  plugins (implementation detail — see
+  [plugin-protocol.md](plugin-protocol.md#plugin-discovery-and-loading)).
+- Removing a bundled plugin is an error — the CLI rejects it with a
+  `suggestion` pointing at `yaya plugin disable` (reserved for 0.5+).
 
 ## JSON mode (`--json`)
 
-- Stdout carries `{"ok": bool, ...}`. Contract enforced by `cli/output.py`.
+- Stdout carries `{"ok": bool, ...}`. Contract enforced by
+  `cli/output.py`.
 - Success: `{"ok": true, "action": "<verb>", ...data}`.
 - Error: `{"ok": false, "error": "...", "suggestion": "...", ...data}`.
 - Human logs / warnings go to **stderr** (`warn(...)`).
 
-## Extending the CLI — checklist
+## Extending the CLI — checklist (rarely used)
 
-Adding a new CLI command is a GOAL.md amendment (see surface above). If
-approved, follow this:
+Adding a new built-in CLI command is a **GOAL.md amendment**. If the
+amendment is approved:
 
 - [ ] Amend GOAL.md's "Command surface" in the same PR.
 - [ ] Create `src/yaya/cli/commands/<name>.py` exposing `register(app)`.
 - [ ] Register it in `src/yaya/cli/__init__.py`.
-- [ ] Body pattern: build a structured result in `core/` or `kernel/`,
-      then `emit_ok` / `emit_error`. No direct printing.
+- [ ] Body pattern: build a structured result in `kernel/` or
+      `core/`, then `emit_ok` / `emit_error`. No direct printing.
 - [ ] Add `epilog=EXAMPLES` with at least one runnable example.
 - [ ] Destructive? Add `--dry-run` and `--yes`.
 - [ ] Error paths must emit a `suggestion` and exit non-zero.
-- [ ] Add `tests/cli/test_<name>.py` covering text mode, `--json`, and
-      at least one failure path (exit code + JSON shape).
-- [ ] Network/disk work: add `tests/core/test_<module>.py` with
-      `pytest-httpx` mocks — no real network in tests.
+- [ ] Add `tests/cli/test_<name>.py` covering text mode, `--json`,
+      and at least one failure path (exit code + JSON shape).
+- [ ] Network/disk work: `pytest-httpx` mocks — no real network in
+      tests.

--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -1,0 +1,264 @@
+# Plugin Protocol (v0 → 1.0)
+
+yaya's kernel is deliberately small: an event bus, a plugin registry,
+and a fixed agent loop. **Everything else is a plugin** — every user
+surface, every LLM provider, every tool, every skill, every memory
+backend, every next-action strategy. This document is the authoritative
+contract.
+
+- **v0** is the 0.1 shape we ship with. Shapes may evolve in 0.x.
+- **1.0** freezes: event kinds, payload schemas, the registration ABI,
+  the strategy interface, the adapter contract, and the web↔kernel WS
+  schema. Plugins written against 1.0 keep working across 1.x.
+
+## Plugin categories (closed set)
+
+| Category | Role | Subscribes to | Emits |
+|---|---|---|---|
+| `adapter` | User surface (web, TUI, Telegram, …). Translates external I/O to kernel events and renders outgoing events. | `assistant.message.*`, `tool.call.start`, `plugin.*`, `kernel.*` | `user.message.received`, `user.interrupt` |
+| `tool` | Executes a discrete action (run shell, read file, HTTP). | `tool.call.request` (filtered by tool name) | `tool.call.result` |
+| `llm-provider` | Speaks to one LLM vendor (OpenAI, Anthropic, Ollama, …). | `llm.call.request` (filtered by provider id) | `llm.call.response`, `llm.call.error` |
+| `strategy` | Decides the agent loop's next step. | `strategy.decide.request` | `strategy.decide.response` |
+| `memory` | Stores and retrieves conversational state. | `memory.query`, `memory.write` | `memory.result` |
+| `skill` | Domain-specific behavior built on top of the other categories. Subscribes to user messages (filtered) and orchestrates via kernel events. | `user.message.received` (filtered) | any public event via the kernel |
+
+A plugin declares exactly one category. Multi-category plugins ship as
+multiple packages.
+
+## Event taxonomy (v0 — frozen at 1.0)
+
+All events carry a common envelope:
+
+```python
+class Event(TypedDict):
+    id: str              # uuid, kernel-assigned on publish
+    kind: str            # dotted identifier — see catalog below
+    session_id: str      # conversation scope; plugin-private events pick any stable id
+    ts: float            # kernel-assigned unix epoch seconds
+    source: str          # plugin name that emitted it (or "kernel")
+    payload: dict        # kind-specific; shapes below
+```
+
+### Public event kinds (closed)
+
+#### User input (adapter → kernel)
+
+| kind | payload |
+|---|---|
+| `user.message.received` | `{ text: str, attachments?: list[Attachment] }` |
+| `user.interrupt` | `{}` (ends the current turn) |
+
+#### Assistant output (kernel → adapters)
+
+| kind | payload |
+|---|---|
+| `assistant.message.delta` | `{ content: str }` (streaming chunk) |
+| `assistant.message.done` | `{ content: str, tool_calls: list[ToolCall] }` |
+
+#### LLM invocation (kernel ↔ llm-provider)
+
+| kind | direction | payload |
+|---|---|---|
+| `llm.call.request` | kernel → provider | `{ provider: str, model: str, messages: list[Message], tools?: list[ToolSchema], params: dict }` |
+| `llm.call.response` | provider → kernel | `{ text?: str, tool_calls?: list[ToolCall], usage: Usage }` |
+| `llm.call.error` | provider → kernel | `{ error: str, retry_after_s?: float }` |
+
+#### Tool execution (kernel ↔ tool)
+
+| kind | direction | payload |
+|---|---|---|
+| `tool.call.request` | kernel → tool | `{ id: str, name: str, args: dict }` |
+| `tool.call.start` | kernel → adapters (for UI) | `{ id: str, name: str, args: dict }` |
+| `tool.call.result` | tool → kernel | `{ id: str, ok: bool, value?: Any, error?: str }` |
+
+#### Memory (kernel ↔ memory)
+
+| kind | direction | payload |
+|---|---|---|
+| `memory.query` | kernel → memory | `{ query: str, k: int }` |
+| `memory.write` | kernel → memory | `{ entry: MemoryEntry }` |
+| `memory.result` | memory → kernel | `{ hits: list[MemoryEntry] }` |
+
+#### Strategy (kernel ↔ strategy)
+
+| kind | direction | payload |
+|---|---|---|
+| `strategy.decide.request` | kernel → strategy | `{ state: AgentLoopState }` |
+| `strategy.decide.response` | strategy → kernel | `{ next: "llm" \| "tool" \| "memory" \| "done", ... }` |
+
+#### Plugin lifecycle (kernel → all)
+
+| kind | payload |
+|---|---|
+| `plugin.loaded` | `{ name: str, version: str, category: str }` |
+| `plugin.reloaded` | `{ name: str, version: str }` |
+| `plugin.removed` | `{ name: str }` |
+| `plugin.error` | `{ name: str, error: str }` |
+
+#### Kernel (kernel → all)
+
+| kind | payload |
+|---|---|
+| `kernel.ready` | `{ version: str }` |
+| `kernel.shutdown` | `{ reason: str }` |
+| `kernel.error` | `{ source: str, message: str }` |
+
+### Extension namespace
+
+Plugins may emit and subscribe to events named `x.<plugin>.<kind>`.
+The kernel routes these through the same bus but **does not interpret
+them and does not promise compatibility across versions**. Use this
+namespace for plugin-private payloads (e.g., a `stats` skill plugin
+emitting `x.stats.token.counted`). Do not use `x.*` as a workaround
+for missing public events — propose a public event kind instead.
+
+### What makes the set "closed"
+
+- A PR that introduces a new **public** event kind (anything not under
+  `x.<plugin>.<kind>`) is a **governance** change. It amends this
+  document, `GOAL.md`'s plugin category table, and the Python
+  `kernel/events.py` catalog in the same PR, and must carry the
+  `governance` label.
+- A PR that changes the **payload shape** of an existing public kind
+  is a breaking change. Before 1.0, bump the minor version and note
+  the migration. After 1.0, it requires a new kind (`foo.v2`) with
+  both carried during a deprecation window.
+
+## Plugin discovery and loading
+
+Plugins are ordinary Python packages that expose a setuptools entry
+point in the `yaya.plugins.v1` group:
+
+```toml
+# your-plugin's pyproject.toml
+[project]
+name = "yaya-tool-bash"
+version = "0.1.0"
+
+[project.entry-points."yaya.plugins.v1"]
+bash = "yaya_tool_bash:plugin"
+```
+
+`yaya_tool_bash:plugin` resolves to a `Plugin` object (see ABI below).
+
+The kernel discovers plugins in this order at boot:
+
+1. **Bundled** — subpackages of `src/yaya/plugins/` declared in yaya's
+   own `pyproject.toml` under the same entry-point group. Bundled
+   plugins load through the **same protocol** as third-party plugins.
+   No special cases.
+2. **Installed** — any package in the active environment exposing a
+   `yaya.plugins.v1` entry point (e.g., `pip install yaya-tool-bash`).
+3. **Local overrides** — packages registered via `yaya plugin install
+   <path>` (dev mode) in the user state directory.
+
+`yaya plugin install <src>` accepts:
+- A PyPI name: `yaya plugin install yaya-tool-bash` → shells to `pip install`.
+- A local path: `yaya plugin install ./my-plugin` → editable install.
+- A registry URL (2.0+): resolved through the future marketplace.
+
+## Plugin ABI
+
+Every plugin module exposes a `plugin` attribute conforming to this
+interface:
+
+```python
+# pseudocode — authoritative Python lives in src/yaya/kernel/plugin.py
+
+class Plugin(Protocol):
+    name: str              # globally unique, kebab-case
+    version: str           # semver
+    category: Category     # one of the six categories above
+    requires: list[str]    # other plugin names this depends on
+
+    def subscriptions(self) -> list[str]:
+        """Event kinds this plugin subscribes to.
+
+        For `tool`, `llm-provider`, `strategy`, `memory`: the kernel
+        filters by the category's default routing rules (see below).
+        For `adapter` and `skill`: the plugin picks from the public
+        event set; filtering by session_id is the plugin's job.
+        """
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        """Called once after registration, before any event delivery."""
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        """Handle an event. Raise to surface a plugin.error."""
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        """Called on hot-reload or kernel shutdown. Must be idempotent."""
+```
+
+`KernelContext` gives the plugin an `emit(kind, payload, *,
+session_id)` method, a scoped logger, access to its configuration,
+and a state directory under `<XDG_DATA_HOME>/yaya/plugins/<name>/`.
+
+### Category-specific extras
+
+- **`tool`** declares `tool_name: str` and `json_schema: dict` for
+  arguments. The kernel routes `tool.call.request` to the plugin whose
+  `tool_name` matches.
+- **`llm-provider`** declares `provider_id: str` (e.g., `"openai"`).
+  The kernel routes `llm.call.request` by `payload.provider`.
+- **`strategy`** declares `strategy_id: str`. Only one strategy is
+  active per session; `yaya serve --strategy <id>` (or a per-session
+  setting) selects it. Default: `react`.
+- **`memory`** declares whether it is a "short-term" or "long-term"
+  store. Kernel may route queries differently based on session age.
+- **`adapter`** declares `adapter_id: str`. An adapter may be
+  short-lived (one WebSocket session per user) or long-lived (Telegram
+  polling loop).
+
+## Agent loop (kernel-owned)
+
+The loop shape is fixed. Each turn runs this sequence:
+
+```
+user.message.received
+  → strategy.decide.request  →  strategy.decide.response
+    → memory.query           →  memory.result (if requested)
+    → llm.call.request       →  llm.call.response
+      → tool.call.request    →  tool.call.result   (repeat per tool)
+    → assistant.message.done
+  → memory.write (if requested by strategy)
+```
+
+Strategies control: which tools to offer, when to call memory, when to
+stop. Strategies **do not** change the ordering of the sequence —
+that is the kernel's contract with adapters.
+
+## Plugin failure model
+
+- A plugin raising from `on_event` produces `plugin.error` and the
+  kernel continues. Repeated failures (threshold configurable) unload
+  the plugin and emit `plugin.removed`.
+- A plugin hanging in `on_event` past a deadline (default 30s, per
+  category) is cancelled; the same counter increments.
+- `on_load` failure prevents registration; the plugin is marked
+  `status: failed` in `yaya plugin list` with the stack trace in its
+  state directory.
+- **The kernel never crashes because a plugin did**. If the kernel
+  itself raises, `kernel.error` fires, and `yaya serve` exits non-zero.
+
+## Security posture (1.0)
+
+- Plugins run in-process as trusted code. There is no sandbox in 1.0.
+- `yaya plugin install` surfaces a confirmation prompt showing the
+  source (PyPI / path / URL) and declared category.
+- The future sandbox (2.0) will restrict plugins by category-default
+  capability sets (e.g., `tool` plugins get no network unless they
+  declare it).
+
+## What NOT To Do
+
+- Do NOT add a special code path for bundled plugins. They must load,
+  subscribe, and fail through the same protocol as third-party plugins.
+- Do NOT emit public event kinds from plugin-private code paths. Use
+  the `x.<plugin>.<kind>` namespace.
+- Do NOT introduce a parallel event channel (e.g., a "fast path" for
+  adapter events). The bus is the bus.
+- Do NOT let plugins import from `src/yaya/cli/` or from each other
+  directly. Cross-plugin communication happens through events.
+- Do NOT break the agent loop's event ordering contract in a strategy
+  plugin. Strategies decide *content*, not *order*.

--- a/docs/dev/web-ui.md
+++ b/docs/dev/web-ui.md
@@ -1,7 +1,13 @@
-# Web UI
+# Web Adapter Plugin
 
-yaya's default surface is a local web UI served by `yaya serve` from a
-single Python process. The UI is built on
+The web UI is an **adapter plugin** named `web`, bundled with yaya and
+loaded by default when you run `yaya serve`. It is not a kernel
+subpackage — it lives under `src/yaya/plugins/web/` and loads through
+the same protocol as any third-party adapter (see
+[plugin-protocol.md](plugin-protocol.md)). The kernel has no special
+case for it.
+
+The browser UI is built on
 [`@mariozechner/pi-web-ui`](https://github.com/badlogic/pi-mono/tree/main/packages/web-ui)
 (Lit web components + TailwindCSS v4).
 
@@ -9,72 +15,95 @@ single Python process. The UI is built on
 
 ```
 yaya serve
-└── one Python process (uvicorn + FastAPI)
-    ├── GET /             → pre-built UI shell (HTML)
-    ├── GET /assets/*     → static JS/CSS (importlib.resources)
-    ├── WS  /ws           → kernel event bus ↔ UI (the contract)
-    └── API /plugins/*    → list / install / remove / reload
+└── one Python process
+    ├── kernel boot (bus · registry · agent loop)
+    │     └── discover + load bundled plugin "web" (and any others
+    │         registered via yaya.plugins.v1 entry point)
+    └── "web" adapter plugin started:
+          ├── uvicorn + FastAPI (ASGI)
+          ├── GET /            → pre-built UI shell (HTML)
+          ├── GET /assets/*    → static JS/CSS (importlib.resources)
+          ├── WS  /ws          → adapter ↔ kernel bridge (over the event bus)
+          └── API /plugins/*   → thin proxies to the registry
 ```
 
 - Default bind: `127.0.0.1:<port>` (port picked from env / CLI flag /
   first-free). Non-goal: public-internet deployment (see
   [GOAL.md](../goal.md)).
 - `yaya serve --no-open` suppresses the automatic browser launch.
-- The agent loop runs in Python. The browser is a **renderer and input
-  device**, not an agent runtime. We do **not** embed `pi-agent-core` or
-  any JS/TS agent.
+- The agent loop runs in the Python **kernel**. The browser is a
+  renderer and input device, nothing more. We do **not** embed
+  `pi-agent-core` or any JS/TS agent runtime.
+
+## Role in the plugin protocol
+
+The `web` plugin is an `adapter` (see
+[plugin-protocol.md](plugin-protocol.md#plugin-categories-closed-set)):
+
+| | |
+|---|---|
+| Subscribes | `assistant.message.*`, `tool.call.start`, `plugin.*`, `kernel.*` |
+| Emits | `user.message.received`, `user.interrupt` |
+| ABI extras | `adapter_id = "web"` |
+
+Each WebSocket client gets its own `session_id`. The adapter
+translates kernel events into WS frames to the browser and browser
+frames back into `user.message.received` events on the bus.
 
 ## Source layout
 
 ```
-src/yaya/web/
-├── package.json          # npm workspace — declares @mariozechner/pi-web-ui
+src/yaya/plugins/web/
+├── pyproject.toml       # ships as a Python subpackage; registers entry point
+├── __init__.py          # exposes `plugin: Plugin`
+├── server.py            # FastAPI app + WebSocket bridge
+├── package.json         # npm: @mariozechner/pi-web-ui (build-time dep)
 ├── tsconfig.json
 ├── vite.config.ts
-├── src/                  # our shell: wires pi-web-ui components to the WS event bus
+├── src/                 # our shell wiring pi-web-ui to the WS schema
 │   ├── main.ts
-│   ├── ws-client.ts      # thin WebSocket client speaking yaya's event protocol
-│   └── components/       # yaya-specific Lit components composing pi-web-ui primitives
+│   ├── ws-client.ts     # thin WS client speaking the yaya event schema
+│   └── components/      # yaya-specific Lit components
 ├── index.html
-└── static/               # *build output* — do NOT edit by hand
+└── static/              # *build output* — ships in the wheel
     ├── index.html
     ├── assets/*.js
     └── assets/*.css
 ```
 
-`static/` is git-tracked so end users who install the wheel get the UI
-without needing Node. CI verifies `static/` is up-to-date with `src/`
-(see below).
+`static/` is git-tracked so end users who install the wheel get the
+UI without Node. CI verifies `static/` is up-to-date with `src/`.
 
 ## Dependency policy
 
-- pi-web-ui is consumed **as an npm dependency** (`package.json`) — not
-  vendored, not forked. Upgrades go through ordinary `npm update` PRs.
-- `vendor/pi-mono/` in the repo is **reference only** — a pinned mirror
-  for agents and humans to read. Do NOT import from it; the build must
-  resolve through npm.
-- Peer dependencies (`@mariozechner/mini-lit`, `lit`) live in yaya's own
-  `package.json` and are pinned.
+- pi-web-ui is consumed **as an npm dependency** (`package.json`) —
+  not vendored, not forked. Upgrades go through ordinary `npm update`
+  PRs.
+- `vendor/pi-mono/` in the repo is **reference only** — a pinned
+  mirror for humans and agents to read. Do NOT import from it; the
+  build must resolve through npm.
+- Peer dependencies (`@mariozechner/mini-lit`, `lit`) live in the
+  plugin's own `package.json` and are pinned.
 
 ## Build pipeline
 
-yaya ships two toolchains; only the Python half is required at install
-time.
+yaya ships two toolchains; only the Python half is required at
+install time.
 
-- **Install time (user-facing)**: `pip install yaya`. Pure Python. The
-  wheel already contains `src/yaya/web/static/`.
+- **Install time (user-facing)**: `pip install yaya`. Pure Python.
+  The wheel already contains `src/yaya/plugins/web/static/`.
 - **Build time (contributor)**: Node + npm. `just web-build` runs
-  `npm ci && npm run build` inside `src/yaya/web/` and writes into
-  `static/`. The wheel's build step (`hatchling`) includes `static/`
-  as package data.
+  `npm ci && npm run build` inside `src/yaya/plugins/web/` and writes
+  into `static/`. The wheel's build step (`hatchling`) includes
+  `static/` as package data.
 - **Dev loop**: `just web-dev` starts Vite's dev server with HMR on a
-  separate port, proxied by `yaya serve --dev` to the Python backend.
+  separate port, proxied by `yaya serve --dev` to the Python kernel.
   Two processes during development, one at release.
 
 ### just recipes
 
 ```bash
-just web-install    # npm ci inside src/yaya/web
+just web-install    # npm ci inside src/yaya/plugins/web
 just web-build      # npm run build → static/
 just web-dev        # vite dev server (HMR)
 just web-check      # biome + tsc --noEmit
@@ -83,48 +112,48 @@ just web-check      # biome + tsc --noEmit
 ### CI rules
 
 - `just web-check` runs on every PR.
-- `just web-build` runs and CI **fails if `static/` changed** — i.e. the
+- `just web-build` runs and CI **fails if `static/` changed** — the
   PR author must commit the built assets alongside source changes.
-  Rationale: keeps the wheel reproducible; avoids Node in the release
-  pipeline.
+  Rationale: keeps the wheel reproducible; avoids Node in the
+  release pipeline.
 - Wheel-size budget (see [GOAL.md](../goal.md) success metrics) is
   asserted on the built artifact.
 
-## WebSocket event protocol (overview)
+## WebSocket schema
 
-The contract between kernel and UI is a stream of events. Shapes live in
-`src/yaya/kernel/events.py` (Python, authoritative) and
-`src/yaya/web/src/events.ts` (TypeScript, generated or hand-maintained
-in lock-step).
+The WS schema is a thin serialization of the public event set. The
+authoritative catalog lives in `src/yaya/kernel/events.py`; the TS
+mirror lives at `src/yaya/plugins/web/src/events.ts`. **Any change to
+`events.py` updates the TS side in the same PR** — CI compares a JSON
+Schema export of the Python catalog against the TS types.
 
-**Mandatory pairing**: any change to `events.py` updates the TS side in
-the same PR. A mismatch fails CI (checksum compare between Python JSON
-schema export and the TS type file).
+Frames flow in both directions:
 
-Minimal event kinds:
-
-| Kind | Direction | Payload |
+| WS frame | Direction | Kernel event |
 |---|---|---|
-| `user.message` | UI → kernel | `{ text, attachments? }` |
-| `assistant.message.delta` | kernel → UI | streaming text chunk |
-| `assistant.message.done` | kernel → UI | final message + tool calls |
-| `tool.call.start` | kernel → UI | `{ id, name, args }` |
-| `tool.call.result` | kernel → UI | `{ id, ok, value \| error }` |
-| `plugin.installed` | kernel → UI | `{ name, version }` |
-| `plugin.reloaded` | kernel → UI | `{ names }` |
-| `kernel.error` | kernel → UI | `{ source, message }` |
+| `{type: "user.message", text, attachments?}` | browser → adapter | `user.message.received` |
+| `{type: "user.interrupt"}` | browser → adapter | `user.interrupt` |
+| `{type: "assistant.delta", content}` | adapter → browser | `assistant.message.delta` |
+| `{type: "assistant.done", content, tool_calls}` | adapter → browser | `assistant.message.done` |
+| `{type: "tool.start", id, name, args}` | adapter → browser | `tool.call.start` |
+| `{type: "tool.result", id, ok, value?, error?}` | adapter → browser | `tool.call.result` |
+| `{type: "plugin.loaded", ...}` | adapter → browser | `plugin.loaded` |
+| `{type: "kernel.error", source, message}` | adapter → browser | `kernel.error` |
 
-Full catalog with JSON Schema lives next to `events.py` and is surfaced
-in [agent-spec.md](agent-spec.md) contracts.
+Extension events (`x.<plugin>.<kind>`) are forwarded transparently so
+plugin-private UI surfaces can receive their private events without
+kernel involvement.
 
 ## What NOT To Do
 
+- Do NOT special-case the web plugin in kernel code. It must register
+  and receive events through the same ABI as third-party adapters.
 - Do NOT import from `vendor/pi-mono/` — use the npm package.
-- Do NOT embed `pi-agent-core` or any JS/TS agent runtime. The agent is
-  Python; the browser renders.
+- Do NOT embed `pi-agent-core` or any JS/TS agent runtime. The agent
+  is Python; the browser renders.
 - Do NOT add a build step that requires Node **at install time** —
   users get a pre-built wheel.
-- Do NOT introduce an auth layer or a public-bind default to "make it
-  easier to deploy". That is a 2.x conversation at earliest.
+- Do NOT introduce an auth layer or a public-bind default. That is a
+  2.x conversation at earliest.
 - Do NOT couple UI components directly to kernel internals — the
-  WebSocket event protocol is the only contract.
+  event catalog is the only contract.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,8 @@ Requires Python 3.14+. Other install options → [Install](guide/install.md).
 
 ## Development
 
-- [Architecture](dev/architecture.md) — layout and layering.
+- [Architecture](dev/architecture.md) — kernel + plugins layout.
+- [Plugin Protocol](dev/plugin-protocol.md) — event catalog, ABI, categories (authoritative).
 - [Workflow](dev/workflow.md) — issue → worktree → PR (MANDATORY).
 - [Multi-Agent](dev/multi-agent.md) — parallel dispatch, hand-off rules.
 - [CLI Conventions](dev/cli.md) — command pattern and extension checklist.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - Usage: guide/usage.md
   - Development:
       - Architecture: dev/architecture.md
+      - Plugin Protocol: dev/plugin-protocol.md
       - Workflow: dev/workflow.md
       - Multi-Agent: dev/multi-agent.md
       - Maintaining AGENT.md: dev/maintaining-agent-md.md

--- a/src/yaya/AGENT.md
+++ b/src/yaya/AGENT.md
@@ -4,30 +4,34 @@
 
 ## Philosophy
 Package root. Defines the versioned public API and the CLI entry point.
+The core lives under `kernel/`; every user surface and capability is a
+plugin under `plugins/`.
 
 ## External Reality
 - `yaya.__version__` is the release contract — release-please bumps it from Conventional Commits.
 - Public exports from `__init__.py` are covered by tests in `tests/` (layout mirrors source).
-- Import graph is the contract: `kernel/` and `core/` MUST NOT import from `cli/` or `web/`. `just check` (ruff + mypy) verifies.
-- The WebSocket event schema (`kernel/events.py`) is the kernel↔UI contract. Drift against `web/src/events.ts` fails CI.
+- Import graph is the contract: `kernel/` MUST NOT import from `cli/`, `plugins/`, or `core/`. `plugins/*` MUST import only from `kernel/`. `just check` (ruff + mypy) verifies.
+- The event catalog `kernel/events.py` is authoritative. The TypeScript mirror `plugins/web/src/events.ts` is regenerated in-sync; drift fails CI.
 
 ## Constraints
 - `__init__.py` — `__version__` + public re-exports. Nothing else importable from outside.
 - `__main__.py` — `python -m yaya` shim; delegates to `cli.app`.
-- `cli/` — Typer entrypoints (serve / version / plugin). See [cli/AGENT.md](cli/AGENT.md).
-- `kernel/` — event bus, plugin loader, event schemas (`events.py` is authoritative).
-- `web/` — FastAPI app + WebSocket bridge + pre-built static assets. See [../../docs/dev/web-ui.md](../../docs/dev/web-ui.md).
-- `plugins/` — seed plugins shipped in-tree (`version`, `update`, `hello`).
+- `cli/` — Typer entrypoints: `serve · version · update · hello · plugin {list,install,remove}`. See [cli/AGENT.md](cli/AGENT.md).
+- `kernel/` — event bus, plugin registry, fixed agent loop, plugin ABI, event catalog. Nothing else.
+- `plugins/` — bundled plugins (`web` adapter, one LLM provider, one tool, one strategy, one memory). Each loads through the **same protocol** as third-party plugins — no special cases.
 - `core/` — shared pure-logic helpers (updater, etc.). See [core/AGENT.md](core/AGENT.md).
 - Every public callable/class has a Google-style docstring explaining **why**, not **what**.
 
 ## Interaction (patterns)
 - New subpackage ⇒ ships with its own `AGENT.md` in the same PR; otherwise merge is blocked.
+- New public event kind ⇒ governance amendment: update `kernel/events.py`, [`docs/dev/plugin-protocol.md`](../../docs/dev/plugin-protocol.md), and `GOAL.md`'s category table in the same PR.
 - Public API change ⇒ CHANGELOG entry + Conventional Commit scope covering the break.
 - Do NOT add module-level side effects (network, filesystem, env mutation) at import time.
 - Do NOT bypass `cli/output.py` for stdout — all rendering goes through it.
+- Do NOT special-case bundled plugins in `kernel/` or `cli/`. They load through the plugin ABI.
 
 ## Budget & Loading
+- Plugin contract (events, ABI, categories): [../../docs/dev/plugin-protocol.md](../../docs/dev/plugin-protocol.md).
 - Layering contract: [../../docs/dev/architecture.md](../../docs/dev/architecture.md).
-- Agent/flow rules: [../../docs/dev/agent-spec.md](../../docs/dev/agent-spec.md).
+- BDD contracts: [../../docs/dev/agent-spec.md](../../docs/dev/agent-spec.md).
 - Maintenance rule: [../../docs/dev/maintaining-agent-md.md](../../docs/dev/maintaining-agent-md.md).

--- a/src/yaya/cli/commands/AGENT.md
+++ b/src/yaya/cli/commands/AGENT.md
@@ -12,20 +12,24 @@ One file per subcommand. Each exports `register(app: typer.Typer) -> None`.
 
 ## Constraints
 Current commands (1.0 surface — see [GOAL.md](../../../../GOAL.md)):
-- `serve.py` — default entrypoint; boots kernel + FastAPI + web UI in one process.
-- `version.py` — prints `__version__` (also available via `--version`).
-- `plugin.py` — `plugin list / install / remove`; delegates to `yaya.kernel.plugins`.
+- `serve.py` — boot kernel; load bundled `web` adapter plugin; open browser.
+- `version.py` — prints kernel + loaded-plugin versions (also `--version`).
+- `update.py` — self-update the yaya binary/wheel; delegates to `yaya.core.updater`.
+- `hello.py` — smoke-test: boot kernel, emit a synthetic event round-trip, print OK.
+- `plugin.py` — `plugin list / install / remove`; delegates to `yaya.kernel.registry`.
 
 Adding a new built-in command requires a GOAL.md amendment. All other
-features ship as plugins.
+features (adapters, tools, skills, memory, LLM providers, strategies)
+ship as plugins.
 
 Rules:
 - Module exports exactly `register(app)` at top-level side-effect scope — nothing else runs at import.
-- Body pattern: (1) parse args, (2) call `yaya.core.*` for logic, (3) render with `emit_ok`/`emit_error`, (4) non-zero exit on failure.
+- Body pattern: (1) parse args, (2) call into `yaya.kernel.*` or `yaya.core.*`, (3) render with `emit_ok`/`emit_error`, (4) non-zero exit on failure.
 - Destructive commands require `--dry-run` and `--yes`.
 
 ## Interaction (patterns)
-- Do NOT put business logic here — it belongs in `yaya.core.*`.
+- Do NOT put business logic here — it belongs in `yaya.kernel.*` or `yaya.core.*`.
+- Do NOT import from `yaya.plugins.*` — commands drive the kernel, not plugins directly.
 - Do NOT call `print` / `typer.echo` / `Console().print`.
 - Register the new module in `../__init__.py` — otherwise it won't be discoverable.
 - Error paths must emit a `suggestion` field in JSON mode.


### PR DESCRIPTION
## Summary

Architectural clarification pinning the product model.

- Kernel = event bus + plugin registry + fixed agent loop (the scheduler).
- Adapters (web / tui / tg), LLM providers, tools, skills, memory, and
  strategies are **all plugins** — including the ones we bundle.
  \`yaya serve\` boots the kernel and loads the bundled \`web\` adapter
  plugin through the **same protocol** as third-party plugins.
- Closed public event set at 1.0; plugin-private payloads use the
  \`x.<plugin>.<kind>\` extension namespace.
- \`update\` and \`hello\` stay kernel built-ins (self-update + smoke
  test). Corrects the previous PR's \"hello/update become plugins\"
  claim.

## Type of change

| Type | Label |
|------|-------|
| Documentation | \`documentation\` |
| Governance (amends GOAL.md Principles, Milestones, Non-Goals, Command Surface) | \`governance\` |

## Component

\`docs\`

## Closes

Closes #9

## What changed

- \`GOAL.md\` — rewritten Principles (9), Runtime shape diagram, Plugin
  Categories table, Milestone 0.1 must ship one plugin per category,
  Anti-Vision adds \"no special cases for bundled plugins\".
- \`docs/dev/plugin-protocol.md\` (new, authoritative) — closed event
  catalog with payloads, plugin ABI, discovery via
  \`yaya.plugins.v1\` entry points, failure model, extension
  namespace, category-specific extras.
- \`docs/dev/architecture.md\` — redrawn around kernel + \`plugins/*\`;
  new layering rules.
- \`docs/dev/web-ui.md\` — reframed as the bundled \`web\` adapter
  plugin; source moves to \`src/yaya/plugins/web/\`.
- \`docs/dev/cli.md\` — 5 kernel built-ins (serve / version / update
  / hello / plugin {list,install,remove}); new built-in = GOAL
  amendment.
- \`AGENT.md\`, \`src/yaya/AGENT.md\`, \`src/yaya/cli/commands/AGENT.md\` —
  updated to reflect kernel-centered layout.
- \`mkdocs.yml\`, \`docs/index.md\`, \`README.md\` — nav + quick-links
  include plugin-protocol.

## Test plan

- [x] \`just docs-test\` (\`mkdocs build -s\`) — 0 warnings
- [x] Intra-doc links verified (tricky: GOAL.md keeps its plugin-
      protocol reference unlinked so the snippet page at
      \`docs/goal.md\` renders without broken links)
- [x] No special-case language for bundled plugins — verified by
      grep
- [ ] CI green (watching after push)

## Follow-up issues implied (not in this PR)

- Implement \`src/yaya/kernel/\` (bus, registry, loop, plugin ABI,
  events catalog).
- Implement bundled plugins: \`plugins/web\`, \`plugins/llm_openai\`,
  \`plugins/tool_bash\`, \`plugins/strategy_react\`, \`plugins/memory_sqlite\`.
- Implement \`yaya serve\` / \`yaya hello\` / \`yaya plugin *\`.
- Wire \`yaya.plugins.v1\` entry point discovery in the kernel.
- Create folder \`AGENT.md\` for each new subpackage.
- Fill GOAL.md TODO values (kernel LOC budget, cold-start, wheel
  size).