### PR TITLE
test(e2e): yaya serve → WebSocket → assistant.done round-trip (#25)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,5 +167,5 @@ jobs:
           # shellcheck disable=SC1091
           if [ -f .smoke-venv/bin/activate ]; then . .smoke-venv/bin/activate; else . .smoke-venv/Scripts/activate; fi
           python -m pip install --upgrade pip
-          python -m pip install dist/*.whl pytest pytest-timeout pytest-bdd
+          python -m pip install dist/*.whl pytest pytest-timeout pytest-bdd pytest-asyncio websockets
           python -m pytest tests/e2e -v

--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ test-e2e:
     python3.14 -m venv .smoke-venv
     . .smoke-venv/bin/activate
     python -m pip install --upgrade pip >/dev/null
-    python -m pip install "$wheel" pytest pytest-timeout pytest-bdd >/dev/null
+    python -m pip install "$wheel" pytest pytest-timeout pytest-bdd pytest-asyncio websockets >/dev/null
     python -m pytest tests/e2e -v
 
 # Remove build artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pytest-bdd>=8.0",
     "hypothesis>=6.115.0",
     "syrupy>=4.7.0",
+    "websockets>=13.0",
 ]
 docs = [
     "mkdocs>=1.6.0",

--- a/specs/e2e-serve-roundtrip.spec
+++ b/specs/e2e-serve-roundtrip.spec
@@ -1,0 +1,107 @@
+spec: task
+name: "e2e-serve-roundtrip"
+tags: [e2e, kernel, plugins, web, llm-provider]
+---
+
+## Intent
+
+End-to-end integration test that asserts the 0.1 milestone's
+definition of done — kernel + registry + agent loop + strategy_react
++ llm_echo + memory_sqlite + web adapter all hang together as one
+process. The proof is a single round-trip:
+
+1. Spawn ``yaya --json serve --port 0 --no-open`` in a child process.
+2. Read the ephemeral port from the ``serve.started`` JSON event.
+3. Open a real WebSocket client against ``ws://127.0.0.1:<port>/ws``.
+4. Send a ``user.message`` frame.
+5. Assert an ``assistant.done`` frame arrives within 5 s and its
+   ``content`` starts with ``(echo)`` (proves the bundled echo
+   provider drove the turn — there is no API key in the env).
+6. Send the platform-correct shutdown signal and assert clean
+   stderr (no traceback, no "unhandled").
+
+This is the test the 0.1 tracking epic closes on. It runs out of
+``tests/e2e/`` against an installed wheel — the same path CI's
+``E2E smoke`` job exercises on Linux, macOS, and Windows.
+
+## Decisions
+
+- Test file: ``tests/e2e/test_serve_roundtrip.py``.
+- Marker: ``pytest.mark.integration`` (already registered in
+  ``pyproject.toml``).
+- Ephemeral port discovery: parse the ``addr`` field of the
+  ``serve.started`` JSON event emitted on stdout. The port is the
+  segment after the final ``:`` in ``"127.0.0.1:<port>"``.
+- ``OPENAI_API_KEY`` is removed from the child env so
+  :mod:`yaya.plugins.strategy_react` selects the echo provider per
+  the AC-AUTO scenario in ``specs/plugin-llm_echo.spec``.
+- Shutdown signal: ``SIGINT`` on POSIX,
+  ``signal.CTRL_BREAK_EVENT`` on Windows (combined with
+  ``CREATE_NEW_PROCESS_GROUP`` at spawn). Lesson #48: ``SIGINT``
+  to a Windows child raises ``KeyboardInterrupt`` in the parent,
+  not the child.
+- Fixture teardown drains stdout/stderr **after** ``proc.wait`` to
+  avoid the OS-pipe deadlock that hits when the buffer fills mid-
+  test (lesson #11).
+- Stderr "no exception" assertion uses regex
+  (``^Traceback \(most recent call last\):`` and ``\bunhandled\b``)
+  rather than substring — substring matches are too noisy against
+  loguru's free-form WARNING lines.
+- Adds ``websockets>=13.0`` to the dev dependency group; the wheel
+  already pulls it transitively via ``uvicorn[standard]`` for runtime
+  use, but the dev pin makes the test's import explicit.
+- ``just test-e2e`` runs the full e2e suite (the existing recipe
+  already builds the wheel into ``.smoke-venv``); the recipe also
+  installs ``websockets`` so the fresh venv has it.
+- The CI ``E2E smoke`` job in ``.github/workflows/main.yml`` already
+  runs ``pytest tests/e2e -v``; adds ``websockets`` to the
+  ``pip install`` line so this new test imports succeed on all three
+  OSes.
+
+## Boundaries
+
+### Allowed Changes
+- tests/e2e/test_serve_roundtrip.py
+- specs/e2e-serve-roundtrip.spec
+- pyproject.toml
+- uv.lock
+- justfile
+- .github/workflows/main.yml
+
+### Forbidden
+- src/yaya/kernel/
+- src/yaya/cli/
+- src/yaya/core/
+- src/yaya/plugins/
+- GOAL.md
+- AGENT.md
+- docs/dev/plugin-protocol.md
+
+## Completion Criteria
+
+Scenario: AC-01 echo round-trip lands an assistant done frame within five seconds
+  Test:
+    Package: yaya
+    Filter: tests/e2e/test_serve_roundtrip.py::test_serve_roundtrip_echo
+  Level: e2e
+  Given yaya serve is running as a subprocess on an ephemeral port with OPENAI_API_KEY unset
+  When the test opens a WebSocket to /ws and sends a user.message with text hi
+  Then an assistant.done frame arrives within five seconds and its content starts with (echo)
+
+Scenario: AC-02 the kernel exits cleanly on SIGINT with no traceback on stderr
+  Test:
+    Package: yaya
+    Filter: tests/e2e/test_serve_roundtrip.py::test_no_stray_exceptions
+  Level: e2e
+  Given yaya serve is running as a subprocess
+  When the test sends the platform shutdown signal and the process exits
+  Then the captured stderr contains no Traceback header and no token unhandled
+
+## Out of Scope
+
+- Tool-use roundtrip (``tool_bash`` invocation through the loop).
+- Memory persistence across kernel restarts.
+- Multi-turn conversation state.
+- Streaming ``assistant.delta`` chunks — the echo provider emits a
+  single ``assistant.done`` directly.
+- Browser-side rendering — covered by the web adapter's vitest suite.

--- a/tests/e2e/test_serve_roundtrip.py
+++ b/tests/e2e/test_serve_roundtrip.py
@@ -1,0 +1,289 @@
+"""E2E: ``yaya serve`` -> ``/ws`` -> ``user.message`` -> ``assistant.done``.
+
+Spawns ``yaya --json serve --port 0 --no-open`` in a subprocess, parses
+the ``serve.started`` JSON event for the bound port (the kernel reports
+``addr = "127.0.0.1:<port>"``), opens a real websocket client to the
+web adapter's ``/ws`` endpoint, sends a ``user.message`` frame, and
+asserts the resulting ``assistant.done`` body starts with ``(echo)``
+(proving the bundled echo provider drove the turn).
+
+Hard requirements:
+
+* ``OPENAI_API_KEY`` is removed from the child env so
+  :mod:`yaya.plugins.strategy_react` picks the echo provider (see
+  ``specs/plugin-llm_echo.spec`` AC-AUTO).
+* The fixture is responsible for clean teardown — SIGINT on POSIX,
+  ``terminate()`` on Windows where ``signal.SIGINT`` to a child does
+  not unwind the asyncio loop the same way (lesson #48).
+* After the round-trip, the test asserts no traceback / "unhandled"
+  marker landed on stderr (AC-02). The assertion is gated on a regex
+  rather than substring to tolerate unrelated logger output that
+  happens to contain the word as a fragment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+from websockets.asyncio.client import connect
+
+pytestmark = [pytest.mark.integration]
+
+_STARTUP_TIMEOUT_S = 15.0
+"""Upper bound for ``serve.started`` to land. CI cold-starts can be slow."""
+
+_ROUNDTRIP_TIMEOUT_S = 5.0
+"""AC-01 budget — the echo provider answers in microseconds locally."""
+
+_SHUTDOWN_TIMEOUT_S = 8.0
+"""Upper bound for the kernel to drain after the shutdown signal."""
+
+_TRACEBACK_RE = re.compile(r"^Traceback \(most recent call last\):", re.MULTILINE)
+"""Match a real traceback header — substring 'Traceback' alone is too noisy."""
+
+_UNHANDLED_RE = re.compile(r"\bunhandled\b", re.IGNORECASE)
+"""Match the word 'unhandled' as a token, not embedded in another word."""
+
+
+def _wait_for_listen(host: str, port: int, *, deadline: float, proc: subprocess.Popen[str]) -> None:
+    """Block until ``host:port`` accepts a TCP connection or the deadline elapses.
+
+    The web adapter binds asynchronously inside ``on_load``; the kernel
+    can emit ``serve.started`` before uvicorn has finished its bind.
+    Polling with a short connect attempt is the empirical probe — see
+    ``docs/wiki/lessons-learned.md`` #11.
+    """
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"yaya serve exited (code={proc.returncode}) before binding {host}:{port}")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.25)
+            try:
+                sock.connect((host, port))
+            except OSError:
+                time.sleep(0.05)
+                continue
+            return
+    proc.kill()
+    raise TimeoutError(f"web adapter did not start listening on {host}:{port} before deadline")
+
+
+def _pick_free_port() -> int:
+    """Ask the OS for a free TCP port on loopback.
+
+    Racy by design (the OS may hand the port out again before the web
+    adapter binds it), but acceptable for a local test — the test will
+    fail loudly with ``ConnectionRefusedError`` if the race materialises.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _spawn_serve(yaya_bin: str) -> tuple[subprocess.Popen[str], int, list[str]]:
+    """Spawn ``yaya serve`` and wait for the ``serve.started`` event.
+
+    Returns a triple of ``(process, bound_port, startup_lines)`` where
+    ``startup_lines`` is every stdout line consumed during startup
+    (kept so a debugging post-mortem can reconstruct the boot log
+    without re-reading the pipe).
+
+    Raises:
+        RuntimeError: The subprocess exited before emitting
+            ``serve.started`` — typically a startup failure.
+        TimeoutError: ``serve.started`` did not arrive within
+            ``_STARTUP_TIMEOUT_S``.
+    """
+    env = {**os.environ, "NO_COLOR": "1", "YAYA_NO_AUTO_UPDATE": "1"}
+    env.pop("OPENAI_API_KEY", None)  # force the echo provider
+    # The kernel's serve.started addr is the kernel port, NOT the web
+    # adapter port — those are independent (see serve.py docstring and
+    # the YAYA_WEB_PORT note). Pin the adapter port via the documented
+    # env knob so the test knows where to connect.
+    web_port = _pick_free_port()
+    env["YAYA_WEB_PORT"] = str(web_port)
+
+    # creationflags only exists on Windows; Popen rejects unknown kw on
+    # POSIX, so branch the kwargs here. CREATE_NEW_PROCESS_GROUP lets
+    # us send CTRL_BREAK_EVENT during teardown — SIGINT to a child on
+    # Windows raises in the parent, not the child.
+    extra_kwargs: dict[str, object] = {}
+    if sys.platform == "win32":
+        extra_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    proc = subprocess.Popen(
+        [yaya_bin, "--json", "serve", "--port", "0", "--no-open"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        **extra_kwargs,  # type: ignore[arg-type]
+    )
+
+    assert proc.stdout is not None, "Popen with PIPE must expose stdout"
+    assert proc.stderr is not None, "Popen with PIPE must expose stderr"
+
+    # rich.Console.print_json pretty-prints with indent=2 — every JSON
+    # object spans multiple lines. Accumulate stdout into a buffer and
+    # use json.JSONDecoder.raw_decode to peel off complete top-level
+    # objects as they arrive. Whitespace between objects is skipped.
+    decoder = json.JSONDecoder()
+    buf = ""
+    startup_lines: list[str] = []
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        chunk = proc.stdout.readline()
+        if not chunk:
+            if proc.poll() is not None:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"yaya serve exited early (code={proc.returncode})\n"
+                    f"stdout so far:\n{''.join(startup_lines)}\n"
+                    f"stderr:\n{stderr}",
+                )
+            time.sleep(0.02)
+            continue
+        startup_lines.append(chunk)
+        buf += chunk
+        # Drain every complete JSON object currently in the buffer.
+        while True:
+            stripped = buf.lstrip()
+            if not stripped:
+                buf = ""
+                break
+            try:
+                obj, end = decoder.raw_decode(stripped)
+            except json.JSONDecodeError:
+                # Incomplete object — wait for the next chunk. Keep
+                # the leading whitespace stripped to avoid quadratic
+                # buf growth.
+                buf = stripped
+                break
+            buf = stripped[end:]
+            if isinstance(obj, dict) and obj.get("action") == "serve.started":
+                # Sanity-check the kernel addr — but the WS lives on
+                # YAYA_WEB_PORT (the adapter), not the kernel port.
+                addr = obj.get("addr")
+                if not isinstance(addr, str) or ":" not in addr:
+                    proc.kill()
+                    raise RuntimeError(f"serve.started missing addr: {obj!r}")
+                # Wait for the web adapter to actually accept TCP on
+                # its port before returning — uvicorn starts in the
+                # background and may not be listening yet when the
+                # kernel emits serve.started.
+                _wait_for_listen("127.0.0.1", web_port, deadline=deadline, proc=proc)
+                return proc, web_port, startup_lines
+
+    proc.kill()
+    raise TimeoutError(
+        f"yaya serve did not emit serve.started within {_STARTUP_TIMEOUT_S}s\n"
+        f"stdout collected:\n{''.join(startup_lines)}",
+    )
+
+
+def _shutdown(proc: subprocess.Popen[str]) -> None:
+    """Send the platform-correct shutdown signal and wait for exit.
+
+    POSIX: ``SIGINT`` is what an interactive ``Ctrl+C`` produces; the
+    kernel registers a signal handler for it via
+    :meth:`asyncio.AbstractEventLoop.add_signal_handler`.
+
+    Windows: ``signal.SIGINT`` to ``Popen.send_signal`` raises a
+    :class:`KeyboardInterrupt` in the *parent* process, not the child.
+    ``CTRL_BREAK_EVENT`` is the only signal a child created in a new
+    process group will receive — combined with
+    ``CREATE_NEW_PROCESS_GROUP`` from spawn (lesson #48).
+    """
+    if proc.poll() is not None:
+        return
+    if sys.platform == "win32":
+        proc.send_signal(signal.CTRL_BREAK_EVENT)
+    else:
+        proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(timeout=_SHUTDOWN_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=2)
+
+
+@pytest.fixture
+def serve_process(yaya_bin: str) -> Iterator[tuple[subprocess.Popen[str], int, dict[str, str]]]:
+    """Spawn ``yaya serve``; yield ``(proc, port, captured)``.
+
+    ``captured`` is mutated by the teardown to expose the post-shutdown
+    stdout / stderr to tests that need to assert on them. Tests must
+    NOT read ``proc.stderr`` themselves before teardown — the pipe
+    would deadlock if the buffer fills.
+    """
+    proc, port, _startup = _spawn_serve(yaya_bin)
+    captured: dict[str, str] = {"stdout": "", "stderr": ""}
+    try:
+        yield proc, port, captured
+    finally:
+        _shutdown(proc)
+        # Drain pipes after exit; safe now that the child is gone.
+        # Defensive contextlib.suppress around the read in case the
+        # pipes were already closed by the test body.
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            captured["stdout"] = proc.stdout.read() or ""
+            captured["stderr"] = proc.stderr.read() or ""
+
+
+@pytest.mark.asyncio
+async def test_serve_roundtrip_echo(
+    serve_process: tuple[subprocess.Popen[str], int, dict[str, str]],
+) -> None:
+    """AC-01 — full round-trip via the echo provider lands an ``assistant.done``."""
+    _proc, port, _captured = serve_process
+    url = f"ws://127.0.0.1:{port}/ws"
+
+    async def drive() -> dict[str, object]:
+        async with connect(url) as ws:
+            await ws.send(json.dumps({"type": "user.message", "text": "hi"}))
+            async with asyncio.timeout(_ROUNDTRIP_TIMEOUT_S):
+                while True:
+                    raw = await ws.recv()
+                    frame = json.loads(raw)
+                    if isinstance(frame, dict) and frame.get("type") == "assistant.done":
+                        return frame
+
+    frame = await drive()
+    content = frame.get("content")
+    assert isinstance(content, str), f"assistant.done.content not a string: {frame!r}"
+    assert content.startswith("(echo)"), f"echo provider did not drive the turn: {frame!r}"
+
+
+def test_no_stray_exceptions(
+    serve_process: tuple[subprocess.Popen[str], int, dict[str, str]],
+) -> None:
+    """AC-02 — clean stderr after shutdown; no tracebacks, no 'unhandled'."""
+    proc, _port, captured = serve_process
+    # Trigger shutdown inside the test so the captured dict is populated
+    # before our assertions run. The fixture's teardown is a no-op once
+    # the process has already exited.
+    _shutdown(proc)
+    # Drain pipes here too — the fixture finalizer will run after this
+    # function returns, but the assertions need the bytes NOW.
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    captured["stdout"] = proc.stdout.read() or ""
+    captured["stderr"] = proc.stderr.read() or ""
+
+    stderr = captured["stderr"]
+    assert not _TRACEBACK_RE.search(stderr), f"stderr contains a traceback:\n{stderr}"
+    assert not _UNHANDLED_RE.search(stderr), f"stderr mentions 'unhandled':\n{stderr}"

--- a/uv.lock
+++ b/uv.lock
@@ -1484,6 +1484,7 @@ dev = [
     { name = "ruff" },
     { name = "syrupy" },
     { name = "tox-uv" },
+    { name = "websockets" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1521,6 +1522,7 @@ dev = [
     { name = "ruff", specifier = ">=0.7.0" },
     { name = "syrupy", specifier = ">=4.7.0" },
     { name = "tox-uv", specifier = ">=1.16.0" },
+    { name = "websockets", specifier = ">=13.0" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0" },


### PR DESCRIPTION
## Summary

End-to-end integration test for the 0.1 milestone — the test the
tracking epic closes on. Spawns `yaya serve`, pins the web adapter
to a free port via `YAYA_WEB_PORT`, drives the kernel through a real
websocket, asserts the bundled `llm_echo` provider lands an
`assistant.done` frame whose `content` starts with `(echo)`. Second
scenario asserts clean stderr (no traceback, no `unhandled` token)
after the platform-correct shutdown signal.

## What

- `tests/e2e/test_serve_roundtrip.py` — AC-01 round-trip + AC-02 clean
  shutdown.
- `specs/e2e-serve-roundtrip.spec` — both ACs bound to the tests above.
- `pyproject.toml` + `uv.lock` — pin `websockets>=13.0` in the dev
  group (the runtime already pulls it via `uvicorn[standard]`; the
  pin makes the test's import explicit).
- `justfile` `test-e2e` recipe — install `websockets` + `pytest-asyncio`
  into the fresh smoke venv.
- `.github/workflows/main.yml` `e2e-smoke` job — same dependency
  additions on all three OS legs.

## Type of change
| Type | Label |
|------|-------|
| Tests | `enhancement` |

## Closes
Closes #25

## Test plan
- [x] `uv run python -m pytest tests/e2e -m integration` green on macOS
- [x] `uv run mypy --strict` + `uv run ruff check` + `uv run pyright` clean
- [x] `bash scripts/check_specs.sh` green (new spec lints OK)
- [ ] CI green on all three OS legs (Windows is the risk — uses
      `CTRL_BREAK_EVENT` + `CREATE_NEW_PROCESS_GROUP` per lesson #48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)