### PR TITLE
fix(ci): tighten harness sync and web tasks (#86)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.4
+    rev: v0.15.11
     hooks:
       - id: ruff
         args: [--exit-non-zero-on-fix]
@@ -52,4 +52,4 @@ repos:
         entry: uv run python scripts/check_feature_sync.py
         language: system
         pass_filenames: false
-        files: ^(specs/.*\.spec|tests/bdd/features/.*\.feature)$
+        files: ^(specs/.*\.spec|tests/(?:bdd|e2e/bdd)/features/.*\.feature)$

--- a/AGENT.md
+++ b/AGENT.md
@@ -40,7 +40,7 @@ Accountability is to the **artifact**, not to the user's approval.
 
 ## 4. Constraints
 
-- Python 3.14+, `uv` envs, `just` tasks, `ruff`, `mypy --strict`, `pytest`, coverage ≥80%.
+- Python 3.14+, `uv` envs, `just` tasks, `ruff`, `mypy --strict`, `pytest`, coverage ≥88%.
 - English-only in code, comments, commits, docs. Chinese only in user-facing chat.
 - Conventional Commits with `(#N)` + `Closes #N`. Never `--no-verify`.
 - Layout: `cli/` depends on `core/`, never the reverse.

--- a/justfile
+++ b/justfile
@@ -97,23 +97,23 @@ docs-test:
     @echo "📖 Building docs (strict)"
     uv run --group docs mkdocs build -s
 
-# --- Web UI (src/yaya/web/) — pi-web-ui consumer ------------------------------
+# --- Web UI (src/yaya/plugins/web/) --------------------------------------------
 # Install npm deps (run once after clone / lockfile change)
 web-install:
-    @echo "📦 npm ci in src/yaya/web"
-    cd src/yaya/web && npm ci
+    @echo "📦 npm ci in src/yaya/plugins/web"
+    cd src/yaya/plugins/web && npm ci
 
-# Build static assets into src/yaya/web/static/ (CI + pre-wheel)
+# Build static assets into src/yaya/plugins/web/static/ (CI + pre-wheel)
 web-build:
     @echo "🌐 Building web UI (pi-web-ui)"
-    cd src/yaya/web && npm run build
+    cd src/yaya/plugins/web && npm run build
 
 # Dev server with HMR (pair with `yaya serve --dev` in another shell)
 web-dev:
     @echo "🌐 vite dev server (HMR)"
-    cd src/yaya/web && npm run dev
+    cd src/yaya/plugins/web && npm run dev
 
 # Lint + type check TS (biome + tsc --noEmit)
 web-check:
     @echo "🌐 Web UI check"
-    cd src/yaya/web && npm run check
+    cd src/yaya/plugins/web && npm run check

--- a/scripts/check_feature_sync.py
+++ b/scripts/check_feature_sync.py
@@ -1,19 +1,23 @@
-"""Verify every `.feature` file under tests/bdd/features/ stays in sync
-with its companion `specs/*.spec`.
+"""Verify every mirrored `.feature` stays in sync with its companion spec.
 
 Each `.feature` is the executable Gherkin for a spec's Completion
 Criteria scenarios. When an author edits a spec's scenarios without
 updating the `.feature`, pytest-bdd would either run stale text or
 silently fail to bind — the scenarios become de-facto unverified.
 
-This check closes that gap. For every `tests/bdd/features/X.feature`,
-the script looks for `specs/X.spec` and compares:
+This check closes that gap. For every mirrored pair, the script compares:
 
   * Set of scenario names
   * Ordered list of Given/When/Then/And steps per scenario
 
-If any drift, exit non-zero with a human-readable diff. Intended to
-run as part of `just check` and in CI.
+Both directions are enforced:
+
+  * every `specs/*.spec` must have a matching `.feature`;
+  * every mirrored `.feature` must have a matching `.spec`.
+
+If any drift or missing mirror exists, exit non-zero with a
+human-readable diff. Intended to run as part of `just check`, CI, and
+pre-commit.
 
 stdlib-only.
 """
@@ -21,6 +25,7 @@ stdlib-only.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -115,22 +120,42 @@ def diff_scenarios(spec: list[Scenario], feature: list[Scenario]) -> list[str]:
     return diffs
 
 
+def iter_feature_dirs(repo: Path) -> list[Path]:
+    """Return the feature directories that mirror repo specs."""
+    candidates = [
+        repo / "tests" / "bdd" / "features",
+        repo / "tests" / "e2e" / "bdd" / "features",
+    ]
+    return [path for path in candidates if path.is_dir()]
+
+
+def _feature_stems(feature_dirs: Iterable[Path]) -> dict[str, Path]:
+    """Return a stable stem -> feature path map across all mirror dirs."""
+    mapping: dict[str, Path] = {}
+    for feature_dir in feature_dirs:
+        for feature_path in sorted(feature_dir.glob("*.feature")):
+            mapping[feature_path.stem] = feature_path
+    return mapping
+
+
 def collect_sync_errors(repo: Path) -> list[str]:
     """Return human-readable sync errors for all spec/feature pairs."""
-    features_dir = repo / "tests" / "bdd" / "features"
     specs_dir = repo / "specs"
+    feature_dirs = iter_feature_dirs(repo)
 
     errors: list[str] = []
     specs = sorted(specs_dir.glob("*.spec")) if specs_dir.is_dir() else []
-    features = sorted(features_dir.glob("*.feature")) if features_dir.is_dir() else []
+    features_by_stem = _feature_stems(feature_dirs)
+    feature_stems = set(features_by_stem)
 
-    feature_stems = {feature_path.stem for feature_path in features}
     for spec_path in specs:
         if spec_path.stem not in feature_stems:
-            expected = features_dir / f"{spec_path.stem}.feature"
+            expected = (
+                feature_dirs[0] if feature_dirs else repo / "tests" / "bdd" / "features"
+            ) / f"{spec_path.stem}.feature"
             errors.append(f"❌ {_repo_path(spec_path, repo)}: no matching {_repo_path(expected, repo)}")
 
-    for feature_path in features:
+    for feature_path in sorted(features_by_stem.values()):
         spec_path = specs_dir / f"{feature_path.stem}.spec"
         if not spec_path.is_file():
             errors.append(f"❌ {_repo_path(feature_path, repo)}: no matching {_repo_path(spec_path, repo)}")
@@ -152,8 +177,8 @@ def collect_sync_errors(repo: Path) -> list[str]:
 
 def main() -> int:
     repo = Path(__file__).resolve().parents[1]
-    features_dir = repo / "tests" / "bdd" / "features"
     specs_dir = repo / "specs"
+    feature_dirs = iter_feature_dirs(repo)
 
     if not specs_dir.is_dir():
         print(f"no specs dir at {specs_dir}; nothing to check")
@@ -164,13 +189,14 @@ def main() -> int:
         print("\n".join(errors))
         return 1
 
-    if not features_dir.is_dir():
-        print(f"no features dir at {features_dir}; nothing to check")
+    if not feature_dirs:
+        print(f"no feature dirs under {repo / 'tests'}; nothing to check")
         return 0
 
-    features = sorted(features_dir.glob("*.feature"))
+    features = sorted(path for feature_dir in feature_dirs for path in feature_dir.glob("*.feature"))
     if not features:
-        print(f"no .feature files in {features_dir}; nothing to check")
+        joined = ", ".join(_repo_path(path, repo) for path in feature_dirs)
+        print(f"no .feature files in {joined}; nothing to check")
         return 0
 
     for feature_path in features:

--- a/tests/AGENT.md
+++ b/tests/AGENT.md
@@ -6,7 +6,7 @@
 Pytest suite. Mirrors `src/yaya/` one-to-one. Tests are the specification.
 
 ## External Reality
-- `just test` (pytest + coverage) is ground truth. Coverage floor: 80% (`fail_under`).
+- `just test` (pytest + coverage) is ground truth. Coverage floor: 88% (`fail_under`).
 - `addopts` enforces `--strict-markers` + `--strict-config` + 30s timeout.
 - `pytest-randomly` shuffles test order — order-dependence fails CI immediately.
 - Tests run hermetically: autouse fixtures redirect `STATE_DIR` and disable the update toast.

--- a/tests/bdd/features/cli-kernel-commands.feature
+++ b/tests/bdd/features/cli-kernel-commands.feature
@@ -1,0 +1,46 @@
+Feature: CLI kernel commands
+
+  These scenarios mirror specs/cli-kernel-commands.spec and keep the
+  minimal built-in CLI surface executable: hello, serve, and plugin
+  management all stay wired to the kernel contracts they advertise.
+
+  Scenario: yaya hello under --json returns ok=true with received=true
+    Given a fresh kernel with no LLM configured
+    When `yaya --json hello` is invoked
+    Then the command exits 0 and stdout carries `{"ok": true, "action": "hello", "received": true}`
+
+  Scenario: Error path — yaya serve rejects --host
+    Given the serve command registered on the CLI app
+    When the user invokes `yaya serve --host 0.0.0.0`
+    Then Typer exits with code 2 because no such flag is defined
+
+  Scenario: yaya plugin list under --json returns a valid plugins array
+    Given the four bundled seed plugins installed via entry points
+    When `yaya --json plugin list` is invoked
+    Then stdout carries `{"ok": true, "action": "plugin.list", "plugins": [...]}` listing every bundled plugin
+
+  Scenario: Error path — yaya plugin remove of a bundled plugin emits ok=false with suggestion
+    Given a bundled plugin named strategy-react
+    When `yaya --json plugin remove strategy-react --yes` is invoked
+    Then the command exits 1 and stdout carries `{"ok": false, "error": "...bundled...", "suggestion": "...bundled..."}`
+
+  Scenario: Error path — yaya plugin install rejects unsupported scheme
+    Given a source string with an unsupported URL scheme like `git+ssh`
+    When `yaya --json plugin install "git+ssh://example.com/foo.git" --yes` is invoked
+    Then `validate_install_source` raises ValueError before any subprocess is spawned
+    And the CLI surfaces ok=false with a suggestion
+
+  Scenario: yaya serve shuts down cleanly when the shutdown event is set
+    Given `run_serve` is driven via its test-only shutdown_event hook
+    When the event is set after boot
+    Then stdout carries `{"ok": true, "action": "shutdown", "reason": "signal"}` and the task returns exit code 0
+
+  Scenario: yaya serve warns when no web adapter plugin is loaded
+    Given the kernel boots without any plugin whose category is adapter and name starts with web
+    When `run_serve` starts up
+    Then a human-facing warning whose text contains "no web adapter" lands on stderr and the kernel continues running
+
+  Scenario: yaya plugin install under --json requires --yes
+    Given the user passes --json without --yes
+    When `yaya --json plugin install some-pkg` is invoked
+    Then the command exits 1 with ok=false and error=confirmation_required

--- a/tests/bdd/features/kernel-approval.feature
+++ b/tests/bdd/features/kernel-approval.feature
@@ -1,0 +1,43 @@
+Feature: Kernel approval runtime
+
+  These scenarios mirror specs/kernel-approval.spec and keep the
+  human-in-the-loop approval path executable: approve, reject, timeout,
+  session caching, kernel-session routing, and shutdown cancellation.
+
+  Scenario: AC-01 — user approves, tool runs once
+    Given a Tool subclass with requires approval true
+    And an adapter that answers approval request with approve
+    When a tool call request is emitted for the tool
+    Then the tool run method is invoked exactly once
+    And a tool call result event is emitted with ok true
+
+  Scenario: AC-02 — user rejects, tool is blocked
+    Given a Tool subclass with requires approval true
+    And an adapter that answers approval request with reject and feedback no thanks
+    When a tool call request is emitted for the tool
+    Then the tool run method is not invoked
+    And a tool error event is emitted with kind rejected whose brief mentions no thanks
+
+  Scenario: AC-03 — approve for session short-circuits future prompts
+    Given an adapter that answers the first approval with approve for session
+    When two identical tool call requests are published on the same session
+    Then exactly one approval request event is observed by the adapter
+    And both tool call result events carry ok true
+
+  Scenario: AC-04 — 60s timeout cancels the approval
+    Given an approval runtime with a very short timeout
+    And no adapter subscribed to approval request
+    When the runtime request method is awaited
+    Then an approval cancelled event is emitted with reason timeout
+    And an approval cancelled error is raised
+
+  Scenario: AC-05 — approval events route on the kernel session to avoid deadlock
+    Given an adapter subscribed to approval request
+    When the runtime issues a request from inside a tool call session worker
+    Then the approval request envelope carries session id kernel
+    And the resolve path does not deadlock the originating session worker
+
+  Scenario: AC-06 — shutdown cancels pending approvals
+    Given a pending approval request
+    When the approval runtime stop method is called
+    Then the awaiting caller observes an approval cancelled error with reason shutdown

--- a/tests/bdd/features/kernel-config.feature
+++ b/tests/bdd/features/kernel-config.feature
@@ -1,0 +1,37 @@
+Feature: Kernel config resolution
+
+  These scenarios mirror specs/kernel-config.spec and keep the config
+  resolver's precedence, plugin namespace handling, and CLI redaction
+  contract executable.
+
+  Scenario: AC-01 env var overrides TOML file value
+    Given a TOML file at the resolved CONFIG_PATH sets llm_openai.model = "gpt-4"
+    And the env var YAYA_LLM_OPENAI__MODEL = "gpt-4o" is set
+    When the kernel loads config via load_config()
+    Then KernelConfig.plugin_config("llm_openai")["model"] equals "gpt-4o"
+
+  Scenario: AC-02 yaya config show redacts secrets under JSON
+    Given the env var YAYA_LLM_OPENAI__API_KEY = "sk-abc123" is set
+    When the user runs yaya --json config show
+    Then the output does not contain "sk-abc123"
+    And the resolved value for the api_key key is "***"
+
+  Scenario: TOML overrides built-in defaults
+    Given a TOML file at CONFIG_PATH sets port = 8080 and log_level = "DEBUG"
+    When load_config is called
+    Then KernelConfig.port equals 8080 and KernelConfig.log_level equals "DEBUG"
+
+  Scenario: Plugin namespace lifts arbitrary env vars into a sub-tree
+    Given the env vars YAYA_LLM_OPENAI__MODEL and YAYA_LLM_OPENAI__API_KEY are set
+    When load_config is called
+    Then plugin_config("llm_openai") contains both keys with their string values
+
+  Scenario: Unknown plugin name returns an empty mapping
+    Given a fresh KernelConfig with no extras
+    When plugin_config is called for a plugin name that has no env or TOML entry
+    Then the returned mapping is empty and not None
+
+  Scenario: Secret-key regex catches token, key, secret, password variants
+    Given the redaction predicate _is_secret_key
+    When called with api_key, x_token, SECRET_PASSPHRASE, or PASSWORD variants
+    Then every variant is flagged as a secret

--- a/tests/bdd/features/kernel-logging.feature
+++ b/tests/bdd/features/kernel-logging.feature
@@ -1,0 +1,36 @@
+Feature: Kernel logging and error taxonomy
+
+  These scenarios mirror specs/kernel-logging.spec and keep the logging
+  sink, redaction, intercept, and plugin.error attribution contracts
+  executable.
+
+  Scenario: configure logging is idempotent
+    Given a fresh KernelConfig with log_level INFO
+    When configure_logging is called twice in a row
+    Then the loguru handler count after the second call equals the count after the first
+
+  Scenario: redaction filter scrubs secret keys
+    Given a record with secret-looking keys api_key, x_token, SECRET_PASSPHRASE, PASSWORD, openai_token
+    When the redaction filter walks record["extra"]
+    Then every secret value is replaced with the literal "***"
+    And non-secret keys (like model) are preserved
+
+  Scenario: JSON mode emits valid JSON per line
+    Given the env var YAYA_LOG_JSON = "1" is set
+    When configure_logging runs and a plugin logger emits a line
+    Then the stderr line parses as JSON with message, plugin, level fields
+
+  Scenario: file sink rotates at the size limit
+    Given configure_logging has wired the rotated file sink under tmp_path
+    When more than 10 MiB of log content is written
+    Then a backup file appears alongside yaya.log
+
+  Scenario: stdlib logging intercept routes to loguru
+    Given configure_logging has installed the InterceptHandler on the root logger
+    When a record is emitted via logging.getLogger("third_party").info(...)
+    Then the message appears on the loguru stderr sink
+
+  Scenario: PluginError event carries kind and traceback hash
+    Given a bus subscriber that raises PluginError("boom")
+    When the bus delivers a matching event
+    Then a plugin.error event is emitted with kind="PluginError" and an 8-char hex error_hash

--- a/tests/bdd/features/llm-provider-contract.feature
+++ b/tests/bdd/features/llm-provider-contract.feature
@@ -1,0 +1,55 @@
+Feature: LLM provider contract
+
+  These scenarios mirror specs/llm-provider-contract.spec and keep the
+  TokenUsage model, SDK-error converters, protocol shape, stream
+  semantics, and llm-plugin import scanner executable.
+
+  Scenario: AC-01 — TokenUsage carries Anthropic cache counters and derives totals
+    Given a TokenUsage with input_other 3 input_cache_read 2 input_cache_creation 1 and output 4
+    When input and total are read
+    Then input equals 6 and total equals 10
+
+  Scenario: AC-02 — openai API timeout is translated to APITimeoutError
+    Given an openai APITimeoutError raised by the SDK
+    When openai_to_chat_provider_error is called
+    Then an APITimeoutError instance is returned
+
+  Scenario: AC-03 — openai APIStatusError preserves status_code
+    Given an openai APIStatusError with status_code 429
+    When openai_to_chat_provider_error is called
+    Then the returned APIStatusError carries status_code 429
+
+  Scenario: AC-04 — anthropic typed errors are translated via a stub SDK
+    Given a stub anthropic module exposing APIConnectionError APITimeoutError and APIStatusError
+    When anthropic_to_chat_provider_error is called for each typed error
+    Then the returned exception is the matching yaya taxonomy subclass
+
+  Scenario: AC-05 — raw httpx connect errors are translated to APIConnectionError
+    Given an httpx ConnectError instance
+    When convert_httpx_error is called
+    Then an APIConnectionError is returned
+
+  Scenario: AC-06 — raw httpx read timeouts are translated to APITimeoutError
+    Given an httpx ReadTimeout instance
+    When convert_httpx_error is called
+    Then an APITimeoutError is returned
+
+  Scenario: AC-07 — LLMProvider Protocol is runtime-checkable
+    Given a concrete stub with name model_name thinking_effort and an async generate method
+    When isinstance is called against LLMProvider
+    Then the stub is recognised as an LLMProvider
+
+  Scenario: AC-08 — Streaming provider emits deltas and a final response through the bus
+    Given a fake provider yielding two ContentParts hel and lo
+    When the kernel publishes llm.call.request and the provider re-publishes deltas and a terminal response
+    Then two llm.call.delta events are observed and one llm.call.response carries the merged text hello with a serialised TokenUsage
+
+  Scenario: AC-09 — LLM plugins importing raw httpx are rejected by the scanner
+    Given a fake llm_fake plugin that imports httpx
+    When check_llm_plugin_imports is run against its src root
+    Then an llm-plugin-import violation is reported naming httpx and the plugin file
+
+  Scenario: AC-10 — Non-LLM plugins may use httpx without violating the ban
+    Given a tool_http plugin that imports httpx
+    When check_llm_plugin_imports is run against its src root
+    Then no violation is reported

--- a/tests/bdd/features/plugin-llm_echo.feature
+++ b/tests/bdd/features/plugin-llm_echo.feature
@@ -1,0 +1,42 @@
+Feature: Echo LLM provider plugin
+
+  These scenarios mirror specs/plugin-llm_echo.spec and keep the
+  zero-config echo provider executable through the bus and strategy
+  fallback path.
+
+  Scenario: AC-01 echo round-trip emits response with text tool_calls usage and request_id
+    Given an echo plugin loaded with no configuration
+    When a llm.call.request for provider echo with a user message hello is published
+    Then a llm.call.response event is emitted with text equal to (echo) hello and zero token usage
+    And the response echoes the originating request id
+
+  Scenario: Error path — unrelated provider id leaves the event uncommented by llm-echo
+    Given an echo plugin loaded with no configuration
+    When a llm.call.request for a non-echo provider id is published
+    Then no llm.call.response event is emitted by the llm-echo plugin
+    And no llm.call.error event is emitted by the llm-echo plugin
+
+  Scenario: Empty messages list returns the deterministic no-input marker
+    Given an echo plugin loaded with no configuration
+    When a llm.call.request for provider echo with an empty messages list is published
+    Then a llm.call.response event is emitted with text equal to (echo) (no input)
+
+  Scenario: Multi-turn history echoes only the most recent user message
+    Given an echo plugin loaded with no configuration
+    When a llm.call.request for provider echo carries multiple user turns ending in second is published
+    Then a llm.call.response event is emitted with text equal to (echo) second
+
+  Scenario: Response request_id matches the originating event id for loop correlation
+    Given an echo plugin loaded with no configuration
+    When a llm.call.request for provider echo is published
+    Then the llm.call.response event request_id field equals the originating request event id
+
+  Scenario: AC-AUTO strategy picks echo when no OPENAI_API_KEY is configured
+    Given the OPENAI_API_KEY environment variable is unset
+    When the ReAct strategy decides the next step for an empty conversation
+    Then the response next is llm and the chosen provider is echo
+
+  Scenario: AC-AUTO strategy picks openai when OPENAI_API_KEY is set
+    Given the OPENAI_API_KEY environment variable is set to a placeholder
+    When the ReAct strategy decides the next step for an empty conversation
+    Then the response next is llm and the chosen provider is openai

--- a/tests/bdd/features/tool-contract.feature
+++ b/tests/bdd/features/tool-contract.feature
@@ -1,0 +1,53 @@
+Feature: Tool contract
+
+  These scenarios mirror specs/tool-contract.spec and keep the v1 tool
+  contract executable: validation, schema generation, serialization,
+  dispatch, duplicate registration, legacy bypass, and approval
+  rejection.
+
+  Scenario: AC-01 — tool params are validated before run
+    Given a Tool subclass with a typed int field count
+    When a tool call request is emitted with schema version v1 and args count equal to the string abc
+    Then a tool error event is emitted with kind validation
+    And the tool run method is not invoked
+
+  Scenario: AC-02 — tool returns ToolOk with a display block
+    Given a Tool subclass whose run method returns ToolOk with a TextBlock display
+    When a tool call request is published with schema version v1
+    Then a tool call result event is emitted with ok true and the envelope carries a TextBlock
+
+  Scenario: AC-03 — tool JSON schema is LLM function call compatible
+    Given a Tool subclass with pydantic fields
+    When openai function spec is invoked on the class
+    Then the returned dict carries name description and a parameters JSON schema with required field entries
+
+  Scenario: AC-04 — unknown tool name is rejected with kind not_found
+    Given no tool is registered under the name nope
+    When a tool call request is published with schema version v1 and name nope
+    Then a tool error event is emitted with kind not_found
+
+  Scenario: AC-05 — schema version v1 envelope round trip
+    Given a ToolOk instance with a TextBlock display
+    When model dump is invoked and the resulting dict is validated back
+    Then the round trip returns an equivalent ToolOk instance
+
+  Scenario: AC-07 — dispatcher ignores legacy payloads without schema_version so on_event tools keep working
+    Given a v1 tool registered under the name echo
+    When a tool call request without schema version is published for the echo name
+    Then the dispatcher emits no tool call result and no tool error so the legacy on_event path owns the delivery
+
+  Scenario: AC-08 — register_tool raises ToolAlreadyRegisteredError on duplicate v1 registration
+    Given a v1 Tool subclass already registered under the name echo
+    When register_tool is called with a different subclass claiming the same echo name
+    Then ToolAlreadyRegisteredError is raised before the registry is mutated
+
+  Scenario: AC-09 — Tool.openai_function_spec produces a dict with name description and parameters schema
+    Given a Tool subclass with ClassVar name and description plus pydantic fields
+    When Tool.openai_function_spec is invoked on the class
+    Then the resulting dict carries the name description and parameters JSON schema fit for LLM function calling
+
+  Scenario: AC-06 — requires approval plus denied pre approve is rejected
+    Given a Tool subclass with requires approval true whose pre approve returns false
+    When a tool call request is published with schema version v1
+    Then a tool error event is emitted with kind rejected
+    And no tool call result event is emitted

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -395,6 +395,7 @@ def _strategy_payload(ctx: BDDContext, payload: dict[str, Any]) -> None:
 @given("a strategy.decide.request whose state has no prior assistant message")
 def _strategy_no_assistant(ctx: BDDContext) -> None:
     _strategy_payload(ctx, {"state": {"messages": [{"role": "user", "content": "hi"}]}})
+    ctx.extras["strategy_openai_api_key"] = "sk-test"
 
 
 @given("a strategy.decide.request whose last assistant message carries a non-empty tool_calls list")
@@ -428,6 +429,7 @@ def _strategy_after_tool(ctx: BDDContext) -> None:
             }
         },
     )
+    ctx.extras["strategy_openai_api_key"] = "sk-test"
 
 
 @given("a strategy.decide.request whose last assistant message has no tool_calls and no pending tool result")
@@ -451,7 +453,17 @@ def _strategy_missing_state(ctx: BDDContext) -> None:
 
 
 @when("the ReAct plugin handles the event")
-def _strategy_handles(ctx: BDDContext, tmp_path: Path, loop: asyncio.AbstractEventLoop) -> None:
+def _strategy_handles(
+    ctx: BDDContext,
+    tmp_path: Path,
+    loop: asyncio.AbstractEventLoop,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api_key = ctx.extras.get("strategy_openai_api_key")
+    if isinstance(api_key, str):
+        monkeypatch.setenv("OPENAI_API_KEY", api_key)
+    else:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     bus = EventBus()
     kernel_ctx = _kernel_ctx(bus, tmp_path, react_plugin.name)
     captured: list[Event] = []

--- a/tests/e2e/bdd/features/e2e-serve-roundtrip.feature
+++ b/tests/e2e/bdd/features/e2e-serve-roundtrip.feature
@@ -1,0 +1,15 @@
+Feature: E2E serve roundtrip
+
+  These scenarios mirror specs/e2e-serve-roundtrip.spec and prove an
+  installed yaya wheel can boot the kernel, expose the web adapter,
+  answer through the echo provider, and shut down cleanly.
+
+  Scenario: AC-01 echo round-trip lands an assistant done frame within five seconds
+    Given yaya serve is running as a subprocess on an ephemeral port with OPENAI_API_KEY unset
+    When the test opens a WebSocket to /ws and sends a user.message with text hi
+    Then an assistant.done frame arrives within five seconds and its content starts with (echo)
+
+  Scenario: AC-02 the kernel exits cleanly on SIGINT with no traceback on stderr
+    Given yaya serve is running as a subprocess
+    When the test sends the platform shutdown signal and the process exits
+    Then the captured stderr contains no Traceback header and no token unhandled

--- a/tests/scripts/test_check_feature_sync.py
+++ b/tests/scripts/test_check_feature_sync.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/check_feature_sync.py."""
+"""Tests for ``scripts/check_feature_sync.py``."""
 
 from __future__ import annotations
 
@@ -11,14 +11,14 @@ import pytest
 
 pytestmark = pytest.mark.unit
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_feature_sync.py"
 
-def _load_sync_checker() -> Any:
-    """Import scripts/check_feature_sync.py by path."""
-    root = Path(__file__).resolve().parents[2]
-    script_path = root / "scripts" / "check_feature_sync.py"
-    spec = importlib.util.spec_from_file_location("check_feature_sync", script_path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load sync checker from {script_path}")
+
+def _load_script() -> Any:
+    spec = importlib.util.spec_from_file_location("check_feature_sync", SCRIPT_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load sync checker from {SCRIPT_PATH}")
     module = importlib.util.module_from_spec(spec)
     sys.modules["check_feature_sync"] = module
     spec.loader.exec_module(module)
@@ -26,16 +26,16 @@ def _load_sync_checker() -> Any:
 
 
 @pytest.fixture
-def sync_checker() -> Any:
-    return _load_sync_checker()
+def checker() -> Any:
+    return _load_script()
 
 
-def _write_spec(path: Path, scenario_name: str = "happy path") -> None:
+def _write_spec(path: Path, *, scenario_name: str = "happy path", step: str = "the system is ready") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         "\n".join([
             "spec: task",
-            f'name: "{path.stem}"',
+            'name: "demo"',
             "---",
             "",
             "## Completion Criteria",
@@ -43,67 +43,68 @@ def _write_spec(path: Path, scenario_name: str = "happy path") -> None:
             f"Scenario: {scenario_name}",
             "  Test:",
             "    Package: yaya",
-            "    Filter: tests/test_example.py::test_example",
+            "    Filter: tests/demo.py::test_demo",
             "  Level: unit",
-            "  Given a precondition",
-            "  When an action runs",
-            "  Then an outcome is observed",
-            "",
+            f"  Given {step}",
+            "  When the user runs the demo",
+            "  Then the system responds",
         ]),
         encoding="utf-8",
     )
 
 
-def _write_feature(path: Path, scenario_name: str = "happy path") -> None:
+def _write_feature(path: Path, *, scenario_name: str = "happy path", step: str = "the system is ready") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         "\n".join([
-            "Feature: Example",
+            "Feature: Demo",
             "",
             f"  Scenario: {scenario_name}",
-            "    Given a precondition",
-            "    When an action runs",
-            "    Then an outcome is observed",
-            "",
+            f"    Given {step}",
+            "    When the user runs the demo",
+            "    Then the system responds",
         ]),
         encoding="utf-8",
     )
 
 
-def test_collect_sync_errors_reports_spec_without_feature(sync_checker: Any, tmp_path: Path) -> None:
-    _write_spec(tmp_path / "specs" / "orphan.spec")
-    (tmp_path / "tests" / "bdd" / "features").mkdir(parents=True)
+def test_collect_sync_errors_flags_missing_feature(tmp_path: Path, checker: Any) -> None:
+    _write_spec(tmp_path / "specs" / "demo.spec")
 
-    errors = sync_checker.collect_sync_errors(tmp_path)
+    errors = checker.collect_sync_errors(tmp_path)
 
-    assert errors == [
-        "❌ specs/orphan.spec: no matching tests/bdd/features/orphan.feature",
-    ]
-
-
-def test_collect_sync_errors_reports_spec_when_features_dir_is_missing(sync_checker: Any, tmp_path: Path) -> None:
-    _write_spec(tmp_path / "specs" / "orphan.spec")
-
-    errors = sync_checker.collect_sync_errors(tmp_path)
-
-    assert errors == [
-        "❌ specs/orphan.spec: no matching tests/bdd/features/orphan.feature",
-    ]
+    assert errors
+    assert "specs/demo.spec" in errors[0]
+    assert "tests/bdd/features/demo.feature" in errors[0]
 
 
-def test_collect_sync_errors_reports_feature_without_spec(sync_checker: Any, tmp_path: Path) -> None:
-    _write_feature(tmp_path / "tests" / "bdd" / "features" / "orphan.feature")
-    (tmp_path / "specs").mkdir()
+def test_collect_sync_errors_flags_orphan_feature(tmp_path: Path, checker: Any) -> None:
+    _write_feature(tmp_path / "tests" / "bdd" / "features" / "demo.feature")
 
-    errors = sync_checker.collect_sync_errors(tmp_path)
+    errors = checker.collect_sync_errors(tmp_path)
 
-    assert errors == [
-        "❌ tests/bdd/features/orphan.feature: no matching specs/orphan.spec",
-    ]
+    assert errors
+    assert "tests/bdd/features/demo.feature" in errors[0]
+    assert "specs/demo.spec" in errors[0]
 
 
-def test_collect_sync_errors_accepts_matching_spec_and_feature(sync_checker: Any, tmp_path: Path) -> None:
-    _write_spec(tmp_path / "specs" / "example.spec")
-    _write_feature(tmp_path / "tests" / "bdd" / "features" / "example.feature")
+def test_collect_sync_errors_accepts_e2e_feature_dir(tmp_path: Path, checker: Any) -> None:
+    _write_spec(tmp_path / "specs" / "demo.spec")
+    _write_feature(tmp_path / "tests" / "e2e" / "bdd" / "features" / "demo.feature")
 
-    assert sync_checker.collect_sync_errors(tmp_path) == []
+    errors = checker.collect_sync_errors(tmp_path)
+
+    assert errors == []
+
+
+def test_collect_sync_errors_reports_step_drift(tmp_path: Path, checker: Any) -> None:
+    _write_spec(tmp_path / "specs" / "demo.spec", step="the system is ready")
+    _write_feature(
+        tmp_path / "tests" / "bdd" / "features" / "demo.feature",
+        step="the system is definitely ready",
+    )
+
+    errors = checker.collect_sync_errors(tmp_path)
+
+    assert errors
+    assert "step drift" in errors[0]


### PR DESCRIPTION
## Summary

Fix harness drift around local web tasks and `.spec` / `.feature` enforcement.

- point `web-install`, `web-build`, `web-dev`, and `web-check` at `src/yaya/plugins/web`
- make `scripts/check_feature_sync.py` enforce both missing mirrors and extra mirrors across `tests/bdd/features/` and `tests/e2e/bdd/features/`
- add the missing mirrored `.feature` files for existing specs and regression tests for the sync checker
- update pre-commit's Ruff hook to a Py3.14-capable version and align stale coverage guidance in repo docs
- pin the existing BDD strategy-react tests to the intended `OPENAI_API_KEY` branch so they stay deterministic

## Type of change

Bug fix (`bug`)
CI / Infrastructure (`ci`)

## Component

`ci`

## Closes

Closes #86

## Spec

None. This PR tightens harness enforcement around existing specs rather than owning a single `specs/<slug>.spec`.

## Issue context used

- Issue: #86
- Agent Task Packet source: issue body
- Issue comments that changed the plan: None

## Deviations from issue/spec

None.

## Agent notes

- `uv run pre-commit run -a` still surfaces pre-existing trailing-whitespace churn in unrelated tracked files (`.github/ISSUE_TEMPLATE/*`, one generated web asset, and the help snapshot). I reverted those unrelated edits and validated the hooks relevant to this PR individually after fixing the broken Ruff hook pin.

## Test plan

- [x] Tests pass
- [x] Lints pass
- [x] Tested locally

## Verification evidence

- `just web-install`
- `just web-check`
- `uv run python scripts/check_feature_sync.py`
- `uv run python -m pytest tests/scripts/test_check_feature_sync.py -q`
- `uv run python -m pytest tests/bdd/test_plugins.py -q`
- `just check`
- `just test`
- `uv run pre-commit run ruff --all-files`
- `uv run pre-commit run ruff-format --all-files`
- `uv run pre-commit run check-banned-frameworks --all-files`
- `uv run pre-commit run feature-spec-sync --all-files`
- `uv run pre-commit run agent-spec-enforce --all-files`
