### PR TITLE
docs(workflow): define agent-ready issues (#50)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bdd_task.yml
+++ b/.github/ISSUE_TEMPLATE/bdd_task.yml
@@ -1,0 +1,203 @@
+name: BDD Task
+description: Feature or bugfix with an agent-spec BDD contract
+labels: ["enhancement", "bdd"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## BDD Task
+        Use this template when the issue needs a `ZhangHanDong/agent-spec`
+        contract under `specs/<slug>.spec`.
+        The Agent Task Packet tells the implementation agent how to work in
+        this repository; the agent-spec contract defines observable behavior.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why? Use 2-3 sentences.
+    validations:
+      required: true
+
+  - type: textarea
+    id: plan-spec
+    attributes:
+      label: Plan Spec
+      description: Product context, deliverables, constraints, and out of scope.
+      placeholder: |
+        **Product context:** Why this feature exists, what user problem it solves.
+
+        **Deliverables:**
+        - [ ] Deliverable 1 — brief description
+        - [ ] Deliverable 2 — brief description
+
+        **Constraints:**
+        - Constraint 1
+
+        **Out of scope:**
+        - Thing explicitly excluded
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent-spec-contract
+    attributes:
+      label: "agent-spec Contract Draft"
+      description: |
+        Draft the `specs/<slug>.spec` contract. Minimum 3 scenarios: happy path,
+        error path, and edge case. Every scenario must bind to a concrete test
+        through a `Test:` selector.
+      placeholder: |
+        spec: task
+        name: "<slug>"
+        tags: [<optional tags>]
+        ---
+
+        ## Intent
+
+        One stakeholder-readable paragraph.
+
+        ## Decisions
+
+        - Fixed technical choices that are not up for debate in this PR.
+
+        ## Boundaries
+
+        ### Allowed Changes
+        - `src/...`
+        - `tests/...`
+
+        ### Forbidden
+        - `pyproject.toml`
+
+        ## Completion Criteria
+
+        Scenario: happy path
+          Test:
+            Package: yaya
+            Filter: tests/...::test_happy_path
+          Level: unit
+          Given <precondition>
+          When <action>
+          Then <observable outcome>
+
+        Scenario: error path
+          Test:
+            Package: yaya
+            Filter: tests/...::test_error_path
+          Level: unit
+          Given <precondition>
+          When <invalid action>
+          Then <observable failure>
+
+        Scenario: edge case
+          Test:
+            Package: yaya
+            Filter: tests/...::test_edge_case
+          Level: unit
+          Given <edge condition>
+          When <action>
+          Then <observable outcome>
+
+        ## Out of Scope
+
+        - Deliberately deferred work.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-spec
+    attributes:
+      label: Design Spec
+      description: Files to modify/create, key interface signatures, and constraints.
+      placeholder: |
+        ## Files to modify
+        - `src/module/file.py` — what to change
+
+        ## Files to create
+        - `src/module/new_file.py` — what it does
+
+        ## Key interfaces
+        - `def function_name(...) -> ResultType:`
+
+        ## Constraints
+        - Do NOT do X because Y
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system does this relate to?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Affected modules, packages, or directories.
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+        - `agent-spec lint specs/<slug>.spec`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional Context
+      description: References, parent issues, constraints, or design notes.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `...`
+        2. Send request to ...
+        3. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error output
+      description: Relevant log output or error messages.
+      render: shell
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of the relevant version command.
+      placeholder: "v0.1.0"
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion-criteria
+    attributes:
+      label: Completion Criteria
+      description: Concrete conditions that must be true before the PR is ready.
+      placeholder: |
+        - [ ] Regression is covered by a test.
+        - [ ] Fix is documented where behavior changed.
+        - [ ] `just check && just test` passes.
+      render: markdown
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,81 @@
+name: Chore / Maintenance
+description: CI, dependencies, tooling, or other maintenance tasks
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What maintenance work is needed?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion-criteria
+    attributes:
+      label: Completion Criteria
+      description: Concrete conditions that must be true before the PR is ready.
+      placeholder: |
+        - [ ] Maintenance change is scoped to the requested area.
+        - [ ] Affected docs or automation notes are updated.
+        - [ ] `just check && just test` passes.
+      render: markdown
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,82 @@
+name: Documentation
+description: Improve project documentation, examples, or agent instructions
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What documentation needs to change and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+        - `just docs-test`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion-criteria
+    attributes:
+      label: Completion Criteria
+      description: Concrete conditions that must be true before the PR is ready.
+      placeholder: |
+        - [ ] Docs explain the behavior without duplicating source truth.
+        - [ ] Links and navigation are still valid.
+        - [ ] `just check && just test && just docs-test` passes.
+      render: markdown
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,88 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What do you want and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system does this relate to?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about.
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion-criteria
+    attributes:
+      label: Completion Criteria
+      description: Concrete conditions that must be true before the PR is ready.
+      placeholder: |
+        - [ ] User-visible behavior is implemented.
+        - [ ] Tests cover happy path, failure path, and edge case.
+        - [ ] Docs and folder `AGENT.md` files are updated if behavior changed.
+        - [ ] `just check && just test` passes.
+      render: markdown
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,89 @@
+name: Refactor
+description: Propose a code refactor or technical improvement
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs refactoring and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - kernel (agent loop, plugin registry, event bus)
+        - plugins (bundled or external plugin protocol)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent-owner
+    attributes:
+      label: Agent owner
+      description: Who should implement the first pass?
+      options:
+        - agent:codex
+        - agent:claude
+        - human / unassigned
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: How would you approach this refactor?
+    validations:
+      required: true
+
+  - type: textarea
+    id: agent-task-packet
+    attributes:
+      label: Agent Task Packet
+      description: Context the implementation agent must read before editing.
+      value: |
+        ### Read First
+        - `GOAL.md`
+        - `AGENT.md`
+        - Area-specific docs, specs, and folder `AGENT.md` files
+
+        ### Expected Touch Points
+        - 
+
+        ### Forbidden / Avoid
+        - 
+
+        ### Existing Patterns
+        - 
+
+        ### Validation
+        - `just check`
+        - `just test`
+
+        ### Failure Modes To Cover
+        - 
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: completion-criteria
+    attributes:
+      label: Completion Criteria
+      description: Concrete conditions that must be true before the PR is ready.
+      placeholder: |
+        - [ ] Public behavior is unchanged unless explicitly scoped.
+        - [ ] Existing tests still cover the moved or reshaped behavior.
+        - [ ] `just check && just test` passes.
+      render: markdown
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+## Summary
+
+<!-- Brief description of the changes. -->
+
+## Type of change
+
+<!-- Check the one that applies and add the matching label to this PR. -->
+
+| Type | Label |
+|------|-------|
+| Bug fix | `bug` |
+| New feature | `enhancement` |
+| Breaking change | `breaking-change` |
+| Refactor | `refactor` |
+| CI / Infrastructure | `ci` |
+| Maintenance | `chore` |
+| Documentation | `documentation` |
+
+## Component
+
+<!-- Add the component label that best matches the area you changed. -->
+<!-- `core` · `kernel` · `plugins` · `cli` · `ci` · `docs` -->
+
+## Closes
+
+<!-- REQUIRED: Link the issue this PR resolves. PR merge will auto-close the issue. -->
+<!-- If no issue exists, create one first: gh issue create -->
+
+Closes #
+
+## Issue context used
+
+<!-- Agent-authored PRs must list the issue context used before editing. -->
+
+- Issue:
+- Agent Task Packet source:
+- Issue comments that changed the plan:
+
+## Deviations from issue/spec
+
+<!-- List every scope or design change discovered during implementation. Use "None." if unchanged. -->
+
+## Agent notes
+
+<!-- Reviewer-relevant notes, known trade-offs, or follow-up issue numbers. Use "None." if not needed. -->
+
+## Test plan
+
+- [ ] Tests pass
+- [ ] Lints pass
+- [ ] Tested locally
+
+## Verification evidence
+
+<!-- Paste exact local commands and the CI check summary before reporting done. -->

--- a/AGENT.md
+++ b/AGENT.md
@@ -35,7 +35,7 @@ Accountability is to the **artifact**, not to the user's approval.
 
 - `just check` (ruff + mypy) and `just test` (pytest + coverage) are ground truth.
 - CI is the final gate — `gh pr checks --watch` green before reporting done.
-- Every non-trivial feature PR is backed by a `specs/<slug>.spec.md` contract verified with [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec) (`agent-spec lifecycle` locally, `agent-spec guard` in CI).
+- Every non-trivial feature PR is backed by a `specs/<slug>.spec` contract verified with [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec) (`agent-spec lifecycle` locally, `agent-spec guard` in CI).
 - Folder-local `AGENT.md` is ground truth for that folder. If code contradicts it, one of them is wrong — fix before merging.
 
 ## 4. Constraints
@@ -45,7 +45,7 @@ Accountability is to the **artifact**, not to the user's approval.
 - Conventional Commits with `(#N)` + `Closes #N`. Never `--no-verify`.
 - Layout: `cli/` depends on `core/`, never the reverse.
 - **[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)** for all Python. Every public module/class/function has a Google-style docstring explaining _why_, not _what_. Inline comments mark non-obvious invariants only. See [docs/dev/code-comments.md](docs/dev/code-comments.md).
-- **BDD contracts via [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec).** Every non-trivial feature PR ships with `specs/<slug>.spec.md` (Intent · Decisions · Boundaries · Completion Criteria). Each scenario binds to a test via `Test:` selector. Run `agent-spec lifecycle` before commit; CI runs `agent-spec guard` on staged changes. See [docs/dev/agent-spec.md](docs/dev/agent-spec.md).
+- **BDD contracts via [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec).** Every non-trivial feature PR ships with `specs/<slug>.spec` (Intent · Decisions · Boundaries · Completion Criteria). Each scenario binds to a test via `Test:` selector. Run `agent-spec lifecycle` before commit; CI runs `agent-spec guard` on staged changes. See [docs/dev/agent-spec.md](docs/dev/agent-spec.md).
 - **No third-party AI agent frameworks.** yaya is the kernel; the agent loop, plugin registry, tool orchestration, strategy dispatch, memory, and session state are all implemented in this repo. The following categories are **banned** from imports, dependencies, and vendor/: LangChain, LangGraph, LangSmith, LlamaIndex, Haystack, AutoGen, CrewAI, Semantic Kernel, Instructor, Guidance, DSPy, Mirascope, Marvin, Griptape, Smol, OpenAI Agents SDK, Anthropic `agents` SDK, or any other library whose stated purpose is "agent creation / orchestration / chains / flows". **Permitted for LLM access: the official `openai` and `anthropic` Python SDKs — nothing else.** Permitted for everything else: general-purpose libraries (HTTP, web frameworks, data validation, storage, test infrastructure) as long as their docs do not position them as agent frameworks. If in doubt, vendor a minimal implementation into `src/yaya/kernel/` instead of importing. See [docs/dev/no-agent-frameworks.md](docs/dev/no-agent-frameworks.md).
 
 ## 5. Anti-sycophancy
@@ -68,7 +68,15 @@ gh issue create (labelled)  →  git worktree add .worktrees/issue-{N}-{slug} -b
 
 Required labels on every issue and PR:
 `agent:{claude|codex}` + type (`bug|enhancement|refactor|chore|documentation`)
-+ component (`core|cli|ci|docs`). Templates inherited from `rararulab/.github`.
++ component (`core|kernel|plugins|cli|ci|docs`). yaya carries local
+experimental issue/PR templates so agent-oriented workflow changes can be
+tested here before they move to `rararulab/.github`.
+
+The GitHub issue is the only task record. External coding agents MUST read the
+issue body, the `Agent Task Packet` section, and the latest issue comments
+before editing. Do not create shadow task/story files. Planner notes go in
+issue comments; implementation notes go in the PR body; reviewer findings go
+in PR reviews/comments. See [docs/dev/workflow.md](docs/dev/workflow.md).
 
 Multi-agent: one agent, one worktree, one PR. Coordinate via issue comments,
 never by editing each other's branches. Parallel only for disjoint files;
@@ -106,4 +114,6 @@ Read local first, save tokens. Every code/test/scripts folder has its own
 **Org baseline** (canonical, `gh api repos/rararulab/.github/contents/...`):
 `docs/workflow.md` · `docs/stacked-prs.md` · `docs/commit-style.md` ·
 `docs/agent-friendly-cli.md` · `docs/agent-md.md` · `docs/code-comments.md` ·
-`docs/anti-patterns.md`. Issue/PR templates inherited — do not duplicate.
+`docs/anti-patterns.md`. The local yaya issue/PR templates are an
+experimental overlay; keep them aligned with the org baseline unless an issue
+explicitly tests a workflow change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,14 @@ These live in the org `.github` repo and apply to every rararulab repo. Fetch vi
 
 - Before any code edit: verify you are inside a worktree under `.worktrees/issue-{N}-*`.
   If you're on `main`, stop and open an issue first.
+- yaya carries local experimental issue and PR templates under `.github/`; keep
+  them aligned with the org baseline unless an issue explicitly tests workflow
+  changes.
 - Before reporting done: run `just check && just test` in the worktree, then
   `gh pr checks {PR} --watch` and paste the green summary.
 - Use subagents for independent issues in parallel; one worktree per subagent.
 - BDD contracts via [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec)
-  are non-negotiable for non-trivial feature work: author `specs/<slug>.spec.md`,
+  are non-negotiable for non-trivial feature work: author `specs/<slug>.spec`,
   run `agent-spec lifecycle` before commit, let `agent-spec guard` gate CI.
 - Python code follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html);
   every public symbol has a Google-style docstring.

--- a/docs/dev/agent-spec.md
+++ b/docs/dev/agent-spec.md
@@ -138,12 +138,12 @@ Pre-commit runs `agent-spec lint` automatically on any staged
 - **One contract, one issue.** Split large work into stacked
   contracts; see [workflow.md](workflow.md).
 
-## Relationship to the org BDD issue template
+## Relationship to the yaya BDD issue template
 
-`rararulab/.github/ISSUE_TEMPLATE/bdd_task.yml` captures the same
-sections (Description / Plan Spec / Feature file / Design spec). Use
-the issue template to open the issue; translate its scenarios into
-the `specs/<slug>.spec` format above.
+`.github/ISSUE_TEMPLATE/bdd_task.yml` captures the same sections
+(Description / Plan Spec / agent-spec contract draft / Design spec).
+Use the issue template to open the issue, then commit the executable
+contract as `specs/<slug>.spec`.
 
 ## What NOT To Do
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -85,7 +85,7 @@ serialization of the event catalog, and mismatches fail CI.
 
 ## Specs live next to code
 
-Every non-trivial feature is backed by a `specs/<slug>.spec.md` BDD
+Every non-trivial feature is backed by a `specs/<slug>.spec` BDD
 contract verified with [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec).
 Scenarios bind to test functions via `Test:` selectors. Run
 `agent-spec lifecycle` before commit; CI runs `agent-spec guard` on

--- a/docs/dev/multi-agent.md
+++ b/docs/dev/multi-agent.md
@@ -7,8 +7,9 @@ Coordination happens through GitHub, not chat context.
 
 1. **One agent, one worktree, one branch, one PR.** Agents never share a
    working tree.
-2. **Shared state is the issue tracker.** Discussion, status, and hand-off
-   happen in issue/PR comments — `@claude`, `@codex` mentions route work.
+2. **Shared state is the issue tracker.** Discussion, status, plans, and
+   hand-off happen in issue/PR comments — `@claude`, `@codex` mentions route
+   work.
 3. **No cross-branch edits.** An agent never pushes to another agent's
    branch. Hand-off = comment + new PR.
 4. **Parallelism condition**: issues are dispatched in parallel only when
@@ -16,6 +17,9 @@ Coordination happens through GitHub, not chat context.
    stacked PRs (`rararulab/.github/docs/stacked-prs.md`).
 5. **Identity is a label.** Every issue and PR carries `agent:claude` or
    `agent:codex` so authorship is auditable.
+6. **No shadow task records.** Do not create `.agents/tasks/`, story files,
+   or local task databases for agent work. Use the GitHub issue, PR body, and
+   comments as the durable hand-off record.
 
 ## Dispatch pattern
 
@@ -41,6 +45,7 @@ in order:
 6. `docs/dev/workflow.md`, `testing.md`, `code-comments.md`,
    `agent-spec.md`, `maintaining-agent-md.md` as relevant.
 7. The GitHub issue itself (`gh issue view <N>`).
+8. The issue's `Agent Task Packet` section and the latest issue comments.
 
 Skipping item 3 causes the subagent to re-commit known anti-patterns;
 every review round that uncovers a new hazard **appends a bullet** to
@@ -57,6 +62,23 @@ the wiki doc in the same PR.
 Large features that cannot be decomposed into independent issues use
 **stacked PRs**: one epic issue, sub-issues branched off `feat/{name}`,
 final summary PR to `main`.
+
+## Role hand-off records
+
+When agents split planning, implementation, and review, keep the hand-off in
+GitHub:
+
+- **Planner**: post the implementation plan as an issue comment. Include the
+  Agent Task Packet deltas if discovery changed the expected touch points,
+  validation commands, or forbidden areas.
+- **Implementer**: preserve what context was actually used in the PR body.
+  Call out deviations from the issue packet or BDD spec explicitly.
+- **Reviewer**: leave findings as PR review comments. If a finding exposes a
+  reusable hazard, append it to `docs/wiki/lessons-learned.md` in the fixing
+  PR.
+
+Do not hide hand-off notes in chat context. If the next agent needs it, it
+belongs in the issue or PR.
 
 ## Done criteria (per PR)
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -17,7 +17,7 @@
 - **Tests must fail before they pass.** Write the failing test first, then
   the implementation (TDD).
 - **Feature PRs**: each observable behavior is covered by a BDD scenario
-  in `specs/<slug>.spec.md` whose `Test:` selector names the test
+  in `specs/<slug>.spec` whose `Test:` selector names the test
   function. `agent-spec guard` rejects unbound scenarios. See
   [agent-spec.md](agent-spec.md).
 - **Test layout mirrors `src/`.** A file at `src/yaya/core/foo.py` has its

--- a/docs/dev/workflow.md
+++ b/docs/dev/workflow.md
@@ -27,10 +27,70 @@ Both must be green before `git push`.
 
 - **Agent**: `agent:claude` | `agent:codex`
 - **Type**: `bug` | `enhancement` | `refactor` | `chore` | `documentation`
-- **Component**: `core` | `cli` | `ci` | `docs`
+- **Component**: `core` | `kernel` | `plugins` | `cli` | `ci` | `docs`
 
-Issue and PR templates are inherited from `rararulab/.github` — do not
-duplicate them in this repo.
+yaya carries local experimental issue and PR templates under `.github/` so
+agent-oriented workflow changes can be tested here before they move to the org
+baseline. Keep those templates aligned with `rararulab/.github` unless the
+issue explicitly tests a workflow change.
+
+## Issue as the task record
+
+The GitHub issue is the only task record. Do not create shadow task files,
+BMAD-style story files, local task databases, or `.agents/tasks/` records
+unless the issue explicitly asks for a durable product artifact.
+
+All agent-facing task context belongs in the issue body or issue comments.
+Planner output goes in issue comments. Implementation notes go in the PR body.
+Reviewer findings go in PR reviews or PR comments.
+
+## Agent Task Packet
+
+Every issue assigned to a coding agent MUST include an **Agent Task Packet**
+section in the issue body or a linked issue comment. For small issues, a
+terse packet is enough; for agent-runtime, plugin-protocol, prompt, or
+security work, fill every subsection.
+
+```markdown
+## Agent Task Packet
+
+### Read First
+- `GOAL.md`
+- `AGENT.md`
+- Area-specific docs, specs, and folder `AGENT.md` files
+
+### Expected Touch Points
+- Files or folders the agent is expected to edit
+
+### Forbidden / Avoid
+- Files, layers, dependencies, or design moves that are out of scope
+
+### Existing Patterns
+- Local code, tests, docs, or prior PRs the agent should imitate
+
+### Validation
+- Exact commands the agent must run before pushing
+
+### Failure Modes To Cover
+- Error paths, rollback paths, security boundaries, and drift risks
+```
+
+The packet is not a replacement for a BDD spec. The issue packet tells the
+agent how to work in this repository; `specs/<slug>.spec` defines the
+observable behavior and test bindings for the change.
+
+## PR as the implementation record
+
+The local PR template is the baseline. For agent-authored PRs, fill the body
+with these additional facts instead of creating a separate local note:
+
+- **Issue context used**: issue number, Agent Task Packet source, and any
+  issue comments that changed the plan.
+- **Deviations from issue/spec**: every scope or design change discovered
+  during implementation, with the GitHub comment or commit that explains it.
+- **Agent notes**: reviewer-relevant implementation notes, known trade-offs,
+  and any follow-up issue numbers.
+- **Verification evidence**: exact local commands run and the CI check summary.
 
 ## Multi-agent dispatch
 

--- a/docs/wiki/lessons-learned.md
+++ b/docs/wiki/lessons-learned.md
@@ -259,7 +259,7 @@ affected subsequent issues.
 **Root cause** — Implementation-level decisions buried in code
 comments are invisible to the next agent reading only the spec.
 
-**Rule** — `specs/<slug>.spec.md`'s `## Decisions` section captures
+**Rule** — `specs/<slug>.spec`'s `## Decisions` section captures
 every **non-obvious** design choice that affects the external contract
 or downstream issues. One bullet per decision, with the **why**.
 


### PR DESCRIPTION
## Summary

- Define GitHub issues as yaya's only task record for agent-executed work.
- Add local experimental issue forms under `.github/ISSUE_TEMPLATE` so every issue type carries an Agent Task Packet, component choice, agent owner, and completion criteria where applicable.
- Align the BDD issue template with `ZhangHanDong/agent-spec`: non-trivial work drafts and commits `specs/<slug>.spec`, not `.feature` / Gherkin files.
- Add a local PR template that records issue context used, deviations from issue/spec, agent notes, test plan, and verification evidence.
- Clarify multi-agent planner/implementer/reviewer handoffs through issue comments, PR bodies, and PR reviews instead of shadow task files.

## Issue Context Used

- Issue: #50
- Agent Task Packet source: issue body
- Relevant context: `AGENTS.md`, `AGENT.md`, `docs/dev/workflow.md`, `docs/dev/multi-agent.md`, `docs/dev/agent-spec.md`, org `.github` templates fetched through `gh api`

## Deviations From Issue / Spec

The original issue packet avoided local templates because yaya previously inherited org templates. Per maintainer direction, yaya is the experimental repo for this workflow, so this PR now adds local issue and PR templates while documenting them as an experimental overlay that should stay aligned with `rararulab/.github` unless an issue explicitly tests workflow changes.

## Type of change

| Type | Label |
|------|-------|
| Documentation | `documentation` |

## Component

`docs`

## Closes

Closes #50

## Test plan

- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/ISSUE_TEMPLATE/*.yml`
- [x] `just check && just test`
- [x] `just docs-test`
- [x] Tested locally

## Agent Notes

Yes, yaya still uses `ZhangHanDong/agent-spec` for BDD. The issue template only captures the draft and task context; the executable contract remains `specs/<slug>.spec`, linted by `agent-spec` through `just check` / CI. This keeps the experiment inside GitHub issues and PRs rather than adding `.agents/tasks`, BMAD stories, or another task store.

## Verification evidence

Local verification passed on 2026-04-17:

- `just check && just test && just docs-test`
- ruff check passed; ruff format check passed
- mypy strict passed on 15 source files
- agent-spec lint passed with pre-existing info/warnings only
- pytest: 101 passed; coverage 91.35% against required 88%
- mkdocs strict build passed
