### PR TITLE
feat(plugins): bundled llm_echo dev provider — zero-config round-trip (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Read the full anchor: **[GOAL.md](GOAL.md)**.
 
 ```bash
 pip install https://github.com/rararulab/yaya/releases/latest/download/yaya-<VERSION>-py3-none-any.whl
-yaya --help
+yaya serve
 ```
 
-Requires Python 3.14+. Other install options →
-[docs/guide/install.md](docs/guide/install.md).
+`yaya serve` boots the kernel, opens a chat in your browser, and works
+offline out of the box — the bundled `llm_echo` dev provider replies
+deterministically until you set `OPENAI_API_KEY`. Requires Python 3.14+.
+Other install options → [docs/guide/install.md](docs/guide/install.md).
 
 ## Documentation
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -70,6 +70,20 @@ ships a BDD `.spec` (0 WARN from `agent-spec lint`) + unit tests
 under `tests/plugins/<name>/`.
 See: ../../specs/plugin-strategy_react.spec, ../../specs/plugin-memory_sqlite.spec, ../../specs/plugin-llm_openai.spec, ../../specs/plugin-tool_bash.spec, ../../src/yaya/plugins/
 
+## [2026-04-18] ingest | bundled llm_echo dev provider (issue #24)
+Shipped `src/yaya/plugins/llm_echo/` so `yaya serve` round-trips the
+kernel end-to-end without any API key — closes the 0.1 onboarding gap
+exposed by the Playwright smoke (PR #74). The plugin filters
+`llm.call.request` on `provider == "echo"` and replies with
+`(echo) <last user message>` at zero token usage; sibling providers
+coexist on the same subscription via the same payload-filter pattern
+as `llm_openai`. Auto-selection lives in `strategy_react`:
+`_provider_and_model` now sniffs `OPENAI_API_KEY` and falls back to
+`("echo", "echo")` when the key is unset. Temporary env sniff with
+TODO(#23) — provider-selection policy migrates to `ctx.config` once
+the config-loading PR lands. Stdlib-only implementation; no LLM SDK.
+See: ../../specs/plugin-llm_echo.spec, ../../src/yaya/plugins/llm_echo/, ../../src/yaya/plugins/strategy_react/plugin.py
+
 ## [2026-04-18] ingest | pi-web-ui landing (issue #66)
 Replaced the 305-line vanilla-JS placeholder under
 `src/yaya/plugins/web/static/` with a Vite-built integration of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 strategy_react = "yaya.plugins.strategy_react:plugin"
 memory_sqlite = "yaya.plugins.memory_sqlite:plugin"
 llm_openai = "yaya.plugins.llm_openai:plugin"
+llm_echo = "yaya.plugins.llm_echo:plugin"
 tool_bash = "yaya.plugins.tool_bash:plugin"
 web = "yaya.plugins.web:plugin"
 

--- a/specs/plugin-llm_echo.spec
+++ b/specs/plugin-llm_echo.spec
@@ -1,0 +1,144 @@
+spec: task
+name: "plugin-llm_echo"
+tags: [plugin, llm-provider, dev]
+---
+
+## Intent
+
+The echo LLM-provider plugin is a deterministic, zero-config dev
+provider that lets a fresh `yaya serve` round-trip the kernel
+end-to-end without any API key. It subscribes to `llm.call.request`,
+filters by the `echo` provider id so sibling providers can coexist,
+and replies with `(echo) <last user message>` at zero token usage.
+
+The plugin closes the 0.1 onboarding gap (`GOAL.md` §Milestones 0.1):
+`pip install yaya && yaya serve` opens the browser, the user types
+"hello", and `(echo) hello` comes back through the full
+kernel→strategy→llm→assistant flow. Auto-selection is implemented
+in `strategy_react`: when no `OPENAI_API_KEY` is present, the
+strategy picks `provider == "echo"` (temporary env sniff; migrates
+to `ctx.config` in #23).
+
+## Decisions
+
+- Subscribes only to `llm.call.request`; handler returns silently
+  when `payload["provider"]` is not `"echo"` so other provider
+  plugins own their own traffic on the same subscription.
+- Response body is `f"(echo) {last_user_message}"` over the most
+  recent `role == "user"` content in `messages`. When no user
+  message is present (or its content is empty), the response is the
+  literal `(echo) (no input)`.
+- `usage` is hard-coded to `{"input_tokens": 0, "output_tokens": 0}`
+  — this is a dev provider, not a real LLM call.
+- `tool_calls` is always `[]`. The echo provider never asks for
+  tool execution.
+- Every emitted `llm.call.response` echoes `request_id` (per the
+  lessons-learned correlation rule) so the agent loop's
+  `_RequestTracker` correlates concurrent in-flight calls.
+- Stdlib only. No third-party AI agent frameworks (`AGENT.md` §4)
+  and no LLM SDK. `on_unload` is a no-op.
+- Strategy fallback (in `strategy_react`): when `OPENAI_API_KEY`
+  is unset, `_provider_and_model` returns `("echo", "echo")` so
+  the bundled echo plugin answers the request.
+
+## Boundaries
+
+### Allowed Changes
+- src/yaya/plugins/llm_echo/__init__.py
+- src/yaya/plugins/llm_echo/plugin.py
+- src/yaya/plugins/llm_echo/AGENT.md
+- src/yaya/plugins/strategy_react/plugin.py
+- tests/plugins/llm_echo/__init__.py
+- tests/plugins/llm_echo/test_echo.py
+- tests/plugins/strategy_react/test_strategy_react.py
+- tests/plugins/strategy_react/test_provider_selection.py
+- specs/plugin-llm_echo.spec
+- pyproject.toml
+- README.md
+- docs/wiki/log.md
+
+### Forbidden
+- src/yaya/kernel/
+- src/yaya/cli/
+- src/yaya/core/
+- src/yaya/plugins/llm_openai/
+- src/yaya/plugins/memory_sqlite/
+- src/yaya/plugins/tool_bash/
+- src/yaya/plugins/web/
+- docs/dev/plugin-protocol.md
+- GOAL.md
+
+## Completion Criteria
+
+Scenario: AC-01 echo round-trip emits response with text tool_calls usage and request_id
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_echo_response_for_user_message
+  Level: unit
+  Given an echo plugin loaded with no configuration
+  When a llm.call.request for provider echo with a user message hello is published
+  Then a llm.call.response event is emitted with text equal to (echo) hello and zero token usage
+  And the response echoes the originating request id
+
+Scenario: Error path — unrelated provider id leaves the event uncommented by llm-echo
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_non_matching_provider_is_ignored
+  Level: unit
+  Given an echo plugin loaded with no configuration
+  When a llm.call.request for a non-echo provider id is published
+  Then no llm.call.response event is emitted by the llm-echo plugin
+  And no llm.call.error event is emitted by the llm-echo plugin
+
+Scenario: Empty messages list returns the deterministic no-input marker
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_empty_messages_returns_no_input_marker
+  Level: unit
+  Given an echo plugin loaded with no configuration
+  When a llm.call.request for provider echo with an empty messages list is published
+  Then a llm.call.response event is emitted with text equal to (echo) (no input)
+
+Scenario: Multi-turn history echoes only the most recent user message
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_echoes_only_last_user_message
+  Level: unit
+  Given an echo plugin loaded with no configuration
+  When a llm.call.request for provider echo carries multiple user turns ending in second is published
+  Then a llm.call.response event is emitted with text equal to (echo) second
+
+Scenario: Response request_id matches the originating event id for loop correlation
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_request_id_matches_source_event
+  Level: unit
+  Given an echo plugin loaded with no configuration
+  When a llm.call.request for provider echo is published
+  Then the llm.call.response event request_id field equals the originating request event id
+
+Scenario: AC-AUTO strategy picks echo when no OPENAI_API_KEY is configured
+  Test:
+    Package: yaya
+    Filter: tests/plugins/strategy_react/test_provider_selection.py::test_picks_echo_when_no_api_key
+  Level: unit
+  Given the OPENAI_API_KEY environment variable is unset
+  When the ReAct strategy decides the next step for an empty conversation
+  Then the response next is llm and the chosen provider is echo
+
+Scenario: AC-AUTO strategy picks openai when OPENAI_API_KEY is set
+  Test:
+    Package: yaya
+    Filter: tests/plugins/strategy_react/test_provider_selection.py::test_picks_openai_when_api_key_set
+  Level: unit
+  Given the OPENAI_API_KEY environment variable is set to a placeholder
+  When the ReAct strategy decides the next step for an empty conversation
+  Then the response next is llm and the chosen provider is openai
+
+## Out of Scope
+
+- Streaming (`assistant.message.delta` chunks). Parity with
+  llm_openai today, which also emits one chunk.
+- Token-budget accounting; the echo provider always reports zero.
+- Configuration loading via `ctx.config` — replaced when #23 lands.
+- Tool-call generation. The echo provider never emits `tool_calls`.

--- a/src/yaya/plugins/llm_echo/AGENT.md
+++ b/src/yaya/plugins/llm_echo/AGENT.md
@@ -1,0 +1,23 @@
+## Philosophy
+Echo LLM-provider plugin — deterministic, zero-config, dev-only. Ships so a fresh `yaya serve` round-trips the kernel end-to-end without any API key. Closes the 0.1 onboarding gap (`GOAL.md` §Milestones 0.1).
+
+## External Reality
+- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row).
+- Contract: [`specs/plugin-llm_echo.spec`](../../../../specs/plugin-llm_echo.spec).
+- Tests: `tests/plugins/llm_echo/`.
+
+## Constraints
+- `Category.LLM_PROVIDER`. Subscribes only to `llm.call.request`; filters by `payload["provider"] == "echo"`.
+- Stdlib only. No third-party AI agent frameworks (`AGENT.md` §4); no LLM SDK.
+- Deterministic: `(echo) <last user message>` for non-empty user input, else the literal `(echo) (no input)`.
+- Every `llm.call.response` echoes `request_id` (lesson #15).
+- `on_unload` is a no-op — the plugin holds no resources.
+
+## Interaction (patterns)
+- Request filter: `ev.payload.get("provider") != "echo"` → return silently (sibling providers coexist).
+- Iterate `messages` in reverse to grab the most recent `role == "user"` `content` string.
+- Token usage hard-coded to `{"input_tokens": 0, "output_tokens": 0}` — this is a dev provider, not an LLM call.
+- Auto-selection lives in the strategy (see `strategy_react/plugin.py`): when `OPENAI_API_KEY` is unset, the strategy picks `provider == "echo"`. Temporary env sniff; migrates to `ctx.config` in #23.
+
+## Budget & Loading
+- Sibling: [`../AGENT.md`](../AGENT.md). Authoritative: [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md#llm-invocation-kernel--llm-provider).

--- a/src/yaya/plugins/llm_echo/__init__.py
+++ b/src/yaya/plugins/llm_echo/__init__.py
@@ -1,0 +1,15 @@
+"""Echo LLM-provider plugin (deterministic, zero-config, dev-only).
+
+Bundled plugin satisfying the ``llm-provider`` category for the
+``echo`` provider id. Subscribes to ``llm.call.request``, filters
+payloads where ``provider == "echo"``, and replies with a
+deterministic ``(echo) <last user message>`` body so users can
+verify the kernel end-to-end without any API key.
+"""
+
+from yaya.plugins.llm_echo.plugin import EchoLLM
+
+plugin: EchoLLM = EchoLLM()
+"""Entry-point target — referenced by ``yaya.plugins.v1`` in pyproject.toml."""
+
+__all__ = ["EchoLLM", "plugin"]

--- a/src/yaya/plugins/llm_echo/plugin.py
+++ b/src/yaya/plugins/llm_echo/plugin.py
@@ -1,0 +1,123 @@
+"""Echo LLM provider — deterministic, zero-config, dev-only.
+
+Every ``llm.call.request`` with ``provider == "echo"`` gets a
+response body prefixed with ``(echo) `` followed by the last user
+message in ``messages``. Token usage is reported as zero. The
+plugin is bundled so a fresh ``yaya serve`` round-trips the kernel
+without any API key — closes the 0.1 onboarding gap (see
+``GOAL.md`` §Milestones 0.1).
+
+Layering: imports only from ``yaya.kernel``. No third-party
+dependencies — stdlib only, per ``AGENT.md`` §4.
+
+Routing parity with the bundled ``llm_openai`` plugin: subscribes
+only to ``llm.call.request``; non-matching providers return
+silently so sibling LLM plugins coexist on the same subscription.
+Every emitted ``llm.call.response`` echoes ``request_id`` for the
+agent loop's ``_RequestTracker`` correlation (lesson #15 in
+``docs/wiki/lessons-learned.md``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, cast
+
+from yaya.kernel.events import Event
+from yaya.kernel.plugin import Category, KernelContext
+
+_NAME = "llm-echo"
+_VERSION = "0.1.0"
+_PROVIDER_ID = "echo"
+_NO_INPUT = "(echo) (no input)"
+
+
+class EchoLLM:
+    """Bundled echo LLM-provider plugin.
+
+    Attributes:
+        name: Plugin name (kebab-case).
+        version: Semver.
+        category: :class:`Category.LLM_PROVIDER`.
+        provider_id: The literal ``"echo"`` filter value matched on
+            ``ev.payload["provider"]``.
+    """
+
+    name: str = _NAME
+    version: str = _VERSION
+    category: Category = Category.LLM_PROVIDER
+    provider_id: str = _PROVIDER_ID
+    requires: ClassVar[list[str]] = []
+
+    def subscriptions(self) -> list[str]:
+        """Only ``llm.call.request`` — the single request kind for this category."""
+        return ["llm.call.request"]
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        """Log readiness. The echo provider needs no configuration."""
+        ctx.logger.info("llm-echo ready (no API key required)")
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        """Route ``llm.call.request`` for ``provider == "echo"``.
+
+        Non-matching providers are ignored so sibling LLM plugins
+        own their own traffic on the shared subscription.
+        """
+        if ev.kind != "llm.call.request":
+            return
+        if ev.payload.get("provider") != _PROVIDER_ID:
+            return
+
+        text = _build_echo(ev.payload)
+        await ctx.emit(
+            "llm.call.response",
+            {
+                "text": text,
+                "tool_calls": [],
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+                "request_id": ev.id,
+            },
+            session_id=ev.session_id,
+        )
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        """No-op — the echo provider holds no resources."""
+
+
+def _build_echo(payload: dict[str, Any]) -> str:
+    """Compose the echo response from a ``llm.call.request`` payload.
+
+    Pulls the most recent ``role == "user"`` message's ``content``
+    and prefixes it with ``"(echo) "``. When no user message is
+    present (or its content is empty) the response is the
+    deterministic placeholder defined in :data:`_NO_INPUT`.
+
+    Args:
+        payload: The ``llm.call.request`` payload dict.
+
+    Returns:
+        The plain-text response body to surface in
+        ``llm.call.response.text``.
+    """
+    raw_messages: Any = payload.get("messages") or []
+    if not isinstance(raw_messages, list):
+        return _NO_INPUT
+    last_user = ""
+    # ``raw_messages`` is ``Any`` from the dict; narrowing only filters
+    # the non-list branch and per-element ``isinstance`` is the only
+    # typing barrier in the loop.
+    for msg in reversed(raw_messages):  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
+        if not isinstance(msg, dict):
+            continue
+        msg_dict = cast("dict[str, Any]", msg)
+        if msg_dict.get("role") != "user":
+            continue
+        content = msg_dict.get("content")
+        if isinstance(content, str) and content:
+            last_user = content
+        break
+    if not last_user:
+        return _NO_INPUT
+    return f"(echo) {last_user}"
+
+
+__all__ = ["EchoLLM"]

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -9,6 +9,7 @@ turns remain deterministic.
 
 from __future__ import annotations
 
+import os
 from typing import Any, ClassVar, cast
 
 from yaya.kernel.events import Event
@@ -18,7 +19,11 @@ from yaya.kernel.plugin import Category, KernelContext
 # plumbs per-plugin config (the registry currently hands every plugin
 # an empty Mapping; see ``src/yaya/kernel/registry.py::_make_context``).
 _DEFAULT_PROVIDER = "openai"
+_FALLBACK_PROVIDER = "echo"
 _DEFAULT_MODEL = "gpt-4o-mini"
+# The bundled echo provider needs no model id — pick a stable
+# placeholder so the ``llm.call.request`` payload type-checks.
+_FALLBACK_MODEL = "echo"
 
 _NAME = "strategy-react"
 _VERSION = "0.1.0"
@@ -92,14 +97,34 @@ class ReActStrategy:
         """Return the effective ``(provider, model)`` pair.
 
         Reads ``ctx.config`` first (for when registry P3 plumbs config),
-        falling back to the seed defaults so current bundled boots keep
-        working without a config file.
+        then falls back to an env sniff so a fresh ``yaya serve`` with
+        no API key still round-trips through the bundled ``llm_echo``
+        dev provider. Resolution order:
+
+        1. ``ctx.config["provider"]`` / ``["model"]`` if non-empty strings.
+        2. ``OPENAI_API_KEY`` set → ``("openai", "gpt-4o-mini")``.
+        3. Otherwise → ``("echo", "echo")`` so the bundled echo
+           provider answers the request.
+
+        TODO(#23): replace the env sniff with ``ctx.config`` once the
+        config-loading PR lands. Strategy plugins must not own
+        provider-selection policy long-term.
         """
         cfg = ctx.config
         provider_raw = cfg.get("provider") if cfg else None
         model_raw = cfg.get("model") if cfg else None
-        provider = provider_raw if isinstance(provider_raw, str) and provider_raw else _DEFAULT_PROVIDER
-        model = model_raw if isinstance(model_raw, str) and model_raw else _DEFAULT_MODEL
+        if isinstance(provider_raw, str) and provider_raw:
+            provider = provider_raw
+        elif os.environ.get("OPENAI_API_KEY"):
+            provider = _DEFAULT_PROVIDER
+        else:
+            provider = _FALLBACK_PROVIDER
+        if isinstance(model_raw, str) and model_raw:
+            model = model_raw
+        elif provider == _FALLBACK_PROVIDER:
+            model = _FALLBACK_MODEL
+        else:
+            model = _DEFAULT_MODEL
         return provider, model
 
 

--- a/tests/plugins/llm_echo/test_echo.py
+++ b/tests/plugins/llm_echo/test_echo.py
@@ -1,0 +1,236 @@
+"""Tests for the echo LLM-provider plugin.
+
+AC-bindings from ``specs/plugin-llm_echo.spec``:
+
+* AC-01 echo round-trip → ``test_echo_response_for_user_message``
+* filter           → ``test_non_matching_provider_is_ignored``
+* empty-messages   → ``test_empty_messages_returns_no_input_marker``
+* multi-turn       → ``test_echoes_only_last_user_message``
+* request_id echo  → ``test_request_id_matches_source_event``
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.events import Event, new_event
+from yaya.kernel.plugin import KernelContext
+from yaya.plugins.llm_echo.plugin import EchoLLM
+
+
+def _make_ctx(bus: EventBus, tmp_path: Path, plugin: EchoLLM) -> KernelContext:
+    return KernelContext(
+        bus=bus,
+        logger=logging.getLogger("plugin.llm-echo"),
+        config={},
+        state_dir=tmp_path,
+        plugin_name=plugin.name,
+    )
+
+
+async def _drive(
+    tmp_path: Path,
+    payload: dict[str, object],
+    *,
+    response_kind: str = "llm.call.response",
+    error_kind: str = "llm.call.error",
+) -> tuple[Event, list[Event], list[Event]]:
+    """Publish one ``llm.call.request`` and return (request, responses, errors)."""
+    plugin = EchoLLM()
+    bus = EventBus()
+    ctx = _make_ctx(bus, tmp_path, plugin)
+    await plugin.on_load(ctx)
+
+    async def _handler(ev: Event) -> None:
+        await plugin.on_event(ev, ctx)
+
+    bus.subscribe("llm.call.request", _handler, source=plugin.name)
+
+    responses: list[Event] = []
+    errors: list[Event] = []
+
+    async def _r(ev: Event) -> None:
+        responses.append(ev)
+
+    async def _e(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe(response_kind, _r, source="observer")
+    bus.subscribe(error_kind, _e, source="observer")
+
+    req = new_event(
+        "llm.call.request",
+        payload,  # type: ignore[arg-type]
+        session_id="sess-echo",
+        source="kernel",
+    )
+    await bus.publish(req)
+    await plugin.on_unload(ctx)
+    return req, responses, errors
+
+
+async def test_echo_response_for_user_message(tmp_path: Path) -> None:
+    """AC-01: provider=echo + user message → ``(echo) <message>`` response."""
+    req, responses, errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [{"role": "user", "content": "hello"}],
+            "params": {},
+        },
+    )
+    assert errors == []
+    assert len(responses) == 1
+    payload = responses[0].payload
+    assert payload["text"] == "(echo) hello"
+    assert payload["tool_calls"] == []
+    assert payload["usage"] == {"input_tokens": 0, "output_tokens": 0}
+    assert payload["request_id"] == req.id
+
+
+async def test_non_matching_provider_is_ignored(tmp_path: Path) -> None:
+    """A request for a sibling provider does not emit any event from llm-echo."""
+    _req, responses, errors = await _drive(
+        tmp_path,
+        {
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "params": {},
+        },
+    )
+    assert responses == []
+    assert errors == []
+
+
+async def test_empty_messages_returns_no_input_marker(tmp_path: Path) -> None:
+    """No user message → deterministic ``(echo) (no input)`` placeholder."""
+    _req, responses, errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [],
+            "params": {},
+        },
+    )
+    assert errors == []
+    assert len(responses) == 1
+    assert responses[0].payload["text"] == "(echo) (no input)"
+
+
+async def test_echoes_only_last_user_message(tmp_path: Path) -> None:
+    """Multi-turn history → echoes the most recent user turn only."""
+    _req, responses, _errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "(echo) first"},
+                {"role": "user", "content": "second"},
+            ],
+            "params": {},
+        },
+    )
+    assert len(responses) == 1
+    assert responses[0].payload["text"] == "(echo) second"
+
+
+async def test_request_id_matches_source_event(tmp_path: Path) -> None:
+    """The response carries the originating request's id (lesson #15)."""
+    req, responses, _errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [{"role": "user", "content": "ping"}],
+            "params": {},
+        },
+    )
+    assert len(responses) == 1
+    assert responses[0].payload["request_id"] == req.id
+
+
+async def test_user_message_with_empty_content_returns_no_input(tmp_path: Path) -> None:
+    """A user turn with empty content collapses to the no-input marker."""
+    _req, responses, _errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [{"role": "user", "content": ""}],
+            "params": {},
+        },
+    )
+    assert len(responses) == 1
+    assert responses[0].payload["text"] == "(echo) (no input)"
+
+
+def test_subscriptions_returns_only_llm_call_request() -> None:
+    """The plugin advertises its single subscription kind."""
+    assert EchoLLM().subscriptions() == ["llm.call.request"]
+
+
+async def test_non_list_messages_returns_no_input(tmp_path: Path) -> None:
+    """Defensive: a non-list ``messages`` value is treated as empty."""
+    _req, responses, _errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": "not-a-list",  # malformed payload
+            "params": {},
+        },
+    )
+    assert len(responses) == 1
+    assert responses[0].payload["text"] == "(echo) (no input)"
+
+
+async def test_skips_non_dict_and_non_user_messages(tmp_path: Path) -> None:
+    """Defensive: non-dict entries and non-user roles are skipped during scan."""
+    _req, responses, _errors = await _drive(
+        tmp_path,
+        {
+            "provider": "echo",
+            "model": "echo",
+            "messages": [
+                {"role": "system", "content": "ignored"},
+                {"role": "user", "content": "real"},
+                {"role": "assistant", "content": "later"},
+                "garbage-entry",  # non-dict, last → exercises the skip branch
+            ],
+            "params": {},
+        },
+    )
+    assert len(responses) == 1
+    assert responses[0].payload["text"] == "(echo) real"
+
+
+async def test_non_request_event_kind_is_ignored(tmp_path: Path) -> None:
+    """on_event must early-return on unrelated kinds (defence-in-depth)."""
+    plugin = EchoLLM()
+    bus = EventBus()
+    ctx = _make_ctx(bus, tmp_path, plugin)
+    await plugin.on_load(ctx)
+
+    captured: list[Event] = []
+
+    async def _r(ev: Event) -> None:
+        captured.append(ev)
+
+    bus.subscribe("llm.call.response", _r, source="observer")
+
+    other = new_event(
+        "llm.call.response",
+        {"text": "x", "tool_calls": [], "usage": {}},
+        session_id="sess-other",
+        source="kernel",
+    )
+    await plugin.on_event(other, ctx)
+    assert captured == []
+    await plugin.on_unload(ctx)

--- a/tests/plugins/strategy_react/test_provider_selection.py
+++ b/tests/plugins/strategy_react/test_provider_selection.py
@@ -1,0 +1,82 @@
+"""Tests for the strategy_react env-driven provider fallback.
+
+AC-binding from ``specs/plugin-llm_echo.spec`` (`@AC-AUTO`):
+
+* no key → echo  → ``test_picks_echo_when_no_api_key``
+* key set → openai → ``test_picks_openai_when_api_key_set``
+
+The fallback is a temporary env sniff that lives inside
+``ReActStrategy._provider_and_model``; once #23 lands the
+config-loading layer, the policy moves to ``ctx.config`` and these
+tests migrate with it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.events import Event, new_event
+from yaya.kernel.plugin import KernelContext
+from yaya.plugins.strategy_react import plugin as react_plugin
+
+
+def _make_ctx(bus: EventBus, tmp_path: Path) -> KernelContext:
+    return KernelContext(
+        bus=bus,
+        logger=logging.getLogger("plugin.strategy-react"),
+        config={},
+        state_dir=tmp_path,
+        plugin_name=react_plugin.name,
+    )
+
+
+async def _drive_first_turn(tmp_path: Path) -> Event:
+    """Publish a first-turn ``strategy.decide.request`` and return the response."""
+    bus = EventBus()
+    ctx = _make_ctx(bus, tmp_path)
+    await react_plugin.on_load(ctx)
+
+    async def _handler(ev: Event) -> None:
+        await react_plugin.on_event(ev, ctx)
+
+    bus.subscribe("strategy.decide.request", _handler, source=react_plugin.name)
+    captured: list[Event] = []
+
+    async def _observer(ev: Event) -> None:
+        captured.append(ev)
+
+    bus.subscribe("strategy.decide.response", _observer, source="observer")
+
+    req = new_event(
+        "strategy.decide.request",
+        {"state": {"messages": [{"role": "user", "content": "hi"}]}},
+        session_id="sess-provider",
+        source="kernel",
+    )
+    await bus.publish(req)
+    assert len(captured) == 1
+    return captured[0]
+
+
+async def test_picks_echo_when_no_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``OPENAI_API_KEY`` → strategy falls back to the echo dev provider."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    response = await _drive_first_turn(tmp_path)
+    payload = response.payload
+    assert payload["next"] == "llm"
+    assert payload["provider"] == "echo"
+    assert payload["model"] == "echo"
+
+
+async def test_picks_openai_when_api_key_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OPENAI_API_KEY`` present → strategy picks the openai provider."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = await _drive_first_turn(tmp_path)
+    payload = response.payload
+    assert payload["next"] == "llm"
+    assert payload["provider"] == "openai"
+    assert payload["model"] == "gpt-4o-mini"

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -67,8 +67,14 @@ async def _drive(
     return captured
 
 
-async def test_no_assistant_yet_returns_llm(tmp_path: Path) -> None:
-    """No assistant message → llm with provider + model + request_id."""
+async def test_no_assistant_yet_returns_llm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No assistant message → llm with provider + model + request_id.
+
+    Pins ``OPENAI_API_KEY`` so the strategy's env-sniff fallback (see
+    ``_provider_and_model``) resolves to the configured ``openai``
+    branch rather than the ``echo`` dev fallback.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     bus = EventBus()
     captured = await _drive(
         bus,


### PR DESCRIPTION
## Summary

Bundles a deterministic echo LLM provider so \`yaya serve\` works end-
to-end without any API key. Closes the 0.1 onboarding gap that PR
#74's Playwright test exposed: the default state (no key) is now
usable — \`(echo) <your message>\` comes back.

## Type of change
| Type | Label |
|------|-------|
| New feature | \`enhancement\` |

## Component
\`core\`

## Closes
Closes #24

## Key decisions
- Echo plugin filters on \`payload["provider"] == "echo"\` — same ABI as
  llm_openai, same subscription pattern. Stdlib only.
- strategy_react picks \`"echo"\` when \`OPENAI_API_KEY\` is absent.
  Temporary env sniff; migrates to \`ctx.config\` in #23.
- No streaming yet — emits one chunk. Parity with llm_openai today
  (which also emits one chunk). Streaming is a separate concern (#26).

## Test plan
- [x] Python tests green; echo round-trip asserted (259 passed)
- [x] Live smoke with raw WS: assistant.done.content == \"(echo) hello\"
- [x] strategy_react picks echo/openai correctly by env
- [x] agent-spec lifecycle: plugin-llm_echo.spec status=OK
- [x] Plugin coverage 100%
- [ ] CI green (watching)

## Follow-ups
- ctx.config dispatch in #23 replaces the env sniff.
- Streaming deltas (#26) for parity with real providers.