### PR TITLE
fix(tests): TRY004 in e2e conftest — use TypeError (#47)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -71,5 +71,5 @@ def json_stdout(result: subprocess.CompletedProcess[str]) -> dict[str, object]:
             f"stdout is not JSON: {exc}\nraw stdout:\n{result.stdout}",
         ) from exc
     if not isinstance(data, dict):
-        raise AssertionError(f"expected object, got {type(data).__name__}")  # noqa: TRY004
+        raise TypeError(f"expected object, got {type(data).__name__}")
     return data


### PR DESCRIPTION
## Summary

ruff's `TRY004` fires on `tests/e2e/conftest.py:76`
(`raise AssertionError(...)` for a type-validation message).
Change to `TypeError`. Unblocks the Lint & type check job on
every downstream PR.

## Type of change
| Type | Label |
|------|-------|
| Bug fix | `bug` |

## Component
`ci`

## Closes
Closes #47

## Test plan
- [x] `ruff check` clean on e2e/
- [x] `pytest` unchanged (the fixture still raises the same semantic error)
- [ ] CI green (watching)