### PR TITLE
ci: enforce no-agent-frameworks ban via a dependency scanner (#33)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/check_specs.sh
       - name: Verify .feature / .spec sync
         run: uv run python scripts/check_feature_sync.py
+      - name: No banned agent frameworks (AGENT.md §4)
+        run: uv run python scripts/check_banned_frameworks.py
 
   tests:
     name: Tests (${{ matrix.os }}, py${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,18 @@ repos:
     hooks:
       - id: uv-lock
 
+  # No third-party agent frameworks (AGENT.md §4). Runs whenever a
+  # dependency declaration or a Python source file changes — the script
+  # is stdlib-only, completes in <1s on this repo.
+  - repo: local
+    hooks:
+      - id: check-banned-frameworks
+        name: No banned agent frameworks
+        entry: uv run python scripts/check_banned_frameworks.py
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|src/.*\.py|tests/.*\.py)$
+
   # agent-spec enforcement. Runs only when a `.spec` file is staged.
   # Script runs lifecycle (lint hard-gated, boundary/verify reported).
   # If `agent-spec` is not installed locally, the wrapper prints a skip

--- a/docs/dev/no-agent-frameworks.md
+++ b/docs/dev/no-agent-frameworks.md
@@ -93,3 +93,48 @@ issue before writing the import.
 - `vendor/` contains reference repos (e.g. `bub/`, `kimi-cli/`) — they
   are NEVER imported at runtime; `src/yaya/` must not reference
   anything under `vendor/`.
+
+### Mechanical enforcement
+
+`scripts/check_banned_frameworks.py` is the grep-enforced layer for
+this rule. It runs in two places:
+
+- **Pre-commit hook** — fires on changes to `pyproject.toml` or any
+  `src/**.py` / `tests/**.py` file.
+- **CI** — runs as a step in the `Lint & type check` job in
+  `.github/workflows/main.yml`.
+
+The script is stdlib-only (no dep on any framework to check
+frameworks) and scans two surfaces:
+
+1. Declared dependencies in `pyproject.toml` — `[project]
+   dependencies`, every `[dependency-groups]` table, and every
+   `[project.optional-dependencies]` extra. Names are normalized per
+   the [PyPA name normalization spec](https://packaging.python.org/en/latest/specifications/name-normalization/)
+   before comparison, so `Lang_Chain`, `LangChain`, and `langchain`
+   all collide.
+2. AST-walked `import` / `from … import …` statements under `src/`
+   and `tests/`. AST is used (not regex) so string mentions of a
+   banned name in a docstring or comment are NOT false positives.
+
+The ban list is hardcoded in the script and must stay in sync with
+AGENT.md §4 — a PR that edits one MUST edit the other.
+
+#### Known limitations
+
+- **Dynamic imports** via `importlib.import_module("langchain")` are
+  not caught — AST cannot see strings. The ban is policy enforcement,
+  not a hermetic sandbox. If a known offender shows up, add a runtime
+  guard.
+- **Transitive dependencies** (a permitted package that itself pulls
+  in a banned one through `uv.lock`) are not scanned today. The
+  declared-dep gate catches the common case; transitive coverage is
+  tracked for a follow-up.
+
+#### Carve-outs
+
+None today. If a legitimately-needed package collides with a banned
+name (e.g. an internal tool whose distribution name happens to start
+with `smol-`), document the carveout here AND skip-list it
+explicitly in the script's `BANNED_PACKAGES` set with a comment
+linking to the justifying issue.

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -101,6 +101,24 @@ TODO(#23) — provider-selection policy migrates to `ctx.config` once
 the config-loading PR lands. Stdlib-only implementation; no LLM SDK.
 See: ../../specs/plugin-llm_echo.spec, ../../src/yaya/plugins/llm_echo/, ../../src/yaya/plugins/strategy_react/plugin.py
 
+## [2026-04-18] ingest | banned-framework scanner (issue #33)
+Operationalized AGENT.md §4 — the "no third-party agent frameworks"
+rule was previously honor-system. Landed `scripts/check_banned_frameworks.py`,
+a stdlib-only Python scanner that checks two surfaces: declared
+dependencies in `pyproject.toml` (`[project] dependencies`,
+`[dependency-groups]`, `[project.optional-dependencies]`) and AST-walked
+imports under `src/` + `tests/`. Names are normalized per PyPA before
+comparison so case + separator variants collide. Wired into pre-commit
+(fires on `pyproject.toml` or `**/*.py` changes) and the `Lint & type
+check` CI job. AST scan deliberately avoids regex so docstring / comment
+mentions of a banned name don't false-positive (lesson 27 — Dependency
+Rule classification is per-export, not per-library; this script is the
+mechanical layer of the same idea applied to top-level distributions).
+Known limitation: dynamic `importlib.import_module(...)` calls are not
+caught (policy enforcement, not hermetic sandbox); transitive `uv.lock`
+deps are deferred.
+See: ../../scripts/check_banned_frameworks.py, ../dev/no-agent-frameworks.md
+
 ## [2026-04-18] ingest | pi-web-ui landing (issue #66)
 Replaced the 305-line vanilla-JS placeholder under
 `src/yaya/plugins/web/static/` with a Vite-built integration of

--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -11,6 +11,7 @@ Release-time and CI helper scripts. Not imported by the package.
 
 ## Constraints
 - `check_version_tag.py` — verifies the git tag matches `pyproject.toml` version at release time.
+- `check_banned_frameworks.py` — enforces AGENT.md §4 (no third-party agent frameworks). Scans `pyproject.toml` declared deps and AST imports under `src/` + `tests/` against a hardcoded ban list. Stdlib only. Takes `--json` for CI integration. Wired into pre-commit + the `Lint & type check` CI job.
 - Scripts are **standalone**: runnable with `python scripts/<name>.py` using only stdlib (or clearly documented deps available in the CI environment).
 - No imports from `yaya.*` unless strictly required — scripts may run before install in CI.
 - Every script has a module-level docstring stating: what it does, when it runs, exit-code semantics.

--- a/scripts/check_banned_frameworks.py
+++ b/scripts/check_banned_frameworks.py
@@ -1,0 +1,395 @@
+"""Mechanical enforcement of AGENT.md §4 — no third-party agent frameworks.
+
+What this does
+--------------
+Scans two surfaces and exits non-zero if it finds any hit:
+
+1. Declared dependencies in ``pyproject.toml`` — ``[project] dependencies``,
+   every ``[dependency-groups]`` table, and ``[project.optional-dependencies]``.
+2. Source ``import`` statements under ``src/`` and ``tests/`` (AST-based,
+   not regex — won't false-positive on strings or comments).
+
+Why this exists
+---------------
+AGENT.md §4 bans LangChain / LangGraph / LlamaIndex / AutoGen / CrewAI /
+DSPy / etc. Until this script existed, that rule was honor-system. Now
+it is grep-enforced via pre-commit + CI.
+
+When it runs
+------------
+- Pre-commit hook: every commit that touches ``pyproject.toml`` or any
+  ``src/**.py`` / ``tests/**.py`` file.
+- CI: the ``check`` job in ``.github/workflows/main.yml``.
+- Locally: ``uv run python scripts/check_banned_frameworks.py``.
+
+Exit codes
+----------
+- 0 — pass, no banned packages or imports found.
+- 1 — fail, at least one violation reported.
+- 2 — script / config error (e.g. cannot parse ``pyproject.toml``).
+
+Known limitations
+-----------------
+- Dynamic imports via ``importlib.import_module("langchain")`` are NOT
+  caught — AST cannot see strings. The ban is policy enforcement, not a
+  hermetic sandbox. Add a runtime check if a known offender shows up.
+- Transitive dependencies (banned package pulled in by a permitted
+  package) are NOT scanned here — see issue #33 for the future
+  ``uv.lock`` integration once the script's blast radius is well
+  understood.
+
+stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+import tomllib
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Source of truth: AGENT.md §4. Any drift here MUST be matched in
+# AGENT.md and docs/dev/no-agent-frameworks.md in the same PR.
+BANNED_PACKAGES: frozenset[str] = frozenset({
+    # LangChain family.
+    "langchain",
+    "langchain-core",
+    "langchain-community",
+    "langchain-openai",
+    "langchain-anthropic",
+    "langgraph",
+    "langsmith",
+    "langserve",
+    # Index / RAG frameworks.
+    "llamaindex",
+    "llama-index",
+    "llama-index-core",
+    "llama-parse",
+    "haystack",
+    "farm-haystack",
+    "haystack-ai",
+    # Multi-agent frameworks.
+    "autogen",
+    "pyautogen",
+    "autogenstudio",
+    "ag2",
+    "crewai",
+    "crewai-tools",
+    "semantic-kernel",
+    # Prompting / structured-output libraries marketed as agent frameworks.
+    "instructor",
+    "guidance",
+    "dspy",
+    "dspy-ai",
+    "mirascope",
+    "marvin",
+    # Agent-specific toolkits.
+    "griptape",
+    "smol-developer",
+    "smolagents",
+    # Vendor agent SDKs (distinct from the plain LLM SDKs we DO permit).
+    "openai-agents",
+    "anthropic-agents",
+})
+
+# Informational — surfaced in script output so the rule is unambiguous.
+PERMITTED_LLM_SDKS: frozenset[str] = frozenset({"openai", "anthropic"})
+
+# Top-level import names that map to a banned distribution. Distribution
+# names use hyphens, but Python imports use the actual module name. Most
+# banned packages expose a module name that matches the distribution
+# minus hyphens / dashes. We list explicit aliases here so the AST scan
+# catches the import even when the on-disk name differs.
+BANNED_IMPORT_ROOTS: frozenset[str] = frozenset({
+    "langchain",
+    "langchain_core",
+    "langchain_community",
+    "langchain_openai",
+    "langchain_anthropic",
+    "langgraph",
+    "langsmith",
+    "langserve",
+    "llamaindex",
+    "llama_index",
+    "llama_parse",
+    "haystack",
+    "autogen",
+    "pyautogen",
+    "autogenstudio",
+    "ag2",
+    "crewai",
+    "crewai_tools",
+    "semantic_kernel",
+    "instructor",
+    "guidance",
+    "dspy",
+    "mirascope",
+    "marvin",
+    "griptape",
+    "smol_developer",
+    "smolagents",
+    "openai_agents",
+    "anthropic_agents",
+})
+
+# Reference text shown on failure so authors know where to look.
+DOC_REFERENCE = "See docs/dev/no-agent-frameworks.md and AGENT.md §4."
+
+
+def normalize_distribution_name(name: str) -> str:
+    """Apply PyPA name normalization — lowercase, hyphenate underscores.
+
+    See: https://packaging.python.org/en/latest/specifications/name-normalization/
+    """
+    return name.lower().replace("_", "-").replace(".", "-").strip()
+
+
+def _strip_requirement_extras(spec: str) -> str:
+    """Extract the bare distribution name from a PEP 508 requirement string.
+
+    Handles ``foo``, ``foo>=1.0``, ``foo[bar]``, ``foo[bar,baz]==1``,
+    ``foo ; python_version < '3.12'``, and the ``--editable`` / ``-e`` /
+    URL forms commonly tolerated by uv. Returns ``""`` for things that
+    are clearly not a distribution name (URLs, paths) — those cannot be
+    matched against the ban list anyway.
+    """
+    # Strip environment markers.
+    core = spec.split(";", 1)[0].strip()
+    # Strip extras.
+    core = core.split("[", 1)[0].strip()
+    # Strip version specifiers.
+    for sep in ("==", ">=", "<=", "!=", "~=", ">", "<", "@"):
+        if sep in core:
+            core = core.split(sep, 1)[0].strip()
+            break
+    # Bail on anything that looks like a URL or path — uv accepts those
+    # but we cannot evaluate them against a name-based ban list.
+    if "/" in core or core.startswith(("git+", "http://", "https://", ".")):
+        return ""
+    return core
+
+
+@dataclass
+class Violation:
+    """One banned-package or banned-import hit."""
+
+    surface: str  # "pyproject" | "import"
+    package: str  # normalized distribution name OR import root
+    location: str  # "pyproject.toml: [project.dependencies]" or "src/foo.py:3"
+    detail: str = ""
+
+    def render(self) -> str:
+        suffix = f" — {self.detail}" if self.detail else ""
+        return f"{self.location}: {self.package}{suffix}"
+
+
+@dataclass
+class ScanResult:
+    """Aggregate result of a full scan."""
+
+    ok: bool = True
+    violations: list[Violation] = field(default_factory=list)
+    permitted_llm_sdks: list[str] = field(default_factory=lambda: sorted(PERMITTED_LLM_SDKS))
+    banned_packages: list[str] = field(default_factory=lambda: sorted(BANNED_PACKAGES))
+
+
+def scan_pyproject(pyproject_path: Path) -> list[Violation]:
+    """Return every banned distribution declared in ``pyproject_path``.
+
+    Scans ``[project] dependencies``, every group in
+    ``[dependency-groups]``, and every extra in
+    ``[project.optional-dependencies]``.
+    """
+    if not pyproject_path.is_file():
+        return []
+
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    violations: list[Violation] = []
+
+    project = data.get("project", {})
+    if isinstance(project, dict):
+        deps = project.get("dependencies", [])
+        if isinstance(deps, list):
+            violations.extend(_scan_requirement_list(deps, "[project.dependencies]"))
+
+        optional = project.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for extra, items in optional.items():
+                if isinstance(items, list):
+                    location = f"[project.optional-dependencies.{extra}]"
+                    violations.extend(_scan_requirement_list(items, location))
+
+    groups = data.get("dependency-groups", {})
+    if isinstance(groups, dict):
+        for group, items in groups.items():
+            if isinstance(items, list):
+                location = f"[dependency-groups.{group}]"
+                violations.extend(_scan_requirement_list(items, location))
+
+    return violations
+
+
+def _scan_requirement_list(items: list[Any], location: str) -> list[Violation]:
+    """Filter a PEP 508 requirement list down to banned hits."""
+    out: list[Violation] = []
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        raw = _strip_requirement_extras(item)
+        if not raw:
+            continue
+        normalized = normalize_distribution_name(raw)
+        if normalized in BANNED_PACKAGES:
+            out.append(
+                Violation(
+                    surface="pyproject",
+                    package=normalized,
+                    location=f"pyproject.toml {location}",
+                    detail=f"declared as {item!r}",
+                )
+            )
+    return out
+
+
+def _scan_one_file(path: Path) -> list[Violation]:
+    """AST-walk a single Python file; return banned-import violations."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except OSError, SyntaxError:
+        # Skip unreadable / unparseable files — not our job to fix.
+        return []
+
+    out: list[Violation] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".", 1)[0]
+                if top in BANNED_IMPORT_ROOTS:
+                    out.append(
+                        Violation(
+                            surface="import",
+                            package=top,
+                            location=f"{path}:{node.lineno}",
+                            detail=f"import {alias.name}",
+                        )
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if not module:
+                continue
+            top = module.split(".", 1)[0]
+            if top in BANNED_IMPORT_ROOTS:
+                out.append(
+                    Violation(
+                        surface="import",
+                        package=top,
+                        location=f"{path}:{node.lineno}",
+                        detail=f"from {module} import ...",
+                    )
+                )
+    return out
+
+
+def scan_imports(roots: list[Path]) -> list[Violation]:
+    """Walk every ``*.py`` under ``roots`` and report banned imports.
+
+    Uses ``ast`` rather than regex so we don't false-positive on strings,
+    docstrings, or comments. Both ``import x`` and ``from x.y import z``
+    are checked against ``BANNED_IMPORT_ROOTS`` on the top-level package.
+    """
+    violations: list[Violation] = []
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            violations.extend(_scan_one_file(path))
+    return violations
+
+
+def run(repo_root: Path) -> ScanResult:
+    """Run both scans rooted at ``repo_root`` and return a combined result."""
+    result = ScanResult()
+    pyproject_hits = scan_pyproject(repo_root / "pyproject.toml")
+    import_hits = scan_imports([repo_root / "src", repo_root / "tests"])
+    result.violations = pyproject_hits + import_hits
+    result.ok = not result.violations
+    return result
+
+
+def _print_human(result: ScanResult) -> None:
+    print("Scanning pyproject.toml deps...")
+    pyproject_hits = [v for v in result.violations if v.surface == "pyproject"]
+    if not pyproject_hits:
+        print("  PASS: no banned packages declared.")
+    else:
+        for hit in pyproject_hits:
+            print(f"  FAIL: {hit.render()}")
+
+    print("Scanning src/ and tests/ imports...")
+    import_hits = [v for v in result.violations if v.surface == "import"]
+    if not import_hits:
+        print("  PASS: no banned imports found.")
+    else:
+        for hit in import_hits:
+            print(f"  FAIL: {hit.render()}")
+
+    if result.ok:
+        print("Result: PASS")
+        print(f"Permitted LLM SDKs: {', '.join(sorted(PERMITTED_LLM_SDKS))}")
+    else:
+        n = len(result.violations)
+        plural = "violation" if n == 1 else "violations"
+        print(f"Result: FAIL — {n} {plural}")
+        print(DOC_REFERENCE)
+
+
+def _print_json(result: ScanResult) -> None:
+    payload = {
+        "ok": result.ok,
+        "violations": [asdict(v) for v in result.violations],
+        "permitted_llm_sdks": result.permitted_llm_sdks,
+        "banned_packages_count": len(result.banned_packages),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce AGENT.md §4: no third-party agent frameworks.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root (defaults to the script's parent directory).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of the human report.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        result = run(args.repo_root)
+    except (OSError, tomllib.TOMLDecodeError) as exc:  # pragma: no cover
+        print(f"check_banned_frameworks: error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        _print_json(result)
+    else:
+        _print_human(result)
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_banned_frameworks.py
+++ b/tests/scripts/test_check_banned_frameworks.py
@@ -1,0 +1,225 @@
+"""Tests for scripts/check_banned_frameworks.py.
+
+The scanner is the mechanical enforcement of AGENT.md §4. Tests cover
+the happy path against the real repo plus injected violations under
+``tmp_path`` for both surfaces (declared deps + AST imports).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_banned_frameworks.py"
+
+
+def _load_script() -> Any:
+    """Import the script by path — it is not a package."""
+    spec = importlib.util.spec_from_file_location("check_banned_frameworks", SCRIPT_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load scanner from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_banned_frameworks"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def scanner() -> Any:
+    return _load_script()
+
+
+def _make_repo(tmp_path: Path, *, pyproject: str = "", src_files: dict[str, str] | None = None) -> Path:
+    """Build a minimal fake repo under ``tmp_path`` and return its root."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    for relative, body in (src_files or {}).items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------- happy path
+
+
+def test_real_repo_passes(scanner: Any) -> None:
+    """Whatever main looks like today, the scanner must not flag it."""
+    result = scanner.run(REPO_ROOT)
+    assert result.ok, [v.render() for v in result.violations]
+    assert result.violations == []
+
+
+def test_real_repo_passes_via_subprocess() -> None:
+    """End-to-end: subprocess returns 0 on the live repo."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# ---------------------------------------------------------- pyproject scan
+
+
+def test_detects_banned_in_project_dependencies(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject=('[project]\nname = "x"\nversion = "0"\ndependencies = ["langchain>=0.3", "httpx>=0.28"]\n'),
+    )
+    result = scanner.run(repo)
+    assert not result.ok
+    assert any(v.package == "langchain" for v in result.violations)
+
+
+def test_detects_banned_in_dependency_groups(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject=(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n[dependency-groups]\ndev = ["crewai==0.5"]\n'
+        ),
+    )
+    result = scanner.run(repo)
+    assert not result.ok
+    assert any(v.package == "crewai" for v in result.violations)
+
+
+def test_detects_banned_in_optional_dependencies(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject=(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = []\n'
+            '[project.optional-dependencies]\nrag = ["llama-index"]\n'
+        ),
+    )
+    result = scanner.run(repo)
+    assert not result.ok
+    assert any(v.package == "llama-index" for v in result.violations)
+
+
+# ---------------------------------------------------------- import scan
+
+
+def test_detects_banned_import_in_src(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = []\n',
+        src_files={"src/yaya/foo.py": "import langgraph\n"},
+    )
+    result = scanner.run(repo)
+    assert not result.ok
+    hits = [v for v in result.violations if v.surface == "import"]
+    assert any(v.package == "langgraph" for v in hits)
+    assert any("foo.py:1" in v.location for v in hits)
+
+
+def test_detects_banned_from_import(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = []\n',
+        src_files={"tests/foo_test.py": "from langchain.chains import LLMChain\n"},
+    )
+    result = scanner.run(repo)
+    assert not result.ok
+    assert any(v.package == "langchain" for v in result.violations if v.surface == "import")
+
+
+def test_string_mention_is_not_a_violation(tmp_path: Path, scanner: Any) -> None:
+    """AST scan must not false-positive on string mentions of a ban."""
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = []\n',
+        src_files={"src/yaya/notes.py": 'X = "we do not import langchain anywhere"\n'},
+    )
+    result = scanner.run(repo)
+    assert result.ok, [v.render() for v in result.violations]
+
+
+# ---------------------------------------------------------- normalization
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["langchain", "Langchain", "LANGCHAIN", "  langchain  "],
+)
+def test_name_normalization_catches_case_variants(raw: str, scanner: Any) -> None:
+    assert scanner.normalize_distribution_name(raw) == "langchain"
+    assert scanner.normalize_distribution_name(raw) in scanner.BANNED_PACKAGES
+
+
+@pytest.mark.parametrize(
+    ("raw", "normalized"),
+    [
+        ("llama-index", "llama-index"),
+        ("llama_index", "llama-index"),
+        ("Llama.Index", "llama-index"),
+        ("LANGCHAIN_CORE", "langchain-core"),
+    ],
+)
+def test_pypa_normalization_collapses_separators(raw: str, normalized: str, scanner: Any) -> None:
+    """PyPA spec: ``_`` / ``.`` / runs of ``-`` all collapse to ``-`` after lower()."""
+    assert scanner.normalize_distribution_name(raw) == normalized
+    assert normalized in scanner.BANNED_PACKAGES
+
+
+def test_strip_requirement_extras_handles_specifiers(scanner: Any) -> None:
+    assert scanner._strip_requirement_extras("langchain>=0.3") == "langchain"
+    assert scanner._strip_requirement_extras("langchain[extras]==1.0") == "langchain"
+    assert scanner._strip_requirement_extras("langchain ; python_version < '3.13'") == "langchain"
+
+
+def test_strip_requirement_extras_drops_url_form(scanner: Any) -> None:
+    """URL / git refs cannot be matched against the ban list — return ''."""
+    assert scanner._strip_requirement_extras("git+https://example.com/x.git") == ""
+    assert scanner._strip_requirement_extras("https://example.com/x.tar.gz") == ""
+
+
+# ---------------------------------------------------------- CLI shape
+
+
+def test_cli_returns_zero_on_clean_tree(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = ["httpx"]\n',
+    )
+    rc = scanner.main(["--repo-root", str(repo)])
+    assert rc == 0
+
+
+def test_cli_returns_one_on_violation(tmp_path: Path, scanner: Any) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = ["langchain"]\n',
+    )
+    rc = scanner.main(["--repo-root", str(repo)])
+    assert rc == 1
+
+
+def test_cli_json_output_shape(tmp_path: Path, scanner: Any, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _make_repo(
+        tmp_path,
+        pyproject='[project]\nname = "x"\nversion = "0"\ndependencies = ["langchain"]\n',
+    )
+    rc = scanner.main(["--repo-root", str(repo), "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert isinstance(payload["violations"], list)
+    assert payload["violations"], "expected at least one violation"
+    first = payload["violations"][0]
+    assert {"surface", "package", "location", "detail"} <= set(first.keys())
+    assert "permitted_llm_sdks" in payload
+    assert "anthropic" in payload["permitted_llm_sdks"]
+    assert "openai" in payload["permitted_llm_sdks"]


### PR DESCRIPTION
## Summary

Operationalizes AGENT.md §4 — the "no third-party agent frameworks"
rule is now grep-enforced via a stdlib Python scanner. Runs in
pre-commit and CI.

- 33 banned distribution names (LangChain family, agent toolkits,
  vendor agent SDKs).
- PyPA name normalization so case + separator variants collide.
- AST-based import scan (no regex false-positives on docstrings).
- \`--json\` output for CI / tooling integration.

## Type of change
| Type | Label |
|------|-------|
| Chore | \`enhancement\` |

## Component
\`ci\`, \`governance\`

## Closes
Closes #33

## Test plan
- [x] Script exits 0 on current main (runtime ~0.12s)
- [x] Script detects injected ban (fixture tests for each surface)
- [x] Name normalization catches case + separator variants
- [x] \`--json\` output is valid and includes violations + permitted SDKs
- [x] Subprocess test confirms end-to-end exit code on live repo
- [ ] CI green (watching)

## Known limitations
- Dynamic \`importlib.import_module("langchain")\` is not caught
  (policy enforcement, not hermetic sandbox).
- Transitive deps via \`uv.lock\` are not scanned today; declared-dep
  gate covers the common case. Documented in
  \`docs/dev/no-agent-frameworks.md\`.