### PR TITLE
feat(kernel): event bus + Plugin ABI + closed event catalog (#11)

### DIFF
--- a/specs/kernel-bus-and-abi.spec.md
+++ b/specs/kernel-bus-and-abi.spec.md
@@ -1,0 +1,76 @@
+# kernel-bus-and-abi
+
+## Intent
+
+yaya's kernel is the product's bottom layer: an event bus, a plugin ABI, and a
+closed public event catalog. Every other capability — adapters, LLM providers,
+tools, strategies, memory, skills — depends on this layer. This contract
+pins down the observable behavior of the bus and the shape of the event
+envelope before any plugin or the agent loop can be built on top.
+
+## Decisions
+
+- Event catalog lives in `src/yaya/kernel/events.py` as a `typing.Literal`
+  (`PublicEventKind`) plus per-kind `TypedDict` payload types, mirroring
+  the tables in `docs/dev/plugin-protocol.md`. New public kinds require a
+  governance amendment that touches this module, the protocol doc, and
+  `GOAL.md` together.
+- `Event` is a frozen-ish `dataclass` with fields `id`, `kind`, `session_id`,
+  `ts`, `source`, `payload`. `new_event()` is the only sanctioned factory
+  and rejects unknown public kinds with `ValueError`; the `x.<plugin>.<kind>`
+  extension namespace is accepted without type checks.
+- `Plugin` is a `@runtime_checkable` `Protocol`. `Category` is a `StrEnum`
+  with exactly the six categories from `plugin-protocol.md`.
+- `EventBus` is asyncio-native. Exact-kind routing at 1.0 (no wildcards).
+  Per-subscriber 30s timeout (`DEFAULT_HANDLER_TIMEOUT_S`). FIFO per
+  `session_id` via per-session `asyncio.Lock`. A raising or hanging
+  handler is isolated; the bus emits a synthetic `plugin.error`
+  (`source = "kernel"`). Kernel-origin failures do not re-emit.
+- Stdlib only. No imports from `cli`, `plugins`, or `core`.
+
+## Boundaries
+
+- **Allowed**:
+  - `src/yaya/kernel/**`
+  - `tests/kernel/**`
+  - `specs/kernel-bus-and-abi.spec.md`
+- **Forbidden**: everywhere else. This PR must not touch `src/yaya/cli/`,
+  `src/yaya/core/`, `src/yaya/plugins/`, `pyproject.toml` dependencies,
+  `docs/dev/plugin-protocol.md`, or `GOAL.md`.
+
+## Completion Criteria (BDD)
+
+Scenario: Bus delivers an event to subscribers
+  Given a running EventBus
+  And a subscriber registered for "user.message.received"
+  When a "user.message.received" event is published
+  Then the subscriber receives the event with envelope fields populated
+  Test: tests/kernel/test_bus.py::test_delivers_to_subscriber
+
+Scenario: A raising subscriber does not crash the bus
+  Given a running EventBus
+  And a subscriber that raises on receipt
+  And a second healthy subscriber for the same kind
+  When the event is published
+  Then the healthy subscriber still receives the event
+  And a "plugin.error" event is emitted
+  Test: tests/kernel/test_bus.py::test_raising_subscriber_isolated
+
+Scenario: Events carry the mandated envelope
+  Given the events module
+  When new_event is called with a known public kind
+  Then the returned Event has id, ts, source, session_id, kind, and payload fields
+  Test: tests/kernel/test_events.py::test_envelope_fields
+
+Scenario: Extension events route without type checks
+  Given a running EventBus
+  And a subscriber for "x.foo.bar"
+  When an "x.foo.bar" event is published with an arbitrary payload
+  Then the subscriber receives it unchanged
+  Test: tests/kernel/test_bus.py::test_extension_namespace_routes
+
+Scenario: Closed event catalog rejects unknown public kinds
+  Given the events module
+  When code calls new_event with kind "nonsense.unknown"
+  Then ValueError is raised referencing the closed catalog
+  Test: tests/kernel/test_events.py::test_rejects_unknown_public_kind

--- a/specs/kernel-bus-and-abi.spec.md
+++ b/specs/kernel-bus-and-abi.spec.md
@@ -23,8 +23,11 @@ envelope before any plugin or the agent loop can be built on top.
   with exactly the six categories from `plugin-protocol.md`.
 - `EventBus` is asyncio-native. Exact-kind routing at 1.0 (no wildcards).
   Per-subscriber 30s timeout (`DEFAULT_HANDLER_TIMEOUT_S`). FIFO per
-  `session_id` via per-session `asyncio.Lock`. A raising or hanging
-  handler is isolated; the bus emits a synthetic `plugin.error`
+  `session_id` via a per-session drain worker over an `asyncio.Queue`
+  (single worker per session preserves order; handlers may publish on
+  the same session without deadlocking because the follow-up event is
+  enqueued and delivered after the current handler returns). A raising
+  or hanging handler is isolated; the bus emits a synthetic `plugin.error`
   (`source = "kernel"`). Kernel-origin failures do not re-emit.
 - Stdlib only. No imports from `cli`, `plugins`, or `core`.
 

--- a/src/yaya/kernel/AGENT.md
+++ b/src/yaya/kernel/AGENT.md
@@ -14,7 +14,8 @@ The kernel. Event bus, plugin ABI, closed public event catalog, and (later) the 
 ## Constraints
 - `events.py` — closed `PublicEventKind` Literal, per-kind `TypedDict` payloads, `Event` dataclass, `new_event()` factory. New public kind = governance amendment (protocol doc + GOAL.md + this module in the same PR).
 - `plugin.py` — `Category` StrEnum, runtime-checkable `Plugin` Protocol, `KernelContext` (emit stamps `source` with the plugin name; plugins cannot forge identity).
-- `bus.py` — asyncio pub/sub. Exact-kind routing (no wildcards at 1.0). Per-subscriber 30s timeout. FIFO per `session_id` via per-session `asyncio.Lock`. Failing handlers produce a synthetic `plugin.error` (`source = "kernel"`); kernel-origin failures do NOT re-emit (recursion guard).
+- `bus.py` — asyncio pub/sub. Exact-kind routing (no wildcards at 1.0). Per-subscriber 30s timeout. FIFO per `session_id` via a single drain worker task over a per-session `asyncio.Queue`; handlers may call `publish` / `ctx.emit` on the same session while running, the follow-up event is enqueued and delivered after the current handler returns (no re-entry hazard). Failing handlers produce a synthetic `plugin.error` enqueued on the `"kernel"` session (`source = "kernel"`); kernel-origin failures do NOT re-emit (recursion guard).
+- **`source="kernel"` is reserved for kernel-internal code.** The plugin registry (issue #13) will enforce that plugin subscriptions cannot claim this source. Until the registry lands, this is an honor-system invariant — the recursion guard in the bus trusts it to short-circuit loops.
 - Stdlib only (plus `loguru` only if a plugin-facing logger demands it). No module-level side effects at import.
 
 ## Interaction (patterns)

--- a/src/yaya/kernel/AGENT.md
+++ b/src/yaya/kernel/AGENT.md
@@ -1,0 +1,31 @@
+# src/yaya/kernel — Agent Guidelines
+
+<!-- Prompt-system layers. Philosophy / Style / Anti-sycophancy inherit root. -->
+
+## Philosophy
+The kernel. Event bus, plugin ABI, closed public event catalog, and (later) the plugin registry and fixed agent loop. Every other yaya capability depends on this layer. See [GOAL.md](../../../GOAL.md) and [docs/dev/plugin-protocol.md](../../../docs/dev/plugin-protocol.md).
+
+## External Reality
+- [`docs/dev/plugin-protocol.md`](../../../docs/dev/plugin-protocol.md) is the authoritative contract — this module is its Python mirror; drift fails review.
+- `tests/kernel/` is ground truth for behavior; ≥80% coverage enforced by `pyproject.toml`.
+- `mypy --strict` + ruff are the import-graph enforcers: the kernel MUST NOT import from `cli`, `plugins`, or `core`.
+- BDD contract: [`specs/kernel-bus-and-abi.spec.md`](../../../specs/kernel-bus-and-abi.spec.md); `agent-spec guard` rejects unbound scenarios.
+
+## Constraints
+- `events.py` — closed `PublicEventKind` Literal, per-kind `TypedDict` payloads, `Event` dataclass, `new_event()` factory. New public kind = governance amendment (protocol doc + GOAL.md + this module in the same PR).
+- `plugin.py` — `Category` StrEnum, runtime-checkable `Plugin` Protocol, `KernelContext` (emit stamps `source` with the plugin name; plugins cannot forge identity).
+- `bus.py` — asyncio pub/sub. Exact-kind routing (no wildcards at 1.0). Per-subscriber 30s timeout. FIFO per `session_id` via per-session `asyncio.Lock`. Failing handlers produce a synthetic `plugin.error` (`source = "kernel"`); kernel-origin failures do NOT re-emit (recursion guard).
+- Stdlib only (plus `loguru` only if a plugin-facing logger demands it). No module-level side effects at import.
+
+## Interaction (patterns)
+- New public event kind ⇒ update `PublicEventKind`, the per-kind `TypedDict`, [`docs/dev/plugin-protocol.md`](../../../docs/dev/plugin-protocol.md), and `GOAL.md`'s category table in the SAME PR. Label `governance`.
+- Do NOT add wildcard subscription at 1.0 — kind match is exact. Adapters that want many kinds subscribe many times.
+- Do NOT let plugins emit `plugin.error` or `kernel.error` directly. Only the kernel synthesizes them.
+- Do NOT import from `cli`, `plugins`, or `core`. Direction is one-way: everything depends on `kernel`, never the reverse.
+- Do NOT add a "fast path" for bundled plugins. They use the same ABI.
+
+## Budget & Loading
+- Authoritative contract: [../../../docs/dev/plugin-protocol.md](../../../docs/dev/plugin-protocol.md).
+- Layering: [../../../docs/dev/architecture.md](../../../docs/dev/architecture.md).
+- BDD contract shape: [../../../docs/dev/agent-spec.md](../../../docs/dev/agent-spec.md).
+- Sibling indexes: [../AGENT.md](../AGENT.md) · [../../../tests/AGENT.md](../../../tests/AGENT.md).

--- a/src/yaya/kernel/__init__.py
+++ b/src/yaya/kernel/__init__.py
@@ -1,0 +1,32 @@
+"""Public surface of the yaya kernel.
+
+The kernel owns the event bus, the plugin ABI, and the closed public event
+catalog. Everything else — adapters, LLM providers, tools, strategies,
+memory, skills — is a plugin. See ``docs/dev/plugin-protocol.md`` for the
+authoritative contract.
+"""
+
+from __future__ import annotations
+
+from yaya.kernel.bus import DEFAULT_HANDLER_TIMEOUT_S, EventBus, EventHandler, Subscription
+from yaya.kernel.events import (
+    PUBLIC_EVENT_KINDS,
+    Event,
+    PublicEventKind,
+    new_event,
+)
+from yaya.kernel.plugin import Category, KernelContext, Plugin
+
+__all__ = [
+    "DEFAULT_HANDLER_TIMEOUT_S",
+    "PUBLIC_EVENT_KINDS",
+    "Category",
+    "Event",
+    "EventBus",
+    "EventHandler",
+    "KernelContext",
+    "Plugin",
+    "PublicEventKind",
+    "Subscription",
+    "new_event",
+]

--- a/src/yaya/kernel/bus.py
+++ b/src/yaya/kernel/bus.py
@@ -1,0 +1,223 @@
+"""Asyncio-native event bus for the yaya kernel.
+
+The bus fans one published event out to every subscriber whose kind matches
+exactly (no wildcards at 1.0 — see ``docs/dev/plugin-protocol.md``). Each
+subscriber handler runs under a 30s timeout; a raising or hanging handler
+is isolated — the bus synthesizes a ``plugin.error`` event naming the
+failing subscriber and delivery to the other subscribers is unaffected.
+
+**FIFO per session.** All events carrying the same ``session_id`` are
+delivered in publish order. This is the contract adapters and the agent
+loop depend on; a ``user.message.received`` must reach the strategy before
+its follow-up ``llm.call.request``. The invariant is implemented with one
+:class:`asyncio.Lock` per ``session_id``: :meth:`publish` acquires the
+session's lock for the duration of the fan-out. Concurrent publishes on
+**different** sessions run in parallel.
+
+Kernel-origin failures do not recurse: if a handler whose ``source`` is
+already ``"kernel"`` fails (e.g. the error-emit path itself), the bus
+logs and drops it rather than emitting another ``plugin.error``.
+
+Layering: no imports from ``cli``, ``plugins``, or ``core``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from yaya.kernel.events import Event, new_event
+
+if TYPE_CHECKING:
+    pass
+
+EventHandler = Callable[[Event], Awaitable[None]]
+
+DEFAULT_HANDLER_TIMEOUT_S: float = 30.0
+"""Per-subscriber handler timeout per the plugin failure model."""
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _Subscriber:
+    """Internal bookkeeping for a single subscription."""
+
+    kind: str
+    handler: EventHandler
+    source: str
+
+
+@dataclass(slots=True)
+class Subscription:
+    """Handle returned by :meth:`EventBus.subscribe`.
+
+    Holding this handle lets a caller cancel delivery to its handler.
+    Unsubscribing is idempotent.
+    """
+
+    _bus: EventBus
+    _sub: _Subscriber
+    _active: bool = field(default=True)
+
+    def unsubscribe(self) -> None:
+        """Remove this subscription from the bus. Idempotent."""
+        if not self._active:
+            return
+        self._active = False
+        self._bus._remove(self._sub)
+
+
+class EventBus:
+    """In-process asyncio pub/sub bus with per-session FIFO ordering.
+
+    Not safe to use across event loops; instantiate inside the loop that will
+    drive it. :meth:`close` drains in-flight handlers and cancels anything
+    still running so ``yaya serve`` can shut down cleanly.
+    """
+
+    def __init__(self, *, handler_timeout_s: float = DEFAULT_HANDLER_TIMEOUT_S) -> None:
+        """Create an empty bus.
+
+        Args:
+            handler_timeout_s: Per-subscriber handler deadline; a handler that
+                does not complete within this window is cancelled and treated
+                as a failure.
+        """
+        self._subs: dict[str, list[_Subscriber]] = defaultdict(list)
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._in_flight: set[asyncio.Task[None]] = set()
+        self._closed: bool = False
+        self._handler_timeout_s = handler_timeout_s
+
+    # -- subscription management ------------------------------------------------
+
+    def subscribe(
+        self,
+        kind: str,
+        handler: EventHandler,
+        *,
+        source: str,
+    ) -> Subscription:
+        """Register ``handler`` for events matching ``kind`` exactly.
+
+        Args:
+            kind: Public or extension event kind. No wildcards at 1.0.
+            handler: Async callable invoked per matching event.
+            source: Logical owner (plugin name) used in ``plugin.error``
+                payloads if ``handler`` raises or times out.
+
+        Returns:
+            A :class:`Subscription` whose ``unsubscribe()`` removes the handler.
+        """
+        sub = _Subscriber(kind=kind, handler=handler, source=source)
+        self._subs[kind].append(sub)
+        return Subscription(_bus=self, _sub=sub)
+
+    def _remove(self, sub: _Subscriber) -> None:
+        """Drop ``sub`` from the routing table; called by :class:`Subscription`."""
+        subs = self._subs.get(sub.kind)
+        if not subs:
+            return
+        try:
+            subs.remove(sub)
+        except ValueError:
+            return
+        if not subs:
+            self._subs.pop(sub.kind, None)
+
+    # -- publish ----------------------------------------------------------------
+
+    async def publish(self, event: Event) -> None:
+        """Fan ``event`` out to every exact-kind subscriber.
+
+        Delivery is serialized per ``session_id`` so listeners see events in
+        publish order for a given session. Concurrent publishes to different
+        sessions do not block each other. Handlers run under the configured
+        per-subscriber timeout; failure in one handler is isolated via a
+        synthetic ``plugin.error``.
+
+        Args:
+            event: The envelope to deliver. Already validated by
+                :func:`yaya.kernel.events.new_event`.
+        """
+        if self._closed:  # pragma: no cover - guarded by callers.
+            return
+
+        lock = self._session_locks.setdefault(event.session_id, asyncio.Lock())
+        async with lock:
+            # Snapshot so mid-delivery unsubscribes don't mutate the list.
+            targets = list(self._subs.get(event.kind, ()))
+            if not targets:
+                return
+            await asyncio.gather(*(self._deliver(sub, event) for sub in targets))
+
+    async def _deliver(self, sub: _Subscriber, event: Event) -> None:
+        """Run one subscriber with timeout + error isolation."""
+        try:
+            await asyncio.wait_for(sub.handler(event), timeout=self._handler_timeout_s)
+        except BaseException as exc:
+            await self._report_handler_failure(sub, exc)
+
+    async def _report_handler_failure(self, sub: _Subscriber, exc: BaseException) -> None:
+        """Emit a synthetic ``plugin.error`` unless this would recurse.
+
+        The bus itself is ``source = "kernel"``. If the failing subscriber is
+        already a kernel-owned handler, emitting another ``plugin.error``
+        could loop, so we log and drop instead.
+        """
+        if sub.source == "kernel":
+            _logger.exception(
+                "kernel-origin handler failed on event kind %r; dropping to avoid recursion",
+                sub.kind,
+                exc_info=exc,
+            )
+            return
+
+        _logger.warning(
+            "plugin %r raised while handling %r: %s",
+            sub.source,
+            sub.kind,
+            exc,
+        )
+        try:
+            err = new_event(
+                "plugin.error",
+                {"name": sub.source, "error": str(exc)},
+                session_id="kernel",
+                source="kernel",
+            )
+        except Exception:  # pragma: no cover - defensive; new_event cannot raise here.
+            _logger.exception("failed to build plugin.error envelope")
+            return
+
+        # Deliver directly to plugin.error subscribers without re-acquiring the
+        # originating session lock — the error is a kernel-session event.
+        targets = list(self._subs.get("plugin.error", ()))
+        if not targets:
+            return
+        err_lock = self._session_locks.setdefault("kernel", asyncio.Lock())
+        async with err_lock:
+            await asyncio.gather(*(self._deliver(t, err) for t in targets))
+
+    # -- shutdown ---------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Stop accepting publishes; cancel anything still in flight.
+
+        Safe to call multiple times.
+        """
+        self._closed = True
+        if not self._in_flight:
+            return
+        for task in list(self._in_flight):
+            task.cancel()
+        await asyncio.gather(*self._in_flight, return_exceptions=True)
+        self._in_flight.clear()
+
+
+__all__ = ["DEFAULT_HANDLER_TIMEOUT_S", "EventBus", "EventHandler", "Subscription"]

--- a/src/yaya/kernel/bus.py
+++ b/src/yaya/kernel/bus.py
@@ -7,16 +7,25 @@ is isolated — the bus synthesizes a ``plugin.error`` event naming the
 failing subscriber and delivery to the other subscribers is unaffected.
 
 **FIFO per session.** All events carrying the same ``session_id`` are
-delivered in publish order. This is the contract adapters and the agent
-loop depend on; a ``user.message.received`` must reach the strategy before
-its follow-up ``llm.call.request``. The invariant is implemented with one
-:class:`asyncio.Lock` per ``session_id``: :meth:`publish` acquires the
-session's lock for the duration of the fan-out. Concurrent publishes on
-**different** sessions run in parallel.
+delivered in publish order. The invariant is implemented with one
+:class:`asyncio.Queue` plus a single drain worker task per ``session_id``:
+:meth:`publish` enqueues the event, and the worker pops events one at a
+time and fans each out to the matching subscribers serially. Because a
+single worker owns the session's queue, ordering is preserved even when
+handlers themselves call :meth:`publish` (or ``KernelContext.emit``) on
+the same session — those follow-up events append to the queue and run
+after the current handler returns. No re-entry hazard.
+
+Concurrent publishes on **different** sessions run in parallel because
+each session owns its own queue + worker. When a session's queue drains,
+its worker task and queue entry are released so idle sessions do not
+leak.
 
 Kernel-origin failures do not recurse: if a handler whose ``source`` is
 already ``"kernel"`` fails (e.g. the error-emit path itself), the bus
 logs and drops it rather than emitting another ``plugin.error``.
+Synthetic ``plugin.error`` events are enqueued on the ``"kernel"``
+session so they do not interleave with the originating session's FIFO.
 
 Layering: no imports from ``cli``, ``plugins``, or ``core``.
 """
@@ -28,12 +37,8 @@ import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
 from yaya.kernel.events import Event, new_event
-
-if TYPE_CHECKING:
-    pass
 
 EventHandler = Callable[[Event], Awaitable[None]]
 
@@ -42,10 +47,36 @@ DEFAULT_HANDLER_TIMEOUT_S: float = 30.0
 
 _logger = logging.getLogger(__name__)
 
+# Sentinel pushed into session queues by :meth:`EventBus.close` to wake the
+# drain worker and make it exit cleanly. Using a module-level singleton so
+# identity checks suffice.
+_CLOSE_TOKEN: object = object()
+
 
 @dataclass(slots=True)
+class _Envelope:
+    """Queue item pairing an event with its per-publish completion future.
+
+    The future is resolved by the session's drain worker once every
+    subscriber for this event has finished (or failed). :meth:`EventBus.publish`
+    awaits this future so external callers observe synchronous-ish delivery
+    semantics — except from within the worker itself, where awaiting would
+    deadlock (see :meth:`EventBus.publish`).
+    """
+
+    event: Event
+    done: asyncio.Future[None]
+
+
+@dataclass(slots=True, eq=False)
 class _Subscriber:
-    """Internal bookkeeping for a single subscription."""
+    """Internal bookkeeping for a single subscription.
+
+    ``eq=False`` so ``list.remove`` falls back to identity comparison — two
+    subscriptions with the same handler+source are distinct entries and
+    unsubscribe removes exactly the instance whose :class:`Subscription`
+    handle was cancelled.
+    """
 
     kind: str
     handler: EventHandler
@@ -76,8 +107,8 @@ class EventBus:
     """In-process asyncio pub/sub bus with per-session FIFO ordering.
 
     Not safe to use across event loops; instantiate inside the loop that will
-    drive it. :meth:`close` drains in-flight handlers and cancels anything
-    still running so ``yaya serve`` can shut down cleanly.
+    drive it. :meth:`close` drains outstanding session workers and releases
+    queue state so ``yaya serve`` can shut down cleanly.
     """
 
     def __init__(self, *, handler_timeout_s: float = DEFAULT_HANDLER_TIMEOUT_S) -> None:
@@ -89,8 +120,8 @@ class EventBus:
                 as a failure.
         """
         self._subs: dict[str, list[_Subscriber]] = defaultdict(list)
-        self._session_locks: dict[str, asyncio.Lock] = {}
-        self._in_flight: set[asyncio.Task[None]] = set()
+        self._session_queues: dict[str, asyncio.Queue[object]] = {}
+        self._session_workers: dict[str, asyncio.Task[None]] = {}
         self._closed: bool = False
         self._handler_timeout_s = handler_timeout_s
 
@@ -141,34 +172,106 @@ class EventBus:
         per-subscriber timeout; failure in one handler is isolated via a
         synthetic ``plugin.error``.
 
+        When called from outside a session worker, the coroutine returns
+        after every subscriber finished (or failed, or timed out) handling
+        this specific event. Handlers may call :meth:`publish` (or
+        ``KernelContext.emit``) on the **same** ``session_id`` while
+        running — the follow-up event is enqueued and delivered after the
+        current handler returns; the inner :meth:`publish` returns as soon
+        as the event is enqueued (awaiting delivery would deadlock the
+        session's single worker).
+
         Args:
             event: The envelope to deliver. Already validated by
                 :func:`yaya.kernel.events.new_event`.
+
+        Note:
+            Publishing after :meth:`close` is a no-op that logs a WARNING
+            naming the dropped ``event.kind``. The returned coroutine
+            completes normally without delivering the event.
         """
-        if self._closed:  # pragma: no cover - guarded by callers.
+        if self._closed:
+            _logger.warning("publish on closed bus; dropping event kind=%r", event.kind)
             return
 
-        lock = self._session_locks.setdefault(event.session_id, asyncio.Lock())
-        async with lock:
-            # Snapshot so mid-delivery unsubscribes don't mutate the list.
-            targets = list(self._subs.get(event.kind, ()))
-            if not targets:
-                return
-            await asyncio.gather(*(self._deliver(sub, event) for sub in targets))
+        queue = self._ensure_worker(event.session_id)
+        loop = asyncio.get_running_loop()
+        done: asyncio.Future[None] = loop.create_future()
+        await queue.put(_Envelope(event, done))
+
+        # Re-entry: if we're running inside the session's own worker, awaiting
+        # the completion future would deadlock (the worker can't pick up the
+        # new event until the current handler returns). Enqueue-and-return.
+        worker = self._session_workers.get(event.session_id)
+        if worker is not None and asyncio.current_task() is worker:
+            return
+        await done
+
+    def _ensure_worker(self, session_id: str) -> asyncio.Queue[object]:
+        """Return the session's queue, creating queue + worker on first use."""
+        queue = self._session_queues.get(session_id)
+        if queue is not None:
+            return queue
+        queue = asyncio.Queue()
+        self._session_queues[session_id] = queue
+        self._session_workers[session_id] = asyncio.create_task(
+            self._drain(session_id, queue),
+            name=f"yaya-bus-session:{session_id}",
+        )
+        return queue
+
+    async def _drain(self, session_id: str, queue: asyncio.Queue[object]) -> None:
+        """Pop and deliver events for one session until the queue is idle.
+
+        Exits when the queue is empty (releasing the session's state) or
+        when :data:`_CLOSE_TOKEN` is popped (shutdown path).
+        """
+        try:
+            while True:
+                item = await queue.get()
+                if item is _CLOSE_TOKEN:
+                    return
+                assert isinstance(item, _Envelope)  # noqa: S101
+                event = item.event
+                # Snapshot so mid-delivery unsubscribes don't mutate the list.
+                targets = list(self._subs.get(event.kind, ()))
+                try:
+                    for sub in targets:
+                        await self._deliver(sub, event)
+                finally:
+                    if not item.done.done():
+                        item.done.set_result(None)
+
+                # If nothing else is pending, release the session's state so
+                # idle sessions do not leak queue + task entries.
+                if queue.empty():
+                    break
+        finally:
+            # Only release if we're still the current worker for this session.
+            # (close() clears the dicts itself; guard avoids KeyError then.)
+            if self._session_queues.get(session_id) is queue:
+                self._session_queues.pop(session_id, None)
+                self._session_workers.pop(session_id, None)
 
     async def _deliver(self, sub: _Subscriber, event: Event) -> None:
         """Run one subscriber with timeout + error isolation."""
         try:
             await asyncio.wait_for(sub.handler(event), timeout=self._handler_timeout_s)
-        except BaseException as exc:
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
             await self._report_handler_failure(sub, exc)
 
-    async def _report_handler_failure(self, sub: _Subscriber, exc: BaseException) -> None:
-        """Emit a synthetic ``plugin.error`` unless this would recurse.
+    async def _report_handler_failure(self, sub: _Subscriber, exc: Exception) -> None:
+        """Enqueue a synthetic ``plugin.error`` unless this would recurse.
 
         The bus itself is ``source = "kernel"``. If the failing subscriber is
         already a kernel-owned handler, emitting another ``plugin.error``
         could loop, so we log and drop instead.
+
+        The synthetic event is enqueued on the ``"kernel"`` session (not the
+        originating session) so it does not interleave with the caller's
+        per-session FIFO.
         """
         if sub.source == "kernel":
             _logger.exception(
@@ -184,40 +287,44 @@ class EventBus:
             sub.kind,
             exc,
         )
-        try:
-            err = new_event(
-                "plugin.error",
-                {"name": sub.source, "error": str(exc)},
-                session_id="kernel",
-                source="kernel",
-            )
-        except Exception:  # pragma: no cover - defensive; new_event cannot raise here.
-            _logger.exception("failed to build plugin.error envelope")
+        err = new_event(
+            "plugin.error",
+            {"name": sub.source, "error": str(exc)},
+            session_id="kernel",
+            source="kernel",
+        )
+        if self._closed:
             return
-
-        # Deliver directly to plugin.error subscribers without re-acquiring the
-        # originating session lock — the error is a kernel-session event.
-        targets = list(self._subs.get("plugin.error", ()))
-        if not targets:
-            return
-        err_lock = self._session_locks.setdefault("kernel", asyncio.Lock())
-        async with err_lock:
-            await asyncio.gather(*(self._deliver(t, err) for t in targets))
+        queue = self._ensure_worker("kernel")
+        loop = asyncio.get_running_loop()
+        done: asyncio.Future[None] = loop.create_future()
+        await queue.put(_Envelope(err, done))
+        # Do not await ``done`` — the kernel session may be the caller's own
+        # worker (e.g. a plugin.error handler raised) and awaiting would
+        # deadlock. The originating publish's completion future still
+        # resolves once its own envelope finishes; the synthetic error
+        # delivers asynchronously.
+        if asyncio.current_task() is not self._session_workers.get("kernel"):
+            await done
 
     # -- shutdown ---------------------------------------------------------------
 
     async def close(self) -> None:
-        """Stop accepting publishes; cancel anything still in flight.
+        """Stop accepting publishes; drain outstanding session workers.
 
         Safe to call multiple times.
         """
-        self._closed = True
-        if not self._in_flight:
+        if self._closed and not self._session_workers:
             return
-        for task in list(self._in_flight):
-            task.cancel()
-        await asyncio.gather(*self._in_flight, return_exceptions=True)
-        self._in_flight.clear()
+        self._closed = True
+        # Snapshot before mutating so concurrent completions can't race.
+        workers = list(self._session_workers.values())
+        for queue in list(self._session_queues.values()):
+            await queue.put(_CLOSE_TOKEN)
+        if workers:
+            await asyncio.gather(*workers, return_exceptions=True)
+        self._session_queues.clear()
+        self._session_workers.clear()
 
 
 __all__ = ["DEFAULT_HANDLER_TIMEOUT_S", "EventBus", "EventHandler", "Subscription"]

--- a/src/yaya/kernel/bus.py
+++ b/src/yaya/kernel/bus.py
@@ -36,9 +36,20 @@ import asyncio
 import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 
 from yaya.kernel.events import Event, new_event
+
+_IN_WORKER: ContextVar[bool] = ContextVar("_IN_WORKER", default=False)
+"""True while the current task is executing inside a session drain worker.
+
+Set by :meth:`EventBus._drain` for the duration of the worker's loop body.
+ContextVars propagate across ``await`` boundaries within the same task, so
+any handler invoked by the worker — and any nested :meth:`EventBus.publish`
+those handlers make — observes ``True`` and skips awaiting the completion
+future to avoid cross-session and same-session deadlock cycles.
+"""
 
 EventHandler = Callable[[Event], Awaitable[None]]
 
@@ -58,10 +69,11 @@ class _Envelope:
     """Queue item pairing an event with its per-publish completion future.
 
     The future is resolved by the session's drain worker once every
-    subscriber for this event has finished (or failed). :meth:`EventBus.publish`
-    awaits this future so external callers observe synchronous-ish delivery
-    semantics — except from within the worker itself, where awaiting would
-    deadlock (see :meth:`EventBus.publish`).
+    subscriber for this event has finished (or failed). Callers whose task
+    is not running inside any session worker await this future so they
+    observe synchronous-ish delivery. Callers running inside a session
+    worker (detected via a ContextVar) skip the await to avoid
+    cross-session and same-session deadlock cycles.
     """
 
     event: Event
@@ -199,11 +211,9 @@ class EventBus:
         done: asyncio.Future[None] = loop.create_future()
         await queue.put(_Envelope(event, done))
 
-        # Re-entry: if we're running inside the session's own worker, awaiting
-        # the completion future would deadlock (the worker can't pick up the
-        # new event until the current handler returns). Enqueue-and-return.
-        worker = self._session_workers.get(event.session_id)
-        if worker is not None and asyncio.current_task() is worker:
+        if _IN_WORKER.get():
+            # Caller is running inside some session worker; awaiting would risk
+            # a cross-session or same-session deadlock. Fire-and-forget.
             return
         await done
 
@@ -226,6 +236,7 @@ class EventBus:
         Exits when the queue is empty (releasing the session's state) or
         when :data:`_CLOSE_TOKEN` is popped (shutdown path).
         """
+        token = _IN_WORKER.set(True)
         try:
             while True:
                 item = await queue.get()
@@ -247,6 +258,7 @@ class EventBus:
                 if queue.empty():
                     break
         finally:
+            _IN_WORKER.reset(token)
             # Only release if we're still the current worker for this session.
             # (close() clears the dicts itself; guard avoids KeyError then.)
             if self._session_queues.get(session_id) is queue:
@@ -271,7 +283,7 @@ class EventBus:
 
         The synthetic event is enqueued on the ``"kernel"`` session (not the
         originating session) so it does not interleave with the caller's
-        per-session FIFO.
+        per-session FIFO. Delivery is fire-and-forget.
         """
         if sub.source == "kernel":
             _logger.exception(
@@ -297,15 +309,12 @@ class EventBus:
             return
         queue = self._ensure_worker("kernel")
         loop = asyncio.get_running_loop()
+        # Fire-and-forget: this path always runs inside a session worker
+        # (see _deliver -> _drain), so awaiting would create cross-session
+        # deadlock cycles. The completion future is created but never
+        # awaited here — the kernel-session worker still resolves it.
         done: asyncio.Future[None] = loop.create_future()
         await queue.put(_Envelope(err, done))
-        # Do not await ``done`` — the kernel session may be the caller's own
-        # worker (e.g. a plugin.error handler raised) and awaiting would
-        # deadlock. The originating publish's completion future still
-        # resolves once its own envelope finishes; the synthetic error
-        # delivers asynchronously.
-        if asyncio.current_task() is not self._session_workers.get("kernel"):
-            await done
 
     # -- shutdown ---------------------------------------------------------------
 

--- a/src/yaya/kernel/events.py
+++ b/src/yaya/kernel/events.py
@@ -1,0 +1,423 @@
+"""Closed public event catalog + envelope for the yaya kernel.
+
+This module is the **authoritative** Python-side mirror of the event taxonomy
+defined in ``docs/dev/plugin-protocol.md``. The set of public event kinds is
+**closed at 1.0**: introducing a new public kind is a governance change and
+requires amending this module, ``docs/dev/plugin-protocol.md``, and
+``GOAL.md`` in the same PR. Plugin-private events use the
+``x.<plugin>.<kind>`` extension namespace and route through the bus without
+type-checking.
+
+Layering: this module lives in ``src/yaya/kernel/`` and must not import from
+``cli``, ``plugins``, or ``core``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypedDict, get_args
+
+# ---------------------------------------------------------------------------
+# Public event kinds — closed catalog (frozen at 1.0).
+# Any change to this Literal is a governance amendment.
+# ---------------------------------------------------------------------------
+
+PublicEventKind = Literal[
+    # User input (adapter → kernel).
+    "user.message.received",
+    "user.interrupt",
+    # Assistant output (kernel → adapters).
+    "assistant.message.delta",
+    "assistant.message.done",
+    # LLM invocation (kernel ↔ llm-provider).
+    "llm.call.request",
+    "llm.call.response",
+    "llm.call.error",
+    # Tool execution (kernel ↔ tool).
+    "tool.call.request",
+    "tool.call.start",
+    "tool.call.result",
+    # Memory (kernel ↔ memory).
+    "memory.query",
+    "memory.write",
+    "memory.result",
+    # Strategy (kernel ↔ strategy).
+    "strategy.decide.request",
+    "strategy.decide.response",
+    # Plugin lifecycle (kernel → all).
+    "plugin.loaded",
+    "plugin.reloaded",
+    "plugin.removed",
+    "plugin.error",
+    # Kernel (kernel → all).
+    "kernel.ready",
+    "kernel.shutdown",
+    "kernel.error",
+]
+
+PUBLIC_EVENT_KINDS: frozenset[str] = frozenset(get_args(PublicEventKind))
+"""Runtime-accessible set of the closed public event kinds."""
+
+
+# ---------------------------------------------------------------------------
+# Per-kind payload TypedDicts.
+#
+# Shapes mirror the tables in ``docs/dev/plugin-protocol.md``. These are
+# structural hints for type-checkers; the bus itself does not enforce them at
+# runtime (payloads are plain dicts on the wire).
+# ---------------------------------------------------------------------------
+
+
+class Attachment(TypedDict, total=False):
+    """Opaque user-message attachment; shape owned by the adapter producing it."""
+
+    kind: str
+    uri: str
+    mime: str
+
+
+class Message(TypedDict, total=False):
+    """Single chat-style message passed to an LLM provider."""
+
+    role: str
+    content: str
+
+
+class ToolCall(TypedDict, total=False):
+    """A tool invocation decided by the LLM or strategy."""
+
+    id: str
+    name: str
+    args: dict[str, Any]
+
+
+class ToolSchema(TypedDict, total=False):
+    """JSON-schema-ish description of a tool advertised to the LLM."""
+
+    name: str
+    description: str
+    json_schema: dict[str, Any]
+
+
+class Usage(TypedDict, total=False):
+    """Token accounting returned by an LLM provider."""
+
+    input_tokens: int
+    output_tokens: int
+
+
+class MemoryEntry(TypedDict, total=False):
+    """A memory row that memory plugins read and write."""
+
+    id: str
+    text: str
+    meta: dict[str, Any]
+
+
+class AgentLoopState(TypedDict, total=False):
+    """Snapshot of the agent loop handed to a strategy for its decision."""
+
+    session_id: str
+    step: int
+    messages: list[Message]
+    last_tool_result: dict[str, Any] | None
+
+
+# --- User input ------------------------------------------------------------
+
+
+class UserMessageReceivedPayload(TypedDict, total=False):
+    """``user.message.received`` — text the adapter just received from the user."""
+
+    text: str
+    attachments: list[Attachment]
+
+
+class UserInterruptPayload(TypedDict, total=False):
+    """``user.interrupt`` — user-requested end-of-turn; payload is empty by design."""
+
+
+# --- Assistant output ------------------------------------------------------
+
+
+class AssistantMessageDeltaPayload(TypedDict):
+    """``assistant.message.delta`` — one streaming chunk of assistant content."""
+
+    content: str
+
+
+class AssistantMessageDonePayload(TypedDict, total=False):
+    """``assistant.message.done`` — terminal assistant message for a turn."""
+
+    content: str
+    tool_calls: list[ToolCall]
+
+
+# --- LLM invocation --------------------------------------------------------
+
+
+class LlmCallRequestPayload(TypedDict, total=False):
+    """``llm.call.request`` — kernel asks a provider plugin to run a completion."""
+
+    provider: str
+    model: str
+    messages: list[Message]
+    tools: list[ToolSchema]
+    params: dict[str, Any]
+
+
+class LlmCallResponsePayload(TypedDict, total=False):
+    """``llm.call.response`` — provider's completion result."""
+
+    text: str
+    tool_calls: list[ToolCall]
+    usage: Usage
+
+
+class LlmCallErrorPayload(TypedDict, total=False):
+    """``llm.call.error`` — provider failure with optional retry hint."""
+
+    error: str
+    retry_after_s: float
+
+
+# --- Tool execution --------------------------------------------------------
+
+
+class ToolCallRequestPayload(TypedDict):
+    """``tool.call.request`` — kernel asks a tool plugin to run."""
+
+    id: str
+    name: str
+    args: dict[str, Any]
+
+
+class ToolCallStartPayload(TypedDict):
+    """``tool.call.start`` — broadcast to adapters so the UI can render progress."""
+
+    id: str
+    name: str
+    args: dict[str, Any]
+
+
+class ToolCallResultPayload(TypedDict, total=False):
+    """``tool.call.result`` — tool plugin's outcome."""
+
+    id: str
+    ok: bool
+    value: Any
+    error: str
+
+
+# --- Memory ----------------------------------------------------------------
+
+
+class MemoryQueryPayload(TypedDict):
+    """``memory.query`` — kernel asks a memory plugin for ``k`` relevant entries."""
+
+    query: str
+    k: int
+
+
+class MemoryWritePayload(TypedDict):
+    """``memory.write`` — kernel asks a memory plugin to persist one entry."""
+
+    entry: MemoryEntry
+
+
+class MemoryResultPayload(TypedDict):
+    """``memory.result`` — memory plugin's hits list."""
+
+    hits: list[MemoryEntry]
+
+
+# --- Strategy --------------------------------------------------------------
+
+
+class StrategyDecideRequestPayload(TypedDict):
+    """``strategy.decide.request`` — kernel asks the active strategy for a next step."""
+
+    state: AgentLoopState
+
+
+class StrategyDecideResponsePayload(TypedDict, total=False):
+    """``strategy.decide.response`` — strategy's chosen next step.
+
+    ``next`` is one of ``"llm" | "tool" | "memory" | "done"``; additional keys
+    describe the arguments for that step (kept as an open dict at the kernel
+    level — strategy plugins own their own schema).
+    """
+
+    next: Literal["llm", "tool", "memory", "done"]
+
+
+# --- Plugin lifecycle ------------------------------------------------------
+
+
+class PluginLoadedPayload(TypedDict):
+    """``plugin.loaded`` — a plugin registered successfully."""
+
+    name: str
+    version: str
+    category: str
+
+
+class PluginReloadedPayload(TypedDict):
+    """``plugin.reloaded`` — hot-reload completed for a plugin."""
+
+    name: str
+    version: str
+
+
+class PluginRemovedPayload(TypedDict):
+    """``plugin.removed`` — a plugin was unloaded (manual or failure-triggered)."""
+
+    name: str
+
+
+class PluginErrorPayload(TypedDict):
+    """``plugin.error`` — a plugin's handler raised or timed out.
+
+    The kernel synthesizes this event on behalf of the failing plugin. Plugin
+    code must not emit ``plugin.error`` directly.
+    """
+
+    name: str
+    error: str
+
+
+# --- Kernel ----------------------------------------------------------------
+
+
+class KernelReadyPayload(TypedDict):
+    """``kernel.ready`` — kernel boot finished, plugins loaded."""
+
+    version: str
+
+
+class KernelShutdownPayload(TypedDict):
+    """``kernel.shutdown`` — kernel is stopping; adapters should drain."""
+
+    reason: str
+
+
+class KernelErrorPayload(TypedDict):
+    """``kernel.error`` — the kernel itself failed; ``yaya serve`` exits non-zero."""
+
+    source: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Envelope + factory.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Event:
+    """The event envelope carried on the bus.
+
+    Attributes:
+        id: uuid4 hex, kernel-assigned on publish.
+        kind: Dotted identifier; either a member of ``PublicEventKind`` or
+            an extension name starting with ``x.``.
+        session_id: Conversation scope. Plugin-private events may use any
+            stable id — the bus serializes delivery per ``session_id``.
+        ts: Kernel-assigned unix epoch seconds.
+        source: Plugin name that emitted the event, or the literal ``"kernel"``
+            for kernel-origin events (``kernel.*``, synthetic ``plugin.error``).
+        payload: Kind-specific dict; shape per ``docs/dev/plugin-protocol.md``.
+    """
+
+    id: str
+    kind: str
+    session_id: str
+    ts: float
+    source: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+def new_event(
+    kind: str,
+    payload: dict[str, Any],
+    *,
+    session_id: str,
+    source: str,
+) -> Event:
+    """Create a validated :class:`Event` envelope.
+
+    Assigns a fresh ``id`` (uuid4 hex) and a kernel-assigned timestamp. A
+    ``kind`` not prefixed with ``x.`` must be a member of the closed
+    ``PublicEventKind`` catalog; otherwise :class:`ValueError` is raised and
+    names the catalog so the author knows where to propose the new kind.
+
+    Args:
+        kind: Public kind from :data:`PUBLIC_EVENT_KINDS` or an extension
+            kind starting with ``x.``.
+        payload: Kind-specific dict. Shape per ``docs/dev/plugin-protocol.md``;
+            not validated here (static type-checkers enforce this via the
+            per-kind :class:`TypedDict`\\ s above).
+        session_id: Conversation / routing scope.
+        source: Emitter — plugin name, or ``"kernel"`` for kernel-origin events.
+
+    Returns:
+        A fully populated :class:`Event`.
+
+    Raises:
+        ValueError: If ``kind`` is not in the closed public catalog and does
+            not start with ``x.``.
+    """
+    if not kind.startswith("x.") and kind not in PUBLIC_EVENT_KINDS:
+        raise ValueError(
+            f"unknown public event kind {kind!r}; "
+            f"the closed catalog is defined in yaya.kernel.events.PublicEventKind "
+            f"(see docs/dev/plugin-protocol.md). Extension events must be "
+            f"prefixed with 'x.<plugin>.'."
+        )
+    return Event(
+        id=uuid.uuid4().hex,
+        kind=kind,
+        session_id=session_id,
+        ts=time.time(),
+        source=source,
+        payload=payload,
+    )
+
+
+__all__ = [
+    "PUBLIC_EVENT_KINDS",
+    "AgentLoopState",
+    "AssistantMessageDeltaPayload",
+    "AssistantMessageDonePayload",
+    "Attachment",
+    "Event",
+    "KernelErrorPayload",
+    "KernelReadyPayload",
+    "KernelShutdownPayload",
+    "LlmCallErrorPayload",
+    "LlmCallRequestPayload",
+    "LlmCallResponsePayload",
+    "MemoryEntry",
+    "MemoryQueryPayload",
+    "MemoryResultPayload",
+    "MemoryWritePayload",
+    "Message",
+    "PluginErrorPayload",
+    "PluginLoadedPayload",
+    "PluginReloadedPayload",
+    "PluginRemovedPayload",
+    "PublicEventKind",
+    "StrategyDecideRequestPayload",
+    "StrategyDecideResponsePayload",
+    "ToolCall",
+    "ToolCallRequestPayload",
+    "ToolCallResultPayload",
+    "ToolCallStartPayload",
+    "ToolSchema",
+    "Usage",
+    "UserInterruptPayload",
+    "UserMessageReceivedPayload",
+    "new_event",
+]

--- a/src/yaya/kernel/events.py
+++ b/src/yaya/kernel/events.py
@@ -10,14 +10,19 @@ type-checking.
 
 Layering: this module lives in ``src/yaya/kernel/`` and must not import from
 ``cli``, ``plugins``, or ``core``.
-"""
 
-from __future__ import annotations
+Note:
+    This module deliberately does NOT use ``from __future__ import annotations``.
+    ``typing.NotRequired`` inside :class:`TypedDict` bodies must be evaluated
+    at class-construction time for ``__required_keys__`` / ``__optional_keys__``
+    to reflect the intended partition; PEP 563 string annotations defer that
+    evaluation and collapse every field into ``__required_keys__``.
+"""
 
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Literal, TypedDict, get_args
+from typing import Any, Literal, NotRequired, TypedDict, get_args
 
 # ---------------------------------------------------------------------------
 # Public event kinds — closed catalog (frozen at 1.0).
@@ -128,11 +133,11 @@ class AgentLoopState(TypedDict, total=False):
 # --- User input ------------------------------------------------------------
 
 
-class UserMessageReceivedPayload(TypedDict, total=False):
+class UserMessageReceivedPayload(TypedDict):
     """``user.message.received`` — text the adapter just received from the user."""
 
     text: str
-    attachments: list[Attachment]
+    attachments: NotRequired[list[Attachment]]
 
 
 class UserInterruptPayload(TypedDict, total=False):
@@ -148,7 +153,7 @@ class AssistantMessageDeltaPayload(TypedDict):
     content: str
 
 
-class AssistantMessageDonePayload(TypedDict, total=False):
+class AssistantMessageDonePayload(TypedDict):
     """``assistant.message.done`` — terminal assistant message for a turn."""
 
     content: str
@@ -158,29 +163,29 @@ class AssistantMessageDonePayload(TypedDict, total=False):
 # --- LLM invocation --------------------------------------------------------
 
 
-class LlmCallRequestPayload(TypedDict, total=False):
+class LlmCallRequestPayload(TypedDict):
     """``llm.call.request`` — kernel asks a provider plugin to run a completion."""
 
     provider: str
     model: str
     messages: list[Message]
-    tools: list[ToolSchema]
     params: dict[str, Any]
+    tools: NotRequired[list[ToolSchema]]
 
 
-class LlmCallResponsePayload(TypedDict, total=False):
+class LlmCallResponsePayload(TypedDict):
     """``llm.call.response`` — provider's completion result."""
 
-    text: str
-    tool_calls: list[ToolCall]
     usage: Usage
+    text: NotRequired[str]
+    tool_calls: NotRequired[list[ToolCall]]
 
 
-class LlmCallErrorPayload(TypedDict, total=False):
+class LlmCallErrorPayload(TypedDict):
     """``llm.call.error`` — provider failure with optional retry hint."""
 
     error: str
-    retry_after_s: float
+    retry_after_s: NotRequired[float]
 
 
 # --- Tool execution --------------------------------------------------------
@@ -202,13 +207,13 @@ class ToolCallStartPayload(TypedDict):
     args: dict[str, Any]
 
 
-class ToolCallResultPayload(TypedDict, total=False):
+class ToolCallResultPayload(TypedDict):
     """``tool.call.result`` — tool plugin's outcome."""
 
     id: str
     ok: bool
-    value: Any
-    error: str
+    value: NotRequired[Any]
+    error: NotRequired[str]
 
 
 # --- Memory ----------------------------------------------------------------

--- a/src/yaya/kernel/plugin.py
+++ b/src/yaya/kernel/plugin.py
@@ -8,6 +8,7 @@ this module is its Python surface. Kernel layering: no imports from
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from enum import StrEnum
 from pathlib import Path
@@ -94,7 +95,7 @@ class KernelContext:
         self,
         *,
         bus: EventBus,
-        logger: Any,
+        logger: logging.Logger,
         config: Mapping[str, object],
         state_dir: Path,
         plugin_name: str,
@@ -115,7 +116,7 @@ class KernelContext:
         self._plugin_name = plugin_name
 
     @property
-    def logger(self) -> Any:
+    def logger(self) -> logging.Logger:
         """Plugin-scoped logger."""
         return self._logger
 

--- a/src/yaya/kernel/plugin.py
+++ b/src/yaya/kernel/plugin.py
@@ -1,0 +1,162 @@
+"""Plugin ABI: :class:`Category`, :class:`Plugin` Protocol, :class:`KernelContext`.
+
+The ABI is the contract every plugin — bundled or third-party — binds to.
+``docs/dev/plugin-protocol.md`` is the authoritative prose description;
+this module is its Python surface. Kernel layering: no imports from
+``cli``, ``plugins``, or ``core``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from yaya.kernel.events import Event, new_event
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import, breaks an import cycle.
+    from yaya.kernel.bus import EventBus
+
+
+class Category(StrEnum):
+    """Closed set of plugin categories at 1.0.
+
+    A plugin declares exactly one category. Multi-category plugins ship as
+    multiple packages — see ``docs/dev/plugin-protocol.md`` for the routing
+    rules each category inherits.
+    """
+
+    ADAPTER = "adapter"
+    TOOL = "tool"
+    LLM_PROVIDER = "llm-provider"
+    STRATEGY = "strategy"
+    MEMORY = "memory"
+    SKILL = "skill"
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    """Runtime-checkable interface every plugin module's ``plugin`` object implements.
+
+    Attributes:
+        name: Globally unique, kebab-case.
+        version: Semver string.
+        category: One of :class:`Category`.
+        requires: Names of other plugins this one depends on (load order hint).
+
+    Lifecycle methods run inside the asyncio event loop owned by the kernel.
+    A raised exception or a >30s hang surfaces a synthetic ``plugin.error``
+    event; it does not crash the kernel.
+    """
+
+    name: str
+    version: str
+    category: Category
+    requires: list[str]
+
+    def subscriptions(self) -> list[str]:
+        """Return the public or extension event kinds this plugin wants.
+
+        The kernel uses this list to route events. Filtering beyond kind
+        (e.g. by ``session_id``) is the plugin's responsibility.
+        """
+        ...
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        """Run once after registration, before any event is delivered."""
+        ...
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        """Handle one event. Raise to surface a ``plugin.error``."""
+        ...
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        """Run on hot-reload or kernel shutdown. Must be idempotent."""
+        ...
+
+
+# Handler signature used by the registry / bus when subscribing on behalf of
+# a plugin. Kept here so it's importable without pulling in the bus.
+EventHandler = Callable[[Event], Awaitable[None]]
+
+
+class KernelContext:
+    """Per-plugin view of the kernel.
+
+    Each plugin receives its own :class:`KernelContext` in ``on_load``,
+    ``on_event``, and ``on_unload``. The context stamps the plugin's name
+    onto any event emitted through :meth:`emit`, so plugins cannot forge
+    ``source`` for another plugin or the kernel.
+    """
+
+    def __init__(
+        self,
+        *,
+        bus: EventBus,
+        logger: Any,
+        config: Mapping[str, object],
+        state_dir: Path,
+        plugin_name: str,
+    ) -> None:
+        """Bind the context to a specific plugin.
+
+        Args:
+            bus: The kernel's running event bus.
+            logger: Pre-scoped logger for this plugin (name already bound).
+            config: Read-only plugin configuration.
+            state_dir: Writable directory under ``<XDG_DATA_HOME>/yaya/plugins/<name>/``.
+            plugin_name: The owning plugin's ``name``; used as ``source`` on emit.
+        """
+        self._bus = bus
+        self._logger = logger
+        self._config = config
+        self._state_dir = state_dir
+        self._plugin_name = plugin_name
+
+    @property
+    def logger(self) -> Any:
+        """Plugin-scoped logger."""
+        return self._logger
+
+    @property
+    def config(self) -> Mapping[str, object]:
+        """Read-only plugin configuration."""
+        return self._config
+
+    @property
+    def state_dir(self) -> Path:
+        """Writable per-plugin state directory."""
+        return self._state_dir
+
+    async def emit(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        *,
+        session_id: str,
+    ) -> None:
+        """Publish an event on behalf of this plugin.
+
+        Validates ``kind`` against the closed catalog (or accepts any
+        ``x.<plugin>.<kind>`` extension), stamps ``source`` with the owning
+        plugin's name, then hands the event to the bus.
+
+        Args:
+            kind: Public or extension event kind.
+            payload: Kind-specific dict per ``docs/dev/plugin-protocol.md``.
+            session_id: Routing/ordering key.
+
+        Raises:
+            ValueError: If ``kind`` is an unknown public kind.
+        """
+        event = new_event(
+            kind,
+            payload,
+            session_id=session_id,
+            source=self._plugin_name,
+        )
+        await self._bus.publish(event)
+
+
+__all__ = ["Category", "EventHandler", "KernelContext", "Plugin"]

--- a/tests/kernel/test_bus.py
+++ b/tests/kernel/test_bus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -183,3 +184,130 @@ def test_handler_timeout_default_is_30s() -> None:
     from yaya.kernel.bus import DEFAULT_HANDLER_TIMEOUT_S
 
     assert pytest.approx(30.0) == DEFAULT_HANDLER_TIMEOUT_S
+
+
+async def test_handler_can_emit_on_same_session() -> None:
+    """A handler re-publishing on its own session must not deadlock.
+
+    Regression for the per-session Lock design: acquiring the same
+    ``asyncio.Lock`` inside a handler hung and spuriously surfaced a
+    ``plugin.error``. With the queue-based design the follow-up event
+    is enqueued and drained after the current handler returns.
+    """
+    bus = EventBus()
+    results: list[Event] = []
+    errors: list[Event] = []
+
+    async def request_handler(ev: Event) -> None:
+        await bus.publish(
+            new_event(
+                "tool.call.result",
+                {"id": ev.payload["id"], "ok": True, "value": 42},
+                session_id=ev.session_id,
+                source="tool.demo",
+            )
+        )
+
+    async def on_result(ev: Event) -> None:
+        results.append(ev)
+
+    async def on_error(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe("tool.call.request", request_handler, source="tool.demo")
+    bus.subscribe("tool.call.result", on_result, source="observer")
+    bus.subscribe("plugin.error", on_error, source="observer")
+
+    await bus.publish(
+        new_event(
+            "tool.call.request",
+            {"id": "call-1", "name": "demo", "args": {}},
+            session_id="s-1",
+            source="kernel",
+        )
+    )
+    # Let the session worker drain the follow-up event.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert len(results) == 1
+    assert results[0].payload["id"] == "call-1"
+    assert errors == []
+
+
+async def test_session_queue_releases_when_idle() -> None:
+    """After a burst of unique session_ids, no queue/worker entries leak."""
+    bus = EventBus()
+
+    async def handler(_: Event) -> None:
+        return None
+
+    bus.subscribe("x.burst.tick", handler, source="burst")
+
+    async def one(n: int) -> None:
+        await bus.publish(new_event("x.burst.tick", {"n": n}, session_id=f"s-{n}", source="gen"))
+
+    await asyncio.gather(*(one(i) for i in range(1000)))
+    # Give pending worker coroutines a chance to finalise their ``finally``
+    # cleanup block.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert len(bus._session_queues) == 0
+    assert len(bus._session_workers) == 0
+
+
+async def test_cancellation_propagates_without_plugin_error() -> None:
+    """Cancelling an outer publish must not be swallowed as plugin.error."""
+    bus = EventBus()
+    errors: list[Event] = []
+    started = asyncio.Event()
+
+    async def slow(_: Event) -> None:
+        started.set()
+        await asyncio.sleep(10)
+
+    async def on_err(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe("user.message.received", slow, source="slow")
+    bus.subscribe("plugin.error", on_err, source="observer")
+
+    task = asyncio.create_task(
+        bus.publish(new_event("user.message.received", {"text": "x"}, session_id="s", source="a"))
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Allow any pending error-emit path to run (there should be none).
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert errors == []
+
+
+async def test_duplicate_subscription_same_args_unsubscribes_one_copy() -> None:
+    """Subscribing the same handler+source twice yields two distinct entries."""
+    bus = EventBus()
+    count = 0
+
+    async def handler(_: Event) -> None:
+        nonlocal count
+        count += 1
+
+    sub_a = bus.subscribe("kernel.ready", handler, source="t")
+    bus.subscribe("kernel.ready", handler, source="t")
+    sub_a.unsubscribe()
+
+    await bus.publish(new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel"))
+    assert count == 1
+
+
+async def test_publish_after_close_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Publishing after close is a no-op but surfaces a warning with the kind."""
+    bus = EventBus()
+    await bus.close()
+    with caplog.at_level(logging.WARNING, logger="yaya.kernel.bus"):
+        await bus.publish(new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel"))
+    assert any("kernel.ready" in rec.getMessage() for rec in caplog.records)

--- a/tests/kernel/test_bus.py
+++ b/tests/kernel/test_bus.py
@@ -105,7 +105,7 @@ async def test_fifo_per_session() -> None:
     seen: list[int] = []
 
     async def handler(ev: Event) -> None:
-        # Variable delay to try to reorder — the per-session lock must prevent it.
+        # Variable delay to try to reorder — the per-session worker must preserve order.
         await asyncio.sleep(0.01 if ev.payload["n"] % 2 == 0 else 0.001)
         seen.append(ev.payload["n"])
 
@@ -302,6 +302,76 @@ async def test_duplicate_subscription_same_args_unsubscribes_one_copy() -> None:
 
     await bus.publish(new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel"))
     assert count == 1
+
+
+async def test_cross_session_cycle_does_not_deadlock() -> None:
+    """Handlers on different sessions that publish into each other must not deadlock.
+
+    With per-session workers AND await-done-for-external-callers, a cycle
+    where s1 handler publishes to s2 and s2 handler publishes to s1 would
+    block both workers on each other's completion future. The fix is to
+    treat any in-worker caller as fire-and-forget, regardless of target
+    session.
+    """
+    bus = EventBus(handler_timeout_s=1.0)
+    seen_pong: list[Event] = []
+
+    async def on_ping(ev: Event) -> None:
+        # Received on s2; publishes a pong to s1.
+        await bus.publish(new_event("x.pong", {"reply": ev.payload["n"]}, session_id="s1", source="p"))
+
+    async def on_pong(ev: Event) -> None:
+        seen_pong.append(ev)
+
+    bus.subscribe("x.ping", on_ping, source="p")
+    bus.subscribe("x.pong", on_pong, source="observer")
+
+    # External call: top-level task publishes a ping to s2 and awaits delivery.
+    await asyncio.wait_for(
+        bus.publish(new_event("x.ping", {"n": 1}, session_id="s2", source="kernel")),
+        timeout=0.5,
+    )
+    # Let s1's worker drain the pong.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert len(seen_pong) == 1
+    assert seen_pong[0].payload["reply"] == 1
+
+
+async def test_plugin_error_cascade_does_not_deadlock() -> None:
+    """A plugin.error handler that publishes back to the originating session must not deadlock.
+
+    Regression for the round-1 design: _report_handler_failure awaited the
+    kernel-session done from inside a session worker, so a plugin.error
+    handler that cascaded back to the originating session would hang.
+    """
+    bus = EventBus(handler_timeout_s=1.0)
+    cascade: list[Event] = []
+
+    async def bad(_: Event) -> None:
+        raise RuntimeError("boom")
+
+    async def on_error_cascade(_: Event) -> None:
+        await bus.publish(new_event("x.echo", {"msg": "after-error"}, session_id="s1", source="errhandler"))
+
+    async def on_echo(ev: Event) -> None:
+        cascade.append(ev)
+
+    bus.subscribe("x.trigger", bad, source="bad")
+    bus.subscribe("plugin.error", on_error_cascade, source="errhandler")
+    bus.subscribe("x.echo", on_echo, source="observer")
+
+    await asyncio.wait_for(
+        bus.publish(new_event("x.trigger", {}, session_id="s1", source="kernel")),
+        timeout=0.5,
+    )
+    # Allow kernel + s1 workers to drain.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert len(cascade) == 1
+    assert cascade[0].payload["msg"] == "after-error"
 
 
 async def test_publish_after_close_logs_warning(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/kernel/test_bus.py
+++ b/tests/kernel/test_bus.py
@@ -1,0 +1,185 @@
+"""Tests for EventBus: delivery, isolation, extension routing, timeout, FIFO."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.events import Event, new_event
+
+
+async def test_delivers_to_subscriber() -> None:
+    """AC-01 — a published event reaches an exact-kind subscriber with envelope fields."""
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(ev: Event) -> None:
+        received.append(ev)
+
+    bus.subscribe("user.message.received", handler, source="test")
+    ev = new_event("user.message.received", {"text": "hi"}, session_id="s-1", source="adapter")
+    await bus.publish(ev)
+
+    assert len(received) == 1
+    got = received[0]
+    assert got.id == ev.id
+    assert got.kind == "user.message.received"
+    assert got.session_id == "s-1"
+    assert got.source == "adapter"
+    assert got.ts > 0
+    assert got.payload == {"text": "hi"}
+
+
+async def test_raising_subscriber_isolated() -> None:
+    """AC-02 — a raising handler does not stop other subscribers and triggers plugin.error."""
+    bus = EventBus()
+    healthy: list[Event] = []
+    errors: list[Event] = []
+
+    async def bad(_: Event) -> None:
+        raise RuntimeError("boom")
+
+    async def good(ev: Event) -> None:
+        healthy.append(ev)
+
+    async def on_err(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe("user.message.received", bad, source="bad-plugin")
+    bus.subscribe("user.message.received", good, source="good-plugin")
+    bus.subscribe("plugin.error", on_err, source="observer")
+
+    await bus.publish(new_event("user.message.received", {"text": "x"}, session_id="s", source="adapter"))
+
+    assert len(healthy) == 1
+    assert len(errors) == 1
+    err = errors[0]
+    assert err.kind == "plugin.error"
+    assert err.source == "kernel"
+    assert err.payload == {"name": "bad-plugin", "error": "boom"}
+
+
+async def test_extension_namespace_routes() -> None:
+    """AC-04 — x.* events route opaquely; payload passes through untouched."""
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(ev: Event) -> None:
+        received.append(ev)
+
+    bus.subscribe("x.foo.bar", handler, source="foo")
+    payload = {"deeply": {"nested": [1, 2, 3]}, "unknown": object()}
+    ev = new_event("x.foo.bar", payload, session_id="s", source="foo")
+    await bus.publish(ev)
+
+    assert len(received) == 1
+    assert received[0].payload is payload
+
+
+async def test_subscriber_timeout_triggers_plugin_error() -> None:
+    """A handler exceeding the configured deadline is cancelled and reported."""
+    bus = EventBus(handler_timeout_s=0.05)
+    errors: list[Event] = []
+
+    async def slow(_: Event) -> None:
+        await asyncio.sleep(10)
+
+    async def on_err(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe("user.message.received", slow, source="slowpoke")
+    bus.subscribe("plugin.error", on_err, source="observer")
+
+    await bus.publish(new_event("user.message.received", {"text": "x"}, session_id="s", source="adapter"))
+
+    assert len(errors) == 1
+    assert errors[0].payload["name"] == "slowpoke"
+
+
+async def test_fifo_per_session() -> None:
+    """Events sharing a session_id are delivered in publish order."""
+    bus = EventBus()
+    seen: list[int] = []
+
+    async def handler(ev: Event) -> None:
+        # Variable delay to try to reorder — the per-session lock must prevent it.
+        await asyncio.sleep(0.01 if ev.payload["n"] % 2 == 0 else 0.001)
+        seen.append(ev.payload["n"])
+
+    bus.subscribe("x.fifo.tick", handler, source="fifo")
+
+    async def publish(n: int) -> None:
+        await bus.publish(new_event("x.fifo.tick", {"n": n}, session_id="same", source="gen"))
+
+    await asyncio.gather(*(publish(i) for i in range(10)))
+
+    assert seen == sorted(seen)  # strictly monotonic per publish order within the session.
+    assert len(seen) == 10
+
+
+async def test_unsubscribe_stops_delivery() -> None:
+    """Subscription.unsubscribe() removes the handler from the routing table."""
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(ev: Event) -> None:
+        received.append(ev)
+
+    sub = bus.subscribe("kernel.ready", handler, source="t")
+    sub.unsubscribe()
+    # Idempotent.
+    sub.unsubscribe()
+    await bus.publish(new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel"))
+    assert received == []
+
+
+async def test_close_is_idempotent_and_blocks_publish() -> None:
+    """Close drains state and becomes a no-op on subsequent publishes."""
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(ev: Event) -> None:
+        received.append(ev)
+
+    bus.subscribe("kernel.ready", handler, source="t")
+    await bus.close()
+    await bus.close()
+    await bus.publish(new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel"))
+    assert received == []
+
+
+async def test_kernel_origin_failure_does_not_recurse() -> None:
+    """A handler that raises with source='kernel' must not spawn another plugin.error."""
+    bus = EventBus()
+    err_count = 0
+
+    async def raising_kernel_handler(_: Event) -> None:
+        raise RuntimeError("kernel internal")
+
+    async def on_err(_: Event) -> None:
+        nonlocal err_count
+        err_count += 1
+
+    bus.subscribe("plugin.error", raising_kernel_handler, source="kernel")
+    bus.subscribe("plugin.error", on_err, source="observer")
+
+    # Publish a plugin.error directly.
+    ev = new_event(
+        "plugin.error",
+        {"name": "foo", "error": "bar"},
+        session_id="kernel",
+        source="kernel",
+    )
+    await bus.publish(ev)
+
+    # The observer saw the original; the raising kernel handler did NOT cause another.
+    assert err_count == 1
+
+
+def test_handler_timeout_default_is_30s() -> None:
+    """Default timeout matches the plugin-protocol 30s deadline."""
+    from yaya.kernel.bus import DEFAULT_HANDLER_TIMEOUT_S
+
+    assert pytest.approx(30.0) == DEFAULT_HANDLER_TIMEOUT_S

--- a/tests/kernel/test_events.py
+++ b/tests/kernel/test_events.py
@@ -1,0 +1,74 @@
+"""Unit tests for the kernel's closed event catalog and envelope factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from yaya.kernel.events import PUBLIC_EVENT_KINDS, Event, new_event
+
+
+def test_envelope_fields() -> None:
+    """new_event populates every envelope field mandated by plugin-protocol.md."""
+    ev = new_event(
+        "user.message.received",
+        {"text": "hello"},
+        session_id="s-1",
+        source="web",
+    )
+
+    assert isinstance(ev, Event)
+    assert ev.kind == "user.message.received"
+    assert ev.session_id == "s-1"
+    assert ev.source == "web"
+    assert ev.payload == {"text": "hello"}
+    assert isinstance(ev.id, str) and len(ev.id) == 32  # uuid4 hex.
+    assert isinstance(ev.ts, float) and ev.ts > 0
+
+
+def test_rejects_unknown_public_kind() -> None:
+    """Kinds outside the closed catalog and not prefixed 'x.' raise ValueError."""
+    with pytest.raises(ValueError, match=r"closed catalog|PublicEventKind"):
+        new_event("nonsense.unknown", {}, session_id="s", source="x")
+
+
+def test_accepts_extension_namespace() -> None:
+    """x.<plugin>.<kind> events are routed without being validated against the catalog."""
+    ev = new_event("x.foo.bar", {"anything": 1}, session_id="s", source="foo")
+    assert ev.kind == "x.foo.bar"
+    assert ev.payload == {"anything": 1}
+
+
+def test_public_catalog_matches_protocol_document() -> None:
+    """Guardrail: every public kind documented in plugin-protocol.md is present."""
+    expected = {
+        "user.message.received",
+        "user.interrupt",
+        "assistant.message.delta",
+        "assistant.message.done",
+        "llm.call.request",
+        "llm.call.response",
+        "llm.call.error",
+        "tool.call.request",
+        "tool.call.start",
+        "tool.call.result",
+        "memory.query",
+        "memory.write",
+        "memory.result",
+        "strategy.decide.request",
+        "strategy.decide.response",
+        "plugin.loaded",
+        "plugin.reloaded",
+        "plugin.removed",
+        "plugin.error",
+        "kernel.ready",
+        "kernel.shutdown",
+        "kernel.error",
+    }
+    assert expected == PUBLIC_EVENT_KINDS
+
+
+def test_new_event_ids_are_unique() -> None:
+    """Two calls with identical inputs produce distinct ids."""
+    a = new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel")
+    b = new_event("kernel.ready", {"version": "0.0.1"}, session_id="s", source="kernel")
+    assert a.id != b.id

--- a/tests/kernel/test_events.py
+++ b/tests/kernel/test_events.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 import pytest
 
-from yaya.kernel.events import PUBLIC_EVENT_KINDS, Event, new_event
+from yaya.kernel.events import (
+    PUBLIC_EVENT_KINDS,
+    AssistantMessageDonePayload,
+    Event,
+    LlmCallErrorPayload,
+    LlmCallRequestPayload,
+    LlmCallResponsePayload,
+    ToolCallResultPayload,
+    UserMessageReceivedPayload,
+    new_event,
+)
 
 
 def test_envelope_fields() -> None:
@@ -65,6 +75,31 @@ def test_public_catalog_matches_protocol_document() -> None:
         "kernel.error",
     }
     assert expected == PUBLIC_EVENT_KINDS
+
+
+@pytest.mark.parametrize(
+    ("td", "required", "optional"),
+    [
+        (UserMessageReceivedPayload, {"text"}, {"attachments"}),
+        (AssistantMessageDonePayload, {"content", "tool_calls"}, set()),
+        (
+            LlmCallRequestPayload,
+            {"provider", "model", "messages", "params"},
+            {"tools"},
+        ),
+        (LlmCallResponsePayload, {"usage"}, {"text", "tool_calls"}),
+        (LlmCallErrorPayload, {"error"}, {"retry_after_s"}),
+        (ToolCallResultPayload, {"id", "ok"}, {"value", "error"}),
+    ],
+)
+def test_typed_dict_required_optional_partition(
+    td: type,
+    required: set[str],
+    optional: set[str],
+) -> None:
+    """Required/optional field partition must match docs/dev/plugin-protocol.md."""
+    assert set(td.__required_keys__) == required
+    assert set(td.__optional_keys__) == optional
 
 
 def test_new_event_ids_are_unique() -> None:

--- a/tests/kernel/test_plugin.py
+++ b/tests/kernel/test_plugin.py
@@ -1,0 +1,92 @@
+"""Tests for Category, Plugin Protocol, KernelContext."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.events import Event
+from yaya.kernel.plugin import Category, KernelContext, Plugin
+
+
+def test_category_round_trips_as_str() -> None:
+    """Category is a StrEnum and its values match the protocol table verbatim."""
+    assert Category.ADAPTER == "adapter"
+    assert Category.TOOL == "tool"
+    assert Category.LLM_PROVIDER == "llm-provider"
+    assert Category.STRATEGY == "strategy"
+    assert Category.MEMORY == "memory"
+    assert Category.SKILL == "skill"
+    assert str(Category.ADAPTER.value) == "adapter"
+
+
+def test_plugin_protocol_is_runtime_checkable() -> None:
+    """A plain object matching the Plugin shape passes isinstance()."""
+
+    class _Stub:
+        name = "stub"
+        version = "0.0.1"
+        category = Category.TOOL
+        requires: ClassVar[list[str]] = []
+
+        def subscriptions(self) -> list[str]:
+            return []
+
+        async def on_load(self, ctx: KernelContext) -> None:
+            return None
+
+        async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+            return None
+
+        async def on_unload(self, ctx: KernelContext) -> None:
+            return None
+
+    assert isinstance(_Stub(), Plugin)
+
+
+async def test_kernel_context_emit_stamps_source_and_routes(tmp_path: Path) -> None:
+    """KernelContext.emit builds an Event with source=plugin-name and publishes via the bus."""
+    bus = EventBus()
+    received: list[Event] = []
+
+    async def handler(ev: Event) -> None:
+        received.append(ev)
+
+    bus.subscribe("user.message.received", handler, source="test")
+
+    ctx = KernelContext(
+        bus=bus,
+        logger=logging.getLogger("plugin.web"),
+        config={"k": "v"},
+        state_dir=tmp_path,
+        plugin_name="web",
+    )
+
+    await ctx.emit("user.message.received", {"text": "hi"}, session_id="s-1")
+
+    assert len(received) == 1
+    assert received[0].source == "web"
+    assert received[0].kind == "user.message.received"
+    assert received[0].payload == {"text": "hi"}
+    # Read-only config surface + writable state_dir.
+    assert ctx.config["k"] == "v"
+    assert ctx.state_dir == tmp_path
+    assert ctx.logger.name == "plugin.web"
+
+
+async def test_kernel_context_emit_rejects_unknown_public_kind(tmp_path: Path) -> None:
+    """Emitting a non-catalog, non-extension kind surfaces ValueError to the caller."""
+    bus = EventBus()
+    ctx = KernelContext(
+        bus=bus,
+        logger=logging.getLogger("plugin.broken"),
+        config={},
+        state_dir=tmp_path,
+        plugin_name="broken",
+    )
+    with pytest.raises(ValueError, match=r"closed catalog|PublicEventKind"):
+        await ctx.emit("not.a.kind", {}, session_id="s")


### PR DESCRIPTION
## Summary

Implements the foundational kernel primitives per
`docs/dev/plugin-protocol.md`. This is the bottom layer; the rest of
the 0.1 milestone (agent loop, registry, seed plugins, CLI, web
adapter) depends on it.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Component

`core`

## Closes

Closes #11

## Test plan

- [x] `just check` clean (ruff + mypy --strict)
- [x] `pytest tests/kernel -v --cov=src/yaya/kernel` 95% kernel coverage (18 tests, all green)
- [x] full `pytest` suite green: 73 tests, 90% total coverage
- [x] `mkdocs build -s` clean
- [x] All 5 BDD scenarios bound via `Test:` selectors
- [x] No imports from cli/plugins/core
- [ ] CI green (watching)

## Notes

- `just check-all` fails on pre-commit's stale pinned ruff version
  (`py314` target unsupported). Pre-existing, unrelated to this PR.