### PR TITLE
fix(plugins/web): restore ep.dist.version lost via squash-merge race (#68)

### DIFF
--- a/docs/wiki/lessons-learned.md
+++ b/docs/wiki/lessons-learned.md
@@ -579,6 +579,49 @@ components.
 
 ---
 
+## 28. Verify squash-merge ingested the latest push before cleanup
+
+**Symptom** — PR #65's round-2 fix commit `fb2f9bd` ("populate version
+from ep.dist.version; lesson #26") was pushed to the branch,
+verified green in CI, then `gh pr merge --squash --admin` was
+called. The squash commit `2d83483` that landed on `main` did NOT
+contain that change — it regressed to the round-1 blank-version
+form. `git branch --contains fb2f9bd` returns empty; the commit is
+orphaned. The lesson #26 fix reached production only two days later
+via PR #68 after the regression was spotted during PR #67's live
+smoke.
+
+**Root cause** — `gh pr merge --admin` resolved the squash against a
+stale head-of-branch because the merge API call raced the final
+`git push`. The symptom showed up at merge time as
+`failed to run git: fatal: 'main' is already used by worktree at
+.../yaya` — which I treated as cosmetic. It wasn't: GitHub had
+already taken the merge-base reading from the earlier SHA and
+silently dropped the in-flight commit.
+
+**Rule** — Before `gh pr merge --admin`, **verify the head matches
+what you expect** with `gh pr view <N> --json headRefOid`. After
+merge, **verify the merge commit contains the intended change**
+with `git log origin/main -1 -- <changed file>` or
+`git diff origin/main~1 origin/main -- <file>`. Any "already used
+by worktree" warning from `gh pr merge` is NOT benign — it hints at
+a non-atomic merge path. Never dismiss it.
+
+For the subagent workflow: a subagent's "CI green; ready to merge"
+report is not a substitute for verifying the merge ACTUALLY
+ingested the expected SHA. After every merge, grep the merged
+source for one specific string from the latest fix to confirm it
+landed.
+
+**Reference** — PR #68 (restore), orphaned commit `fb2f9bd`, merged
+PR #65 as `2d83483`. Related to lesson #22 (long-lived branches
+accumulate ghost deletions in PR diffs) — both are classes of
+"merge-time diff ≠ what you thought" hazards. Cf. lesson #11
+(empirical probes): verify AT the moment of merge, not when code
+was reviewed.
+
+---
+
 ## How to use this doc
 
 - Before starting a PR that touches the kernel, event bus, plugin ABI,

--- a/src/yaya/plugins/web/plugin.py
+++ b/src/yaya/plugins/web/plugin.py
@@ -353,15 +353,30 @@ class WebAdapter:
                 self._ctx.logger.warning("could not enumerate yaya.plugins.v1: %s", exc)
             return
         for ep in eps:
-            # We can't know the plugin's ``category`` without loading
+            # ``ep.dist.version`` is the owning distribution's version
+            # (e.g. "0.0.1" for bundled yaya plugins, or the 3rd-party
+            # package's version). It is NOT the plugin's self-declared
+            # ``version``, but it is cheap to read without loading the
+            # plugin object, and it is strictly better than a blank
+            # column. A subsequent ``plugin.loaded`` event overwrites
+            # with the authoritative value when one arrives (i.e. for
+            # the adapter itself, and any plugin loaded AFTER the
+            # adapter subscribed). See lesson #26.
+            version = ""
+            if ep.dist is not None:
+                try:
+                    version = ep.dist.version
+                except Exception:  # pragma: no cover - defensive only
+                    version = ""
+            # We cannot know the plugin's ``category`` without loading
             # it (the entry-point value is a "module:attr" string, not
-            # a Plugin object). Leave category blank; the subsequent
-            # ``plugin.loaded`` events overwrite with the real value.
+            # a Plugin object); that field stays blank until a
+            # ``plugin.loaded`` event patches it.
             self._plugin_rows.setdefault(
                 ep.name,
                 {
                     "name": ep.name,
-                    "version": "",
+                    "version": version,
                     "category": "",
                     "status": "loaded",
                 },


### PR DESCRIPTION
## Summary

Restores the \`ep.dist.version\` read in \`_prime_plugin_inventory\`
that landed in orphaned commit \`fb2f9bd\` (lesson #26) but was
dropped during PR #65's squash-merge. Live probe on main after PR
#67 confirmed the regression:

Before this PR: all seed plugins show \`version: ""\`.
After this PR: all seed plugins show \`version: "0.0.1"\`.

Also appends lesson #28 documenting the squash-merge race so we
don't repeat it.

## Type of change
| Type | Label |
|------|-------|
| Bug fix | \`bug\` |

## Component
\`core\` (plugins/web)

## Closes
Closes #68
Closes #69

## Test plan
- [x] Live probe shows \`version: "0.0.1"\` for all 4 seed plugins
- [x] \`mypy\`, \`ruff\`, \`pytest tests/plugins/web\` clean
- [x] Lesson #28 appended to \`docs/wiki/lessons-learned.md\`
- [ ] CI green (watching)

## Verification after merge
Per lesson #28, I will verify the merged commit contains
\`ep.dist.version\` with \`git show <merge-sha> -- src/yaya/plugins/web/plugin.py | grep -A2 ep.dist\`
before cleanup.