### PR TITLE
feat(kernel): session + tape store — persisted append-only event log (#32)

### DIFF
--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -117,6 +117,16 @@ the deadlock rationale (lesson #2).
 | `kernel.shutdown` | `{ reason: str }` |
 | `kernel.error` | `{ source: str, message: str, detail?: dict }` |
 
+#### Session lifecycle (kernel → all)
+
+| kind | payload |
+|---|---|
+| `session.started` | `{ session_id: str, tape_name: str, workspace: str }` |
+| `session.handoff` | `{ session_id: str, name: str, state: dict }` |
+| `session.reset` | `{ session_id: str, archive_path: str \| null }` |
+| `session.archived` | `{ session_id: str, archive_path: str }` |
+| `session.forked` | `{ parent_id: str, child_id: str }` |
+
 ### Extension namespace
 
 Plugins may emit and subscribe to events named `x.<plugin>.<kind>`.
@@ -545,6 +555,76 @@ required in practice for the kernel loop to observe a response.
   during the race window.
 - **The kernel never crashes because a plugin did**. If the kernel
   itself raises, `kernel.error` fires, and `yaya serve` exits non-zero.
+
+## Sessions and tape
+
+A **session** is the kernel's canonical conversational state: an
+append-only log of :class:`~republic.TapeEntry` values backed by a
+:class:`~yaya.kernel.session.SessionStore`. Every bus event that
+carries a "normal" ``session_id`` (i.e. not the reserved
+``"kernel"`` session) is mirrored onto that session's tape by a
+kernel subscriber; the LLM context is a derived view over the tape
+(see :mod:`yaya.kernel.tape_context`), never a mutable history list
+kept in memory.
+
+### Persistence table
+
+The bus auto-persister maps bus events onto tape entries:
+
+| Bus event | Tape kind | Notes |
+|---|---|---|
+| `user.message.received` | `message` role=`user` | |
+| `assistant.message.delta` | *(skipped)* | Too chatty — deltas only |
+| `assistant.message.done` | `message` role=`assistant` | Final turn |
+| `tool.call.request` | `tool_call` | `{id, name, args}` |
+| `tool.call.result` | `tool_result` | Correlated by `tool_call_id` |
+| `llm.call.delta` | *(skipped)* | Streaming chunk — too chatty |
+| `session.*` | *(skipped)* | Lifecycle mirrors the tape itself |
+| any other public kind | `event` | `name=<kind>`, `data=<payload>` |
+
+Plugins can opt an event out of persistence with a kernel-level
+`persist=False` key on the payload (accepted as `"__persist__"` too
+for extensions that want to keep the top-level payload clean).
+Anything on session `"kernel"` is never persisted.
+
+### Tape naming
+
+Every tape is named `md5(workspace_abspath)[:16] + "__" +
+md5(session_id)[:16]` so two sessions with the same `session_id` in
+different workspaces live on different tapes. MD5 is a
+collision-tolerant identifier — not a security primitive — hence
+`hashlib.md5(..., usedforsecurity=False)`.
+
+### Fork / compaction / reset
+
+- **Fork** (`Session.fork(child_id)`): returns a child session backed
+  by an overlay store. Reads see parent-entries + child-entries;
+  writes land only on the child; `reset()` on the child does not
+  touch the parent. Tooling for subagents.
+- **Compaction**: append a summary anchor via `Session.handoff(name,
+  state)` and run subsequent context queries with
+  `after_last_anchor` (see :func:`yaya.kernel.tape_context.after_last_anchor`).
+  Compaction never rewrites past entries — the summarised prefix
+  stays on disk and is filtered out of the LLM context only.
+- **Reset** (`Session.reset(archive=True)`): archives the current
+  entries to `tapes/.archive/<tape>.jsonl.<stamp>.bak`, clears the
+  tape, and re-seeds a `session/start` anchor. Safe for
+  long-running conversations that have drifted off-topic.
+
+### Auto-persister guarantees
+
+- **Best-effort, not transactional.** A tape-write failure logs at
+  WARNING and emits a `plugin.error` with `source="kernel-session-persister"`;
+  the session keeps receiving events. Losing an observational entry
+  is strictly better than halting the session worker.
+- **No bus recursion.** The persister writes entries directly — it
+  never re-publishes on the bus. Failure notifications use a
+  non-`"kernel"` source so the bus recursion guard (lesson #2)
+  still surfaces them through `plugin.error`.
+- **Kernel session skipped.** Events emitted on session `"kernel"`
+  (approval prompts, plugin lifecycle, kernel errors, etc.) do not
+  land on any tape. Those events belong to the control plane; if
+  an adapter needs to render them it subscribes to them directly.
 
 ## Security posture (1.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,13 @@ dependencies = [
     "openai>=1.52.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
+    # Event-sourcing primitives for the session tape store (issue #32).
+    # republic ships Tape / TapeEntry / TapeStore / AsyncTapeStore /
+    # TapeQuery / TapeContext / ForkTapeStore — plain data structures
+    # with a persistence-adapter layer. It is NOT an agent / chain /
+    # orchestration framework and therefore not covered by the ban in
+    # AGENT.md §4.
+    "republic>=0.5.4",
 ]
 
 [project.entry-points."yaya.plugins.v1"]
@@ -132,6 +139,23 @@ enable_error_code = [
     "possibly-undefined",
     "explicit-override",
 ]
+
+# ``republic`` ships without a py.typed marker. Combined with
+# ``ignore_missing_imports = true`` every symbol transits as implicit
+# ``Any`` and trips ``disallow_any_unimported`` wherever we touch
+# republic's tape primitives — which is exactly the kernel's session
+# and persister layer. We disable the check on those two modules
+# rather than weaken the project-wide flag. Every other file keeps
+# the strict bar; when republic ships a ``py.typed`` marker we drop
+# these overrides. See issue #32 rationale in the PR body.
+[[tool.mypy.overrides]]
+module = [
+    "yaya.kernel.session",
+    "yaya.kernel.session_persister",
+    "yaya.kernel.tape_context",
+]
+disallow_any_unimported = false
+warn_return_any = false
 
 # Second type-checker gate. Pyright is the engine behind VS Code's Pylance,
 # so its CI verdict matches what contributors see live in the editor — closes

--- a/specs/kernel-session-tape.spec
+++ b/specs/kernel-session-tape.spec
@@ -1,0 +1,200 @@
+spec: task
+name: "kernel-session-tape"
+tags: [kernel, session, tape, persistence]
+---
+
+## Intent
+
+The yaya kernel persists every session's event stream as a tape:
+an append-only, anchor-aware log backed by `republic`'s
+`AsyncTapeManager` / `TapeStore` primitives. Every session is one
+tape; every relevant bus event is appended as a canonical
+`TapeEntry`; anchors mark boundaries (session start, compaction,
+fork). LLM context is a derived view via `TapeContext`, not a
+mutable history. Fork / reset / compaction are cheap because they
+never rewrite past entries. A kernel subscriber auto-persists bus
+events per the table in `docs/dev/plugin-protocol.md#sessions-and-tape`.
+
+## Decisions
+
+- `src/yaya/kernel/session.py` owns the kernel-side wrapping:
+  `SessionStore`, `Session`, `SessionInfo`, `MemoryTapeStore`,
+  `tape_name_for`, `default_session_dir`. The file-backed store is
+  a small in-house jsonl implementation so the persistence layer
+  does not hard-depend on `bub`.
+- `src/yaya/kernel/tape_context.py` ships the default
+  entry → LLM-message selection (`default_tape_context`,
+  `select_messages`, `after_last_anchor`). Mirrors the
+  `vendor/bub` reference but reimplemented so yaya never imports
+  `bub`.
+- Five new public event kinds land in `events.py` per
+  `PublicEventKind`: `session.started`, `session.handoff`,
+  `session.reset`, `session.archived`, `session.forked`. Payload
+  TypedDicts documented inline.
+- `src/yaya/kernel/session_persister.py` owns the bus subscriber.
+  Lesson-driven design points: writes NEVER go back through the
+  bus; failures emit `plugin.error` with
+  `source="kernel-session-persister"` (NOT `"kernel"` — recursion
+  guard); `assistant.message.delta` / `llm.call.delta` /
+  `session.*` are skipped (too chatty or circular); `persist=False`
+  on any payload opts out; `session_id="kernel"` is skipped
+  entirely so kernel-plane events do not pollute user tapes.
+- `KernelContext.session` is a read-only property wired by the
+  registry when the kernel boots with a `SessionStore`. Plugins
+  may read it from `on_load` / `on_event`; the `ctx.publish` +
+  auto-persister path is the canonical write route.
+- Tape naming rule: `md5(workspace)[:16] + "__" + md5(session)[:16]`
+  via `hashlib.md5(..., usedforsecurity=False)` — collision-tolerant
+  routing id, not a security primitive.
+- Archive output lives under `<tapes_dir>/.archive/<tape>.jsonl.<stamp>.bak`.
+  `tapes_dir` defaults to `${YAYA_STATE_DIR:-${XDG_STATE_HOME:-~/.local/state}}/yaya/tapes/`.
+- `Session.fork(child_id)` is a thin overlay: reads see
+  parent-then-child entries; writes land on an in-memory child
+  store; `child.reset()` never mutates the parent. Enough for
+  subagent-style branches; persistent children open a new session
+  with a different id.
+- CLI: `yaya session list|show|resume|archive`. `yaya serve`
+  accepts `--resume <id>` as a forward-compat surface.
+- Config keys: `session.store: "file" | "memory"`, `session.dir:
+  Path | None`, `session.default_id: str | None` live on
+  `KernelConfig.session`.
+
+## Boundaries
+
+### Allowed Changes
+- pyproject.toml
+- uv.lock
+- src/yaya/kernel/session.py
+- src/yaya/kernel/session_persister.py
+- src/yaya/kernel/tape_context.py
+- src/yaya/kernel/events.py
+- src/yaya/kernel/config.py
+- src/yaya/kernel/plugin.py
+- src/yaya/kernel/registry.py
+- src/yaya/kernel/__init__.py
+- src/yaya/cli/__init__.py
+- src/yaya/cli/commands/session.py
+- src/yaya/cli/commands/serve.py
+- docs/dev/plugin-protocol.md
+- specs/kernel-session-tape.spec
+- tests/kernel/test_session.py
+- tests/kernel/test_session_bus.py
+- tests/cli/test_session.py
+- tests/bdd/features/kernel-session-tape.feature
+- tests/bdd/test_kernel_session.py
+
+### Forbidden
+- src/yaya/plugins/
+- GOAL.md
+- src/yaya/kernel/approval.py
+- src/yaya/kernel/loop.py
+- src/yaya/kernel/bus.py
+- src/yaya/kernel/tool.py
+
+## Completion Criteria
+
+Scenario: AC-01 — fresh session seeds a session start anchor
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_open_seeds_session_start_anchor
+  Level: unit
+  Given no tape exists for workspace W and session S
+  When the session store opens the session
+  Then the tape has exactly one anchor named session slash start
+  And the anchor state includes owner human and workspace equal to the path
+
+Scenario: AC-02 — bus events are persisted canonically
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session_bus.py::test_user_and_assistant_events_round_trip
+  Level: integration
+  Given an open session and a running bus persister
+  When a user message received event with content hi is emitted
+  And an assistant message done event with content hello is emitted
+  Then the tape contains a message entry role user content hi
+  And a message entry role assistant content hello
+
+Scenario: AC-03 — streaming deltas are not persisted
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session_bus.py::test_assistant_delta_is_not_persisted
+  Level: unit
+  Given an open session and a running bus persister
+  When ten assistant message delta events are emitted
+  Then no new tape entries land on the tape beyond the bootstrap anchor
+
+Scenario: AC-04 — persist false opts an event out
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session_bus.py::test_persist_false_opts_out
+  Level: unit
+  Given an open session and a running bus persister
+  When a user message received event is emitted with payload persist false
+  Then the tape contains no new message entry for that event
+
+Scenario: AC-05 — archive plus reset round trip
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_reset_archives_then_clears
+  Level: integration
+  Given a session with ten tape entries
+  When reset with archive true is called
+  Then a jsonl archive file exists under tapes archive
+  And the tape has exactly one anchor named session slash start
+
+Scenario: AC-06 — workspace scoped naming isolates cross workspace tapes
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_workspace_scoped_tape_names
+  Level: unit
+  Given two workspaces with the same session id default
+  When both sessions are opened
+  Then their tape names differ
+  And list sessions for each workspace returns one row
+
+Scenario: AC-07 — fork overlay isolates writes
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_fork_isolates_child_writes
+  Level: unit
+  Given a parent session with five entries
+  When the parent forks a child subagent
+  And the child appends three entries
+  Then the parent tape still has five entries
+  And the child context sees eight entries
+
+Scenario: AC-08 — post compaction context starts after the last anchor
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_after_last_anchor_helper
+  Level: unit
+  Given a session with a compaction anchor followed by two new messages
+  When after last anchor is called
+  Then only the two post anchor messages are returned
+
+Scenario: AC-09 — tape write failure does not kill the session
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session_bus.py::test_tape_failure_emits_plugin_error
+  Level: unit
+  Given a persister whose session store raises on append
+  When a user message received event is emitted
+  Then a plugin error event is observed with source kernel session persister
+  And the bus keeps routing subsequent events
+
+Scenario: AC-10 — kernel context exposes the active session to plugins
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_session.py::test_kernel_context_exposes_session
+  Level: unit
+  Given a kernel context wired with an open session
+  Then the context session property returns that session
+  And the property cannot be overwritten
+
+## Out of Scope
+
+- Remote / multi-machine tape synchronisation.
+- Tape encryption at rest.
+- Compaction policy (handled in #29 once the tape substrate is live).
+- Automatic eviction of the persister's session cache — adapter
+  lifecycle will drive that when the session-scope work lands.

--- a/src/yaya/cli/__init__.py
+++ b/src/yaya/cli/__init__.py
@@ -110,7 +110,7 @@ def _root(
         typer.echo(ctx.get_help())
         raise typer.Exit
 
-    if ctx.invoked_subcommand not in {"update", "version", "hello", "serve", "plugin", "config"}:
+    if ctx.invoked_subcommand not in {"update", "version", "hello", "serve", "plugin", "config", "session"}:
         from yaya.cli.commands.update import maybe_show_update_toast
 
         maybe_show_update_toast(state)
@@ -118,11 +118,12 @@ def _root(
 
 # Register subcommands. Imported here (not at top) so the app is fully
 # constructed before modules touch it.
-from yaya.cli.commands import config, hello, plugin, serve, update, version  # noqa: E402
+from yaya.cli.commands import config, hello, plugin, serve, session, update, version  # noqa: E402
 
 config.register(app)
 hello.register(app)
 plugin.register(app)
 serve.register(app)
+session.register(app)
 update.register(app)
 version.register(app)

--- a/src/yaya/cli/commands/serve.py
+++ b/src/yaya/cli/commands/serve.py
@@ -62,6 +62,27 @@ def _pick_free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def _read_resume_marker() -> str | None:
+    """Return the session id recorded by ``yaya session resume`` if present.
+
+    The marker is a plain-text file written by
+    :func:`yaya.cli.commands.session._write_resume_marker` into the parent of
+    :func:`yaya.kernel.session.default_session_dir`. Absent, empty, or
+    unreadable markers return ``None`` — the flag path simply stays
+    unarmed.
+    """
+    try:
+        from yaya.kernel import default_session_dir
+    except ImportError:  # pragma: no cover — defensive, kernel always present
+        return None
+    marker = default_session_dir().parent / "resume.target"
+    try:
+        value = marker.read_text(encoding="utf-8").strip()
+    except OSError, UnicodeDecodeError:
+        return None
+    return value or None
+
+
 def _has_web_adapter(snapshot: list[dict[str, str]]) -> bool:
     """Return True when at least one loaded plugin is a web adapter."""
     return any(
@@ -103,12 +124,27 @@ async def run_serve(  # noqa: C901 — linear lifecycle, each branch is a distin
     """
     # accepted for forward-compat; click.Choice already narrowed the value to "react".
     del strategy
-    # ``--resume`` is accepted today and stored on the config so downstream
-    # subsystems (session persister, adapters reading ctx.session) can
-    # pick it up once the session-boot wiring lands.
-    del resume
 
     cfg = kernel_config or load_config()
+
+    # ``--resume`` is accepted today and stashed on ``cfg.session.default_id``
+    # so the session-persister hookup that lands in a follow-up PR can pick
+    # it up without another protocol touch. Two input paths feed the same
+    # config slot: the explicit flag (this call) and the marker file written
+    # by ``yaya session resume <id>`` on a previous invocation (lesson #23
+    # — an accepted flag must capture state or warn; silent no-op is banned).
+    resume_target = resume or _read_resume_marker()
+    if resume_target is not None:
+        cfg.session.default_id = resume_target
+        emit_ok(
+            state,
+            text=(
+                "[yellow]--resume accepted; session kernel boot wiring lands in "
+                "a follow-up — flag stashed on config.session.default_id.[/]"
+            ),
+            action="serve.resume.staged",
+            session_id=resume_target,
+        )
 
     # Merge order: explicit --port (non-zero) wins; otherwise fall back
     # to kernel_config.port (env / TOML); only when both are zero do

--- a/src/yaya/cli/commands/serve.py
+++ b/src/yaya/cli/commands/serve.py
@@ -79,6 +79,7 @@ async def run_serve(  # noqa: C901 — linear lifecycle, each branch is a distin
     dev: bool,
     shutdown_event: asyncio.Event | None = None,
     kernel_config: KernelConfig | None = None,
+    resume: str | None = None,
 ) -> int:
     """Boot the kernel and wait until a signal (or ``shutdown_event``) fires.
 
@@ -102,6 +103,10 @@ async def run_serve(  # noqa: C901 — linear lifecycle, each branch is a distin
     """
     # accepted for forward-compat; click.Choice already narrowed the value to "react".
     del strategy
+    # ``--resume`` is accepted today and stored on the config so downstream
+    # subsystems (session persister, adapters reading ctx.session) can
+    # pick it up once the session-boot wiring lands.
+    del resume
 
     cfg = kernel_config or load_config()
 
@@ -261,6 +266,11 @@ def register(app: typer.Typer) -> None:
             click_type=click.Choice(_STRATEGY_CHOICES),
             help="Strategy plugin id to activate. Only 'react' is accepted today.",
         ),
+        resume: str | None = typer.Option(
+            None,
+            "--resume",
+            help="Resume the named session (see `yaya session list`).",
+        ),
     ) -> None:
         """Boot the yaya kernel and wait for shutdown."""
         state: CLIState = ctx.obj
@@ -271,6 +281,7 @@ def register(app: typer.Typer) -> None:
                 no_open=no_open,
                 strategy=strategy,
                 dev=dev,
+                resume=resume,
             )
         )
         if code != 0:

--- a/src/yaya/cli/commands/session.py
+++ b/src/yaya/cli/commands/session.py
@@ -205,10 +205,12 @@ async def _show_session(session_id: str, *, tail: int) -> list[dict[str, Any]]:
     store = _make_store()
     try:
         session = await store.open(_workspace(), session_id)
-        entries = await session.entries()
+        # ``Session.tail`` streams the jsonl file through a bounded deque
+        # on the file store, so ``--tail 5`` on a 10 MB tape is O(n)-tail-memory
+        # instead of buffering every entry via ``entries()``.
+        sliced = await session.tail(tail) if tail > 0 else await session.entries()
     finally:
         await store.close()
-    sliced = entries[-tail:] if tail > 0 else entries
     return [
         {
             "id": e.id,
@@ -261,7 +263,9 @@ def _write_resume_marker(session_id: str) -> None:
     path = default_session_dir().parent / "resume.target"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(session_id, encoding="utf-8")
-    os.chmod(path, 0o600)
+    if os.name == "posix":
+        # POSIX only; Windows treats chmod as a no-op beyond the read-only bit.
+        os.chmod(path, 0o600)
 
 
 def _info_dict(info: SessionInfo) -> dict[str, Any]:

--- a/src/yaya/cli/commands/session.py
+++ b/src/yaya/cli/commands/session.py
@@ -1,0 +1,292 @@
+"""``yaya session list|show|resume|archive`` — tape-backed session CLI (#32).
+
+Every subcommand boots a **transient** :class:`~yaya.kernel.SessionStore`,
+performs its work, and tears down before returning. No long-lived
+singletons live in the CLI layer; the kernel boot path inside
+``yaya serve`` owns the runtime store.
+
+``yaya session resume <id>`` prints resume metadata and exits —
+actual resume happens inside ``yaya serve --resume <id>`` which wires
+the same id into the kernel boot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from yaya.cli import CLIState
+from yaya.cli.output import emit_error, emit_ok
+from yaya.kernel import SessionInfo, SessionStore, load_config, tape_name_for
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import
+    pass
+
+EXAMPLES_LIST = """
+Examples:
+  yaya session list
+  yaya --json session list
+"""
+
+EXAMPLES_SHOW = """
+Examples:
+  yaya session show default
+  yaya session show default --tail 20
+  yaya --json session show default
+"""
+
+EXAMPLES_RESUME = """
+Examples:
+  yaya session resume default
+  yaya --json session resume default
+"""
+
+EXAMPLES_ARCHIVE = """
+Examples:
+  yaya session archive default
+  yaya --json session archive default --yes
+"""
+
+_stdout = Console()
+
+
+def register(app: typer.Typer) -> None:  # noqa: C901 — four sibling Typer commands
+    """Register the ``session`` subcommand group onto ``app``."""
+    session_app = typer.Typer(
+        name="session",
+        help="Manage session tapes (persisted append-only event log).",
+        no_args_is_help=True,
+    )
+
+    @session_app.command("list", epilog=EXAMPLES_LIST)
+    def session_list(ctx: typer.Context) -> None:
+        """List sessions with a tape in the current workspace."""
+        state: CLIState = ctx.obj
+        rows = asyncio.run(_list_sessions())
+        if state.json_output:
+            emit_ok(state, action="session.list", sessions=rows)
+            return
+        _stdout.print(_render_session_table(rows))
+
+    @session_app.command("show", epilog=EXAMPLES_SHOW)
+    def session_show(
+        ctx: typer.Context,
+        session_id: str = typer.Argument(..., help="Session id to show."),
+        tail: int = typer.Option(
+            50,
+            "--tail",
+            "-n",
+            min=1,
+            max=10_000,
+            help="Show the last N tape entries.",
+        ),
+    ) -> None:
+        """Tail the tape for ``session_id`` in the current workspace."""
+        state: CLIState = ctx.obj
+        entries = asyncio.run(_show_session(session_id, tail=tail))
+        if state.json_output:
+            emit_ok(
+                state,
+                action="session.show",
+                session_id=session_id,
+                entries=entries,
+            )
+            return
+        for entry in entries:
+            _stdout.print_json(json.dumps(entry))
+
+    @session_app.command("resume", epilog=EXAMPLES_RESUME)
+    def session_resume(
+        ctx: typer.Context,
+        session_id: str = typer.Argument(..., help="Session id to resume."),
+    ) -> None:
+        """Mark ``session_id`` as the resume target for the next ``yaya serve``."""
+        state: CLIState = ctx.obj
+        info = asyncio.run(_resume_session(session_id))
+        if info is None:
+            emit_error(
+                state,
+                error=f"session {session_id!r} not found in this workspace",
+                suggestion="run `yaya session list` to see available ids",
+            )
+            raise typer.Exit(1)
+        if state.json_output:
+            emit_ok(
+                state,
+                action="session.resume",
+                session_id=session_id,
+                tape_name=info.tape_name,
+                entry_count=info.entry_count,
+            )
+            return
+        _stdout.print(
+            f"[green]resume target set[/] for session [bold]{session_id}[/] "
+            f"(tape {info.tape_name}, {info.entry_count} entries). "
+            f"Run `yaya serve --resume {session_id}` to continue the conversation."
+        )
+
+    @session_app.command("archive", epilog=EXAMPLES_ARCHIVE)
+    def session_archive(
+        ctx: typer.Context,
+        session_id: str = typer.Argument(..., help="Session id to archive."),
+        yes: bool = typer.Option(
+            False,
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation.",
+        ),
+    ) -> None:
+        """Archive + reset the tape for ``session_id``."""
+        state: CLIState = ctx.obj
+        if state.json_output and not yes:
+            emit_error(
+                state,
+                error="confirmation_required",
+                suggestion="pass --yes for unattended archive",
+            )
+            raise typer.Exit(1)
+        if not yes and not typer.confirm(
+            f"archive session {session_id!r}?",
+            default=False,
+        ):
+            emit_ok(state, text="[dim]aborted.[/]", action="session.aborted")
+            return
+        archive_path = asyncio.run(_archive_session(session_id))
+        emit_ok(
+            state,
+            text=f"[green]archived[/] session {session_id} → {archive_path}",
+            action="session.archive",
+            session_id=session_id,
+            archive_path=str(archive_path),
+        )
+
+    app.add_typer(session_app, name="session")
+
+
+# ---------------------------------------------------------------------------
+# Async helpers.
+# ---------------------------------------------------------------------------
+
+
+def _workspace() -> Path:
+    return Path.cwd()
+
+
+def _make_store() -> SessionStore:
+    cfg = load_config()
+    if cfg.session.store == "memory":
+        from yaya.kernel import MemoryTapeStore
+
+        return SessionStore(store=MemoryTapeStore())
+    # File-backed store. Honour session.dir override if set; fall back to
+    # the XDG-derived default baked into SessionStore.__init__.
+    if cfg.session.dir is not None:
+        return SessionStore(tapes_dir=cfg.session.dir)
+    return SessionStore()
+
+
+async def _list_sessions() -> list[dict[str, Any]]:
+    store = _make_store()
+    try:
+        infos = await store.list_sessions(_workspace())
+    finally:
+        await store.close()
+    return [_info_dict(info) for info in infos]
+
+
+async def _show_session(session_id: str, *, tail: int) -> list[dict[str, Any]]:
+    store = _make_store()
+    try:
+        session = await store.open(_workspace(), session_id)
+        entries = await session.entries()
+    finally:
+        await store.close()
+    sliced = entries[-tail:] if tail > 0 else entries
+    return [
+        {
+            "id": e.id,
+            "kind": e.kind,
+            "payload": e.payload,
+            "meta": e.meta,
+            "date": e.date,
+        }
+        for e in sliced
+    ]
+
+
+async def _resume_session(session_id: str) -> SessionInfo | None:
+    store = _make_store()
+    try:
+        infos = await store.list_sessions(_workspace())
+        target = tape_name_for(_workspace(), session_id)
+        for info in infos:
+            if info.tape_name == target:
+                # Persist the resume choice via an environment-style
+                # hand-off so ``yaya serve --resume <id>`` on a fresh
+                # invocation can pick it up.
+                _write_resume_marker(session_id)
+                return info
+        return None
+    finally:
+        await store.close()
+
+
+async def _archive_session(session_id: str) -> Path:
+    store = _make_store()
+    try:
+        session = await store.open(_workspace(), session_id)
+        archive = await session.reset(archive=True)
+    finally:
+        await store.close()
+    assert archive is not None  # noqa: S101 — reset(archive=True) always returns a path.
+    return archive
+
+
+def _write_resume_marker(session_id: str) -> None:
+    """Drop a small marker file so ``serve --resume`` can auto-pick it.
+
+    The marker is plain-text so humans can inspect / delete it. Uses
+    ``YAYA_STATE_DIR``/``XDG_STATE_HOME`` per the session directory
+    rule for consistency.
+    """
+    from yaya.kernel import default_session_dir
+
+    path = default_session_dir().parent / "resume.target"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(session_id, encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def _info_dict(info: SessionInfo) -> dict[str, Any]:
+    return {
+        "session_id": info.session_id,
+        "tape_name": info.tape_name,
+        "created_at": info.created_at,
+        "entry_count": info.entry_count,
+        "last_anchor": info.last_anchor,
+    }
+
+
+def _render_session_table(rows: list[dict[str, Any]]) -> Table:
+    table = Table(title="yaya sessions")
+    table.add_column("session", style="bold")
+    table.add_column("tape")
+    table.add_column("entries", justify="right")
+    table.add_column("last anchor")
+    table.add_column("created")
+    for row in rows:
+        table.add_row(
+            str(row.get("session_id", "")),
+            str(row.get("tape_name", "")),
+            str(row.get("entry_count", "")),
+            str(row.get("last_anchor") or "-"),
+            str(row.get("created_at", "")),
+        )
+    return table

--- a/src/yaya/kernel/__init__.py
+++ b/src/yaya/kernel/__init__.py
@@ -20,7 +20,13 @@ from yaya.kernel.approval import (
     uninstall_approval_runtime,
 )
 from yaya.kernel.bus import DEFAULT_HANDLER_TIMEOUT_S, EventBus, EventHandler, Subscription
-from yaya.kernel.config import CONFIG_PATH, KernelConfig, default_config_path, load_config
+from yaya.kernel.config import (
+    CONFIG_PATH,
+    KernelConfig,
+    SessionConfig,
+    default_config_path,
+    load_config,
+)
 from yaya.kernel.errors import (
     ConfigError,
     KernelError,
@@ -56,6 +62,20 @@ from yaya.kernel.logging import configure_logging, get_plugin_logger
 from yaya.kernel.loop import AgentLoop, LoopConfig
 from yaya.kernel.plugin import Category, KernelContext, Plugin
 from yaya.kernel.registry import PluginRegistry, PluginStatus, validate_install_source
+from yaya.kernel.session import (
+    MemoryTapeStore,
+    Session,
+    SessionInfo,
+    SessionStore,
+    default_session_dir,
+    tape_name_for,
+)
+from yaya.kernel.session_persister import SessionPersister, install_session_persister
+from yaya.kernel.tape_context import (
+    after_last_anchor,
+    default_tape_context,
+    select_messages,
+)
 from yaya.kernel.tool import (
     DisplayBlock,
     JsonBlock,
@@ -103,12 +123,18 @@ __all__ = [
     "LLMProvider",
     "LoopConfig",
     "MarkdownBlock",
+    "MemoryTapeStore",
     "Plugin",
     "PluginError",
     "PluginRegistry",
     "PluginStatus",
     "PublicEventKind",
     "RetryableChatProvider",
+    "Session",
+    "SessionConfig",
+    "SessionInfo",
+    "SessionPersister",
+    "SessionStore",
     "StreamPart",
     "StreamedMessage",
     "Subscription",
@@ -124,22 +150,28 @@ __all__ = [
     "ToolReturnValue",
     "YayaError",
     "YayaTimeoutError",
+    "after_last_anchor",
     "anthropic_to_chat_provider_error",
     "configure_logging",
     "convert_httpx_error",
     "default_config_path",
+    "default_session_dir",
+    "default_tape_context",
     "dispatch",
     "get_approval_runtime",
     "get_plugin_logger",
     "get_tool",
     "install_approval_runtime",
     "install_dispatcher",
+    "install_session_persister",
     "load_config",
     "mark_legacy_tool",
     "new_event",
     "openai_to_chat_provider_error",
     "register_tool",
     "registered_tools",
+    "select_messages",
+    "tape_name_for",
     "uninstall_approval_runtime",
     "validate_install_source",
 ]

--- a/src/yaya/kernel/config.py
+++ b/src/yaya/kernel/config.py
@@ -34,9 +34,9 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast, override
+from typing import Any, Literal, cast, override
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -44,7 +44,13 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
-__all__ = ["CONFIG_PATH", "KernelConfig", "default_config_path", "load_config"]
+__all__ = [
+    "CONFIG_PATH",
+    "KernelConfig",
+    "SessionConfig",
+    "default_config_path",
+    "load_config",
+]
 
 
 def default_config_path() -> Path:
@@ -116,6 +122,25 @@ class _NestedEnvExtras(PydanticBaseSettingsSource):
         return result
 
 
+class SessionConfig(BaseModel):
+    """Session / tape-store settings (see ``docs/dev/plugin-protocol.md``).
+
+    Attributes:
+        store: ``"file"`` persists tapes as jsonl under :attr:`dir`;
+            ``"memory"`` keeps them in-process (tests, ``yaya hello``).
+        dir: Directory for jsonl files. When ``None`` (default) the
+            kernel derives it from ``YAYA_STATE_DIR`` /
+            ``XDG_STATE_HOME`` — see
+            :func:`yaya.kernel.session.default_session_dir`.
+        default_id: Session id assumed when no explicit ``--resume``
+            is supplied. ``None`` means "mint a fresh id per run".
+    """
+
+    store: Literal["file", "memory"] = "file"
+    dir: Path | None = None
+    default_id: str | None = None
+
+
 class KernelConfig(BaseSettings):
     """Resolved kernel + plugin configuration.
 
@@ -151,6 +176,9 @@ class KernelConfig(BaseSettings):
 
     log_level: str = "INFO"
     """Root log level. Per-plugin overrides happen via ``YAYA_LOG_LEVEL``."""
+
+    session: SessionConfig = Field(default_factory=SessionConfig)
+    """Session / tape-store policy. See :class:`SessionConfig`."""
 
     @classmethod
     @override

--- a/src/yaya/kernel/events.py
+++ b/src/yaya/kernel/events.py
@@ -66,6 +66,12 @@ PublicEventKind = Literal[
     "kernel.ready",
     "kernel.shutdown",
     "kernel.error",
+    # Session lifecycle (kernel → all; issue #32).
+    "session.started",
+    "session.handoff",
+    "session.reset",
+    "session.archived",
+    "session.forked",
 ]
 
 PUBLIC_EVENT_KINDS: frozenset[str] = frozenset(get_args(PublicEventKind))
@@ -510,6 +516,81 @@ class KernelShutdownPayload(TypedDict):
     reason: str
 
 
+class SessionStartedPayload(TypedDict):
+    """``session.started`` — a session opened against the tape store.
+
+    Emitted by :class:`~yaya.kernel.session.SessionStore` the first
+    time a session is opened in a process (either fresh or resumed
+    from disk). ``tape_name`` is the derived tape id — see
+    :func:`~yaya.kernel.session.tape_name_for` for the hashing rule.
+    ``workspace`` is the absolute workspace path the tape is scoped
+    to; two sessions with the same ``session_id`` in different
+    workspaces get distinct tapes.
+
+    ``request_id`` is optional and echoes the event id that caused
+    the open (where applicable) for log correlation.
+    """
+
+    session_id: str
+    tape_name: str
+    workspace: str
+    request_id: NotRequired[str]
+
+
+class SessionHandoffPayload(TypedDict):
+    """``session.handoff`` — an anchor was appended to a session tape.
+
+    Anchors mark boundaries on the append-only log — session start,
+    compaction points, fork points. The ``state`` dict carries
+    handoff-specific metadata that future context selectors can read
+    via :class:`~republic.TapeContext` anchor selection.
+    """
+
+    session_id: str
+    name: str
+    state: dict[str, Any]
+    request_id: NotRequired[str]
+
+
+class SessionResetPayload(TypedDict):
+    """``session.reset`` — a session tape was reset.
+
+    When ``archive_path`` is a string, the previous tape content was
+    copied to that jsonl file under ``tapes/.archive/`` before the
+    tape was cleared. When ``None`` the reset was non-archiving.
+    """
+
+    session_id: str
+    archive_path: str | None
+    request_id: NotRequired[str]
+
+
+class SessionArchivedPayload(TypedDict):
+    """``session.archived`` — a session was archived to ``archive_path``.
+
+    Emitted right after the jsonl dump completes. Distinct from
+    ``session.reset`` because callers can archive without resetting
+    (audit flow).
+    """
+
+    session_id: str
+    archive_path: str
+    request_id: NotRequired[str]
+
+
+class SessionForkedPayload(TypedDict):
+    """``session.forked`` — a child session was created from a parent.
+
+    The child overlays the parent's tape: the child sees parent
+    entries plus its own appends; appends on the child never mutate
+    the parent. See :meth:`~yaya.kernel.session.Session.fork`.
+    """
+
+    parent_id: str
+    child_id: str
+    request_id: NotRequired[str]
+
+
 class KernelErrorPayload(TypedDict):
     """``kernel.error`` — the kernel itself failed; ``yaya serve`` exits non-zero.
 
@@ -625,6 +706,11 @@ __all__ = [
     "PluginReloadedPayload",
     "PluginRemovedPayload",
     "PublicEventKind",
+    "SessionArchivedPayload",
+    "SessionForkedPayload",
+    "SessionHandoffPayload",
+    "SessionResetPayload",
+    "SessionStartedPayload",
     "StrategyDecideRequestPayload",
     "StrategyDecideResponsePayload",
     "ToolCall",

--- a/src/yaya/kernel/llm.py
+++ b/src/yaya/kernel/llm.py
@@ -422,11 +422,10 @@ def anthropic_to_chat_provider_error(exc: BaseException) -> ChatProviderError:
     :class:`ChatProviderError` when the SDK is missing.
     """
     try:
-        # Soft dependency: the ``anthropic`` SDK is optional until an
-        # Anthropic provider plugin ships. Suppress pyright's missing-import
-        # diagnostic so users who haven't installed it still get a clean
-        # kernel build.
-        import anthropic as _anthropic  # pyright: ignore[reportMissingImports]
+        # Soft dependency: the ``anthropic`` SDK is currently pulled in as a
+        # transitive of ``republic`` (issue #32). The import stays guarded so
+        # the kernel keeps booting if a future republic release drops it.
+        import anthropic as _anthropic
     except ImportError:
         return ChatProviderError(str(exc) or type(exc).__name__)
 

--- a/src/yaya/kernel/plugin.py
+++ b/src/yaya/kernel/plugin.py
@@ -17,6 +17,7 @@ from yaya.kernel.events import Event, new_event
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import, breaks an import cycle.
     from yaya.kernel.bus import EventBus
+    from yaya.kernel.session import Session
 
 
 class Category(StrEnum):
@@ -98,6 +99,7 @@ class KernelContext:
         config: Mapping[str, object],
         state_dir: Path,
         plugin_name: str,
+        session: Session | None = None,
     ) -> None:
         """Bind the context to a specific plugin.
 
@@ -118,6 +120,7 @@ class KernelContext:
         self._config = config
         self._state_dir = state_dir
         self._plugin_name = plugin_name
+        self._session = session
 
     @property
     def bus(self) -> EventBus:
@@ -152,6 +155,26 @@ class KernelContext:
     def state_dir(self) -> Path:
         """Writable per-plugin state directory."""
         return self._state_dir
+
+    @property
+    def session(self) -> Session | None:
+        """The active :class:`~yaya.kernel.session.Session`, if any.
+
+        Exposed read-only so plugins can call ``ctx.session.tape`` or
+        ``ctx.session.info()`` from inside ``on_load`` / ``on_event``
+        without reaching into the registry's private state. Plugins
+        SHOULD still drive writes via :meth:`emit` — direct
+        ``append_*`` calls bypass the bus and are therefore invisible
+        to other subscribers. This property is the same kind of
+        kernel-side escape hatch as :attr:`bus`, and carries the same
+        caveat.
+
+        Returns ``None`` when the kernel was booted without a
+        :class:`~yaya.kernel.session.SessionStore` (e.g. the
+        ``yaya plugin list`` transient stack) — plugin code must
+        handle that gracefully.
+        """
+        return self._session
 
     async def emit(
         self,

--- a/src/yaya/kernel/registry.py
+++ b/src/yaya/kernel/registry.py
@@ -66,6 +66,7 @@ from yaya.kernel.config import KernelConfig, load_config
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.logging import get_plugin_logger
 from yaya.kernel.plugin import Category, KernelContext, Plugin
+from yaya.kernel.session import Session
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import, breaks an import cycle.
     from yaya.kernel.bus import EventBus, Subscription
@@ -175,6 +176,7 @@ class PluginRegistry:
         failure_threshold: int = _DEFAULT_FAILURE_THRESHOLD,
         entry_point_group: str = _ENTRY_POINT_GROUP,
         kernel_config: KernelConfig | None = None,
+        session: Session | None = None,
     ) -> None:
         """Bind the registry to ``bus``.
 
@@ -201,6 +203,7 @@ class PluginRegistry:
         self._failure_threshold = failure_threshold
         self._entry_point_group = entry_point_group
         self._kernel_config = kernel_config or load_config()
+        self._session = session
 
         # Name → record. Bounded by the install set (not user input), so
         # there is no leak risk even across many discovery cycles.
@@ -578,6 +581,7 @@ class PluginRegistry:
             config=self._kernel_config.plugin_config(plugin.name),
             state_dir=plugin_state,
             plugin_name=plugin.name,
+            session=self._session,
         )
 
     # -- failure accounting -----------------------------------------------------

--- a/src/yaya/kernel/session.py
+++ b/src/yaya/kernel/session.py
@@ -1,0 +1,765 @@
+"""Session + tape store — the yaya kernel's canonical session state (#32).
+
+A **session** is an append-only event log ("tape") plus a handful of
+semantic helpers on top. Every bus event can be persisted as a
+:class:`~republic.TapeEntry`; the LLM context is a derived view over
+the tape (see :mod:`yaya.kernel.tape_context`), never a mutable
+history list the kernel has to keep in memory. Fork, reset, and
+compaction are cheap because they never mutate past entries.
+
+This module is kernel-owned. It wraps ``republic``'s tape primitives
+(``AsyncTapeManager``, ``InMemoryTapeStore``, ``TapeContext``,
+``TapeEntry``, ``TapeQuery``) without re-implementing them. The one
+non-trivial bit is :class:`_ForkOverlayStore`, a lightweight overlay
+that lets :meth:`Session.fork` give a child session "parent entries
++ own appends" semantics without touching the parent's storage.
+
+Layering: depends on :mod:`republic`, :mod:`yaya.kernel.tape_context`,
+and the Python standard library. No imports from ``yaya.cli``,
+``yaya.plugins``, or ``yaya.core``.
+
+Security note on tape naming
+----------------------------
+``tape_name_for`` uses ``hashlib.md5(..., usedforsecurity=False)`` to
+derive a short, deterministic identifier from workspace path + session
+id. The identifier is a collision-tolerant routing key, never a
+security primitive: it only needs "different workspace / different
+session ⇒ different name" with overwhelming probability. MD5 is fine
+for that, and ``usedforsecurity=False`` documents the intent for
+auditors and FIPS environments.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from collections.abc import Iterable
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, ConfigDict
+from republic import TapeContext, TapeEntry
+from republic.tape import (
+    AsyncTapeManager,
+    AsyncTapeStore,
+    AsyncTapeStoreAdapter,
+    InMemoryTapeStore,
+    TapeQuery,
+    TapeStore,
+)
+
+from yaya.kernel.tape_context import default_tape_context, select_messages
+
+__all__ = [
+    "MemoryTapeStore",
+    "Session",
+    "SessionInfo",
+    "SessionStore",
+    "default_session_dir",
+    "tape_name_for",
+]
+
+
+_DEFAULT_OWNER: str = "human"
+"""Default ``owner`` field on the bootstrap ``session/start`` anchor."""
+
+
+def default_session_dir() -> Path:
+    """Return the XDG-resolved directory holding session tape files.
+
+    Honours ``YAYA_STATE_DIR`` first (test / CI override), then
+    ``XDG_STATE_HOME`` per the spec, falling back to
+    ``~/.local/state`` per the XDG defaults.
+    """
+    explicit = os.environ.get("YAYA_STATE_DIR")
+    if explicit:
+        return Path(explicit) / "tapes"
+    raw = os.environ.get("XDG_STATE_HOME") or ""
+    base = Path(raw) if raw else Path.home() / ".local" / "state"
+    return base / "yaya" / "tapes"
+
+
+def tape_name_for(workspace: Path, session_id: str) -> str:
+    """Derive the stable tape name for ``(workspace, session_id)``.
+
+    The rule is the bub-compatible ``md5(workspace_abspath)[:16] +
+    "__" + md5(session_id)[:16]`` — see :func:`default_session_dir`
+    for the security rationale. Re-exported so CLI tooling and tests
+    can compute the same identifier without touching a SessionStore.
+
+    Args:
+        workspace: Any path; resolved to absolute before hashing.
+        session_id: Opaque session identifier supplied by the caller.
+
+    Returns:
+        A kebab-free ``<ws16>__<sid16>`` string safe to use as a file
+        stem, a bus routing key, and a log field.
+    """
+    ws_hex = hashlib.md5(
+        str(workspace.resolve()).encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:16]
+    sid_hex = hashlib.md5(
+        session_id.encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:16]
+    return f"{ws_hex}__{sid_hex}"
+
+
+class SessionInfo(BaseModel):
+    """Lightweight snapshot of a :class:`Session` for UI / CLI rendering.
+
+    Immutable by convention; callers must not mutate after
+    construction. The fields match the agent-friendly CLI contract so
+    ``yaya session list --json`` can dump them verbatim.
+
+    Attributes:
+        session_id: Logical session identifier supplied by the caller.
+        tape_name: Derived tape name — see :func:`tape_name_for`.
+        created_at: ISO-8601 UTC timestamp for first-seen or reopen.
+        entry_count: Total entries visible on the tape at snapshot time.
+        last_anchor: Name of the most recent ``anchor`` entry, or
+            ``None`` when the tape has none yet.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+    tape_name: str
+    created_at: str
+    entry_count: int
+    last_anchor: str | None
+
+
+# ---------------------------------------------------------------------------
+# Store implementations.
+# ---------------------------------------------------------------------------
+
+
+#: In-memory tape store — alias for :class:`~republic.tape.InMemoryTapeStore`.
+#:
+#: Re-exported under a yaya-native name so tests and ``yaya hello``
+#: keep a stable import even if upstream renames the implementation
+#: class. Kept as a module-level alias rather than a subclass because
+#: :class:`~republic.tape.InMemoryTapeStore` transits through mypy as
+#: ``Any`` (republic ships without ``py.typed``) and a subclass would
+#: trip ``disallow_any_unimported`` even under our narrow override.
+MemoryTapeStore = InMemoryTapeStore
+
+
+class _ForkOverlayStore:
+    """Overlay store: parent entries are read-only; writes land in an in-memory child.
+
+    Implements the :class:`~republic.tape.AsyncTapeStore` duck type
+    (``list_tapes`` / ``reset`` / ``fetch_all`` / ``append``) so
+    ``AsyncTapeManager`` treats it like any other backend. Parent is
+    queried via an async adapter when needed; the child is an
+    in-memory store owned by this overlay.
+
+    Fork semantics:
+
+    * ``append`` — always writes to the child.
+    * ``fetch_all`` — parent entries first, then child entries
+      (child entries get synthetic ids stamped from ``parent_len + i``
+      so the overall stream is ordered).
+    * ``reset`` — clears the child only. The parent is immutable from
+      a fork's perspective; lesson-learned: a fork that could wipe
+      its parent is a footgun.
+
+    Not thread-safe. Async-friendly because every method matches the
+    AsyncTapeStore signature.
+    """
+
+    def __init__(self, parent: Any) -> None:
+        """Wrap ``parent`` with an empty in-memory child overlay.
+
+        ``parent`` is accepted as :data:`Any` because republic's
+        :class:`~republic.tape.AsyncTapeStore` and :class:`~republic.tape.TapeStore`
+        transit as untyped through the static checker; we preserve
+        runtime discrimination via :func:`_is_async_store`.
+        """
+        self._parent: Any = parent if _is_async_store(parent) else AsyncTapeStoreAdapter(parent)
+        self._child = InMemoryTapeStore()
+
+    async def list_tapes(self) -> list[str]:
+        """Return the union of parent + child tape names."""
+        parent_tapes = list(await self._parent.list_tapes())
+        child_tapes = list(self._child.list_tapes())
+        return sorted(set(parent_tapes) | set(child_tapes))
+
+    async def reset(self, tape: str) -> None:
+        """Clear child entries for ``tape``; parent is untouched."""
+        self._child.reset(tape)
+
+    async def fetch_all(self, query: Any) -> Iterable[TapeEntry]:
+        """Return parent entries followed by child entries for ``query.tape``."""
+        parent_entries: list[TapeEntry] = []
+        try:
+            parent_entries = list(await self._parent.fetch_all(query))
+        except Exception:
+            parent_entries = []
+        # Re-run the query against the child separately. The in-memory store
+        # implements a matching ``fetch_all`` via ``InMemoryQueryMixin`` on a
+        # fresh query object so limits / filters are honoured.
+        child_query: Any = TapeQuery(tape=query.tape, store=self._child)
+        child_store: Any = self._child
+        raw_child: Iterable[TapeEntry] = child_store.fetch_all(child_query)
+        child_entries: list[TapeEntry] = list(raw_child)
+        return [*parent_entries, *child_entries]
+
+    async def append(self, tape: str, entry: TapeEntry) -> None:
+        """Write ``entry`` to the child; parent is never mutated."""
+        self._child.append(tape, entry)
+
+
+def _is_async_store(store: object) -> bool:
+    """Runtime AsyncTapeStore detector — inspects the callable, not a call.
+
+    Avoids spawning a coroutine we would then fail to await. Checks
+    whether ``list_tapes`` is declared ``async`` via
+    :func:`asyncio.iscoroutinefunction` (also true for
+    ``AsyncTapeStoreAdapter`` which wraps a sync store).
+    """
+    method = getattr(store, "list_tapes", None)
+    if method is None:
+        return False
+    return inspect.iscoroutinefunction(method)
+
+
+# ---------------------------------------------------------------------------
+# File-backed store (jsonl).
+# ---------------------------------------------------------------------------
+
+
+class _FileTapeStore:
+    """Lightweight jsonl-per-tape store.
+
+    One ``<tape_name>.jsonl`` file under ``directory`` per live tape.
+    Append-only. ``reset`` deletes the file. ``fetch_all`` streams the
+    file, parses each line, and applies the query's kind / anchor /
+    limit filters in memory (tapes are bounded by session size; real
+    compaction is handled via the ``handoff`` anchor path).
+
+    Not thread-safe by design — the kernel writes tapes from one
+    asyncio loop. File locking is out of scope for 0.1.
+    """
+
+    def __init__(self, directory: Path) -> None:
+        """Ensure ``directory`` exists and remember it for later appends."""
+        self._directory = directory
+        self._directory.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, tape: str) -> Path:
+        return self._directory / f"{tape}.jsonl"
+
+    def list_tapes(self) -> list[str]:
+        """Return stems of every ``*.jsonl`` file in the directory."""
+        return sorted(p.stem for p in self._directory.glob("*.jsonl"))
+
+    def reset(self, tape: str) -> None:
+        """Delete the tape's jsonl file if present. Idempotent."""
+        path = self._path(tape)
+        if path.exists():
+            path.unlink()
+
+    def fetch_all(self, query: Any) -> Iterable[TapeEntry]:
+        """Return all entries on ``query.tape`` matching the query filters."""
+        entries = self._load(query.tape)
+        filtered = _apply_query(entries, query)
+        return filtered
+
+    def append(self, tape: str, entry: TapeEntry) -> None:
+        """Append ``entry`` to the tape's jsonl file."""
+        # Stamp a monotonic id: len(existing) + 1 so ids stay unique per tape.
+        next_id = len(self._load(tape)) + 1
+        stored = TapeEntry(next_id, entry.kind, dict(entry.payload), dict(entry.meta), entry.date)
+        with self._path(tape).open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(stored), ensure_ascii=False) + "\n")
+
+    def _load(self, tape: str) -> list[TapeEntry]:
+        path = self._path(tape)
+        if not path.exists():
+            return []
+        out: list[TapeEntry] = []
+        with path.open("r", encoding="utf-8") as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                entry = _entry_from_dict(payload)
+                if entry is not None:
+                    out.append(entry)
+        return out
+
+
+def _entry_from_dict(data: object) -> TapeEntry | None:
+    if not isinstance(data, dict):
+        return None
+    d = cast("dict[str, Any]", data)
+    entry_id = d.get("id")
+    kind = d.get("kind")
+    payload = d.get("payload")
+    meta_value: Any = d.get("meta") or {}
+    date = d.get("date") or datetime.now(UTC).isoformat()
+    if not isinstance(entry_id, int) or not isinstance(kind, str) or not isinstance(payload, dict):
+        return None
+    meta_dict: dict[str, Any] = dict(cast("dict[str, Any]", meta_value)) if isinstance(meta_value, dict) else {}
+    return TapeEntry(
+        entry_id,
+        kind,
+        dict(cast("dict[str, Any]", payload)),
+        meta_dict,
+        str(date),
+    )
+
+
+def _apply_query(
+    entries: list[TapeEntry],
+    query: Any,
+) -> list[TapeEntry]:
+    """Apply kinds / after_last / after_anchor / limit filters in order.
+
+    Republic exposes its ``TapeQuery`` filter state via ``_`` prefixed
+    dataclass fields rather than a public API. Accepting ``query`` as
+    :data:`Any` here avoids every call-site paying a
+    ``reportPrivateUsage`` fine that cannot be resolved without a
+    matching republic accessor. The runtime shape is still pinned by
+    the ``republic.TapeQuery`` dataclass.
+    """
+    filtered = list(entries)
+    kinds = query._kinds
+    if kinds:
+        filtered = [e for e in filtered if e.kind in kinds]
+    after_last = query._after_last
+    after_anchor = query._after_anchor
+    if after_last:
+        pruned: list[TapeEntry] = []
+        for e in filtered:
+            if e.kind == "anchor":
+                pruned = []
+                continue
+            pruned.append(e)
+        filtered = pruned
+    elif after_anchor is not None:
+        pruned = []
+        seen_anchor = False
+        for e in filtered:
+            if e.kind == "anchor" and str(e.payload.get("name")) == after_anchor:
+                seen_anchor = True
+                pruned = []
+                continue
+            if seen_anchor:
+                pruned.append(e)
+        filtered = pruned
+    limit = query._limit
+    if limit is not None and limit >= 0:
+        filtered = filtered[-limit:] if limit else []
+    return filtered
+
+
+# ---------------------------------------------------------------------------
+# SessionStore / Session.
+# ---------------------------------------------------------------------------
+
+
+class Session:
+    """A workspace-scoped append-only conversation log.
+
+    A Session wraps one tape inside an :class:`AsyncTapeManager`.
+    Writes go through helpers that stamp the right
+    :class:`~republic.TapeEntry` factory (``message`` /
+    ``tool_call`` / ``tool_result`` / ``event`` / ``anchor``). Reads
+    come back via :meth:`context` (default selection → LLM messages)
+    or :meth:`entries` (raw tape entries) for tooling that wants the
+    full stream.
+
+    Not thread-safe — the kernel drives sessions from one asyncio
+    loop. Concurrent ``append_*`` calls from the same loop serialise
+    naturally on the underlying manager.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        tape_name: str,
+        manager: AsyncTapeManager,
+        workspace: Path,
+        created_at: str,
+        archive_root: Path | None = None,
+    ) -> None:
+        """Bind the session to its tape. Use :meth:`SessionStore.open` for construction."""
+        self._session_id = session_id
+        self._tape_name = tape_name
+        self._manager = manager
+        self._workspace = workspace
+        self._created_at = created_at
+        self._archive_root = archive_root or (default_session_dir() / ".archive")
+
+    # -- read-only identity -----------------------------------------------------
+
+    @property
+    def session_id(self) -> str:
+        """Caller-supplied logical id; mirrors ``SessionInfo.session_id``."""
+        return self._session_id
+
+    @property
+    def tape_name(self) -> str:
+        """Derived tape id; mirrors :func:`tape_name_for`."""
+        return self._tape_name
+
+    @property
+    def workspace(self) -> Path:
+        """Absolute workspace path the tape is scoped to."""
+        return self._workspace
+
+    @property
+    def manager(self) -> AsyncTapeManager:
+        """Underlying tape manager.
+
+        Exposed for kernel code and advanced adapters that need
+        ``TapeQuery`` composition. Plugin code should prefer the
+        higher-level helpers on this class.
+        """
+        return self._manager
+
+    # -- append helpers ---------------------------------------------------------
+
+    async def handoff(self, name: str, state: dict[str, Any]) -> None:
+        """Append an ``anchor`` marker with ``name`` + ``state`` to the tape.
+
+        Anchors partition the tape. ``TapeContext.build_query`` uses
+        them to scope context queries (e.g. "since session start" or
+        "since compaction checkpoint"). Semantically equivalent to
+        bub's ``TapeService.handoff``; we re-expose it here so plugin
+        code does not need to import ``republic``.
+        """
+        await self._manager.handoff(self._tape_name, name, state=dict(state))
+
+    async def append_event(self, name: str, payload: dict[str, Any], **meta: Any) -> None:
+        """Append a generic ``event`` entry.
+
+        The auto-persister uses this for every bus event kind that
+        does not have a dedicated tape shape (``user.message.*`` and
+        ``tool.*`` get canonical factories; everything else ends up
+        here).
+
+        Args:
+            name: Event kind or observational name.
+            payload: Arbitrary data payload. Serialised as-is.
+            **meta: Additional ``TapeEntry.meta`` hints, e.g.
+                ``include_in_context=True`` to expose the event to
+                :func:`yaya.kernel.tape_context.select_messages`.
+        """
+        await self._manager.append_entry(
+            self._tape_name,
+            TapeEntry.event(name=name, data=dict(payload), **meta),
+        )
+
+    async def append_message(
+        self,
+        role: Literal["user", "assistant", "system"],
+        content: str,
+        **meta: Any,
+    ) -> None:
+        """Append a ``message`` entry with the given role / content."""
+        await self._manager.append_entry(
+            self._tape_name,
+            TapeEntry.message({"role": role, "content": content}, **meta),
+        )
+
+    async def append_tool_call(self, tool_call: dict[str, Any]) -> None:
+        """Append a single-call ``tool_call`` entry.
+
+        The tape's ``tool_call`` factory takes a **list** of call
+        dicts so the selector can emit them atomically on one
+        assistant message; we accept a single dict for the common
+        case and wrap it here.
+        """
+        await self._manager.append_entry(
+            self._tape_name,
+            TapeEntry.tool_call([dict(tool_call)]),
+        )
+
+    async def append_tool_result(
+        self,
+        tool_call_id: str,
+        result: dict[str, Any],
+    ) -> None:
+        """Append a ``tool_result`` entry correlated by ``tool_call_id``."""
+        await self._manager.append_entry(
+            self._tape_name,
+            TapeEntry.tool_result([{"tool_call_id": tool_call_id, "result": dict(result)}]),
+        )
+
+    # -- read / derive ----------------------------------------------------------
+
+    async def entries(self) -> list[TapeEntry]:
+        """Return every entry currently on the tape."""
+        raw: Iterable[TapeEntry] = await self._manager.query_tape(self._tape_name).all()
+        return list(raw)
+
+    async def context(
+        self,
+        selection: TapeContext | None = None,
+    ) -> list[dict[str, Any]]:
+        """Project tape entries onto an LLM message list.
+
+        Args:
+            selection: Override the default :class:`TapeContext`. When
+                ``None`` (the default) the yaya-standard
+                :func:`default_tape_context` applies.
+
+        Returns:
+            A list of ``{"role", "content", ...}`` dicts suitable to
+            hand to any LLM provider plugin.
+        """
+        chosen = selection or default_tape_context()
+        entries = await self.entries()
+        selector: Any = chosen.select or select_messages
+        result: list[dict[str, Any]] = list(selector(entries, chosen))
+        return result
+
+    async def info(self) -> SessionInfo:
+        """Return a :class:`SessionInfo` snapshot of the current tape state."""
+        entries = await self.entries()
+        anchors = [e for e in entries if e.kind == "anchor"]
+        last_anchor = str(anchors[-1].payload.get("name")) if anchors else None
+        return SessionInfo(
+            session_id=self._session_id,
+            tape_name=self._tape_name,
+            created_at=self._created_at,
+            entry_count=len(entries),
+            last_anchor=last_anchor,
+        )
+
+    # -- mutate-as-rewrite ------------------------------------------------------
+
+    async def reset(self, *, archive: bool = True) -> Path | None:
+        """Clear the tape; optionally archive it first.
+
+        Args:
+            archive: When True (default), dump every current entry to
+                a timestamped file under ``tapes/.archive/`` before
+                clearing. When False, entries are dropped on the
+                floor — appropriate only for tests or explicit
+                "nuke history" flows.
+
+        Returns:
+            The archive path when ``archive`` was True, else ``None``.
+        """
+        archive_path: Path | None = None
+        if archive:
+            archive_path = await _archive_tape(
+                manager=self._manager,
+                tape_name=self._tape_name,
+                archive_root=self._archive_root,
+            )
+        await self._manager.reset_tape(self._tape_name)
+        # After reset, re-seed a session/start anchor so downstream context
+        # queries (last_anchor) always find a stable boundary.
+        await self.handoff(
+            "session/start",
+            state={
+                "owner": _DEFAULT_OWNER,
+                "workspace": str(self._workspace),
+                **({"archived": str(archive_path)} if archive_path is not None else {}),
+            },
+        )
+        return archive_path
+
+    def fork(self, child_id: str) -> Session:
+        """Return a child Session that overlays this one's tape.
+
+        The child has its own in-memory append stream; reads see
+        parent entries followed by child entries. Writes never
+        mutate the parent. The child is local to the process; it is
+        NOT persisted via :class:`SessionStore.open` — callers that
+        need a durable child should open a new session with a
+        different id.
+
+        Args:
+            child_id: Logical id for the new session (stamped onto
+                ``SessionInfo`` only; the tape name is derived from
+                the parent's tape so the overlay can find it).
+        """
+        parent_store: Any = self._manager._tape_store  # pyright: ignore[reportPrivateUsage]
+        overlay = _ForkOverlayStore(parent_store)
+        child_manager = AsyncTapeManager(store=overlay)
+        return Session(
+            session_id=child_id,
+            tape_name=self._tape_name,
+            manager=child_manager,
+            workspace=self._workspace,
+            created_at=datetime.now(UTC).isoformat(),
+            archive_root=self._archive_root,
+        )
+
+
+class SessionStore:
+    """Open / list / archive sessions for a workspace.
+
+    The store owns one :class:`AsyncTapeManager` (so tape identity is
+    stable across opens) plus a directory root for archive dumps.
+    Bookkeeping is deliberately minimal — republic does the heavy
+    lifting.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: AsyncTapeStore | TapeStore | None = None,
+        tapes_dir: Path | None = None,
+    ) -> None:
+        """Configure the backing store.
+
+        Args:
+            store: Pre-built :class:`AsyncTapeStore` / :class:`TapeStore`.
+                When ``None`` (default) the file-backed
+                :class:`_FileTapeStore` under :func:`default_session_dir`
+                is used. Tests pass :class:`MemoryTapeStore` here.
+            tapes_dir: Directory for tape files and the ``.archive/``
+                subdirectory. Defaults to :func:`default_session_dir`.
+        """
+        self._tapes_dir = tapes_dir or default_session_dir()
+        if store is None:
+            sync_store: TapeStore = _FileTapeStore(self._tapes_dir)
+            store = AsyncTapeStoreAdapter(sync_store)
+        if not _is_async_store(store):
+            store = AsyncTapeStoreAdapter(cast(TapeStore, store))
+        self._store = cast("AsyncTapeStore", store)
+        self._manager = AsyncTapeManager(store=self._store)
+        self._archive_root = self._tapes_dir / ".archive"
+        self._closed = False
+        # Remember the seed timestamp so info() returns a stable value
+        # across reopens inside one process.
+        self._created_at: dict[str, str] = {}
+
+    @property
+    def tapes_dir(self) -> Path:
+        """Root directory for this store's jsonl files."""
+        return self._tapes_dir
+
+    async def open(self, workspace: Path, session_id: str) -> Session:
+        """Open (or resume) a :class:`Session` for ``(workspace, session_id)``.
+
+        On first open the tape is seeded with a
+        ``anchor(name="session/start")`` so :meth:`Session.context`
+        selectors always find a boundary.
+        """
+        if self._closed:
+            raise RuntimeError("SessionStore is closed")
+        tape_name = tape_name_for(workspace, session_id)
+        created_at = self._created_at.setdefault(tape_name, datetime.now(UTC).isoformat())
+        session = Session(
+            session_id=session_id,
+            tape_name=tape_name,
+            manager=self._manager,
+            workspace=workspace,
+            created_at=created_at,
+            archive_root=self._archive_root,
+        )
+        await _ensure_bootstrap_anchor(self._manager, tape_name, workspace)
+        return session
+
+    async def list_sessions(self, workspace: Path) -> list[SessionInfo]:
+        """Return a :class:`SessionInfo` row for every tape in ``workspace``.
+
+        Filters by the workspace-hash prefix in the tape name so
+        cross-workspace entries stay invisible (issue's AC-04 rule).
+        """
+        if self._closed:
+            return []
+        ws_prefix = hashlib.md5(
+            str(workspace.resolve()).encode("utf-8"),
+            usedforsecurity=False,
+        ).hexdigest()[:16]
+        tapes = await self._manager.list_tapes()
+        infos: list[SessionInfo] = []
+        for name in tapes:
+            if not name.startswith(f"{ws_prefix}__"):
+                continue
+            entries = list(await self._manager.query_tape(name).all())
+            anchors = [e for e in entries if e.kind == "anchor"]
+            last_anchor = str(anchors[-1].payload.get("name")) if anchors else None
+            created_at = self._created_at.setdefault(name, datetime.now(UTC).isoformat())
+            # Session id is not recoverable from the hashed tape name;
+            # surface the tape-name suffix so operators can still
+            # correlate rows.
+            sid_suffix = name.split("__", 1)[-1]
+            infos.append(
+                SessionInfo(
+                    session_id=sid_suffix,
+                    tape_name=name,
+                    created_at=created_at,
+                    entry_count=len(entries),
+                    last_anchor=last_anchor,
+                )
+            )
+        return infos
+
+    async def archive(self, session_id: str, *, workspace: Path | None = None) -> Path:
+        """Archive the tape for ``session_id`` and return the archive path.
+
+        When ``workspace`` is omitted, uses the current working
+        directory — matches the ``yaya session`` CLI semantics.
+        """
+        if self._closed:
+            raise RuntimeError("SessionStore is closed")
+        ws = workspace or Path.cwd()
+        tape_name = tape_name_for(ws, session_id)
+        return await _archive_tape(
+            manager=self._manager,
+            tape_name=tape_name,
+            archive_root=self._archive_root,
+        )
+
+    async def close(self) -> None:
+        """Idempotent teardown. Keeps state dir; drops in-memory caches."""
+        self._closed = True
+        self._created_at.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers.
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_bootstrap_anchor(
+    manager: AsyncTapeManager,
+    tape_name: str,
+    workspace: Path,
+) -> None:
+    """Emit the ``session/start`` anchor once per tape."""
+    anchors = list(await manager.query_tape(tape_name).kinds("anchor").all())
+    if anchors:
+        return
+    await manager.handoff(
+        tape_name,
+        "session/start",
+        state={"owner": _DEFAULT_OWNER, "workspace": str(workspace)},
+    )
+
+
+async def _archive_tape(
+    manager: AsyncTapeManager,
+    tape_name: str,
+    archive_root: Path,
+) -> Path:
+    """Dump every entry on ``tape_name`` as jsonl to the archive directory."""
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    archive_root.mkdir(parents=True, exist_ok=True)
+    archive_path = archive_root / f"{tape_name}.jsonl.{stamp}.bak"
+    entries = list(await manager.query_tape(tape_name).all())
+    with archive_path.open("w", encoding="utf-8") as handle:
+        for entry in entries:
+            handle.write(json.dumps(asdict(entry), ensure_ascii=False, default=str) + "\n")
+    return archive_path

--- a/src/yaya/kernel/session.py
+++ b/src/yaya/kernel/session.py
@@ -35,6 +35,7 @@ import hashlib
 import inspect
 import json
 import os
+from collections import deque
 from collections.abc import Iterable
 from dataclasses import asdict
 from datetime import UTC, datetime
@@ -252,6 +253,12 @@ class _FileTapeStore:
         """Ensure ``directory`` exists and remember it for later appends."""
         self._directory = directory
         self._directory.mkdir(parents=True, exist_ok=True)
+        # Per-tape next-id cache. Populated lazily on first ``append`` by
+        # counting lines in the jsonl file; invalidated on ``reset``. Keeps
+        # ``append`` O(1) after the first write instead of O(n) per call
+        # (and O(n²) for n appends, which is what the uncached implementation
+        # degenerated to).
+        self._next_id: dict[str, int] = {}
 
     def _path(self, tape: str) -> Path:
         return self._directory / f"{tape}.jsonl"
@@ -265,6 +272,8 @@ class _FileTapeStore:
         path = self._path(tape)
         if path.exists():
             path.unlink()
+        # Drop the cached next-id so a fresh tape starts at 1 again.
+        self._next_id.pop(tape, None)
 
     def fetch_all(self, query: Any) -> Iterable[TapeEntry]:
         """Return all entries on ``query.tape`` matching the query filters."""
@@ -274,11 +283,43 @@ class _FileTapeStore:
 
     def append(self, tape: str, entry: TapeEntry) -> None:
         """Append ``entry`` to the tape's jsonl file."""
-        # Stamp a monotonic id: len(existing) + 1 so ids stay unique per tape.
-        next_id = len(self._load(tape)) + 1
+        next_id = self._next_id.get(tape)
+        if next_id is None:
+            # Cold path: count existing entries once, then cache.
+            next_id = len(self._load(tape)) + 1
         stored = TapeEntry(next_id, entry.kind, dict(entry.payload), dict(entry.meta), entry.date)
         with self._path(tape).open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(asdict(stored), ensure_ascii=False) + "\n")
+        self._next_id[tape] = next_id + 1
+
+    def tail(self, tape: str, n: int) -> list[TapeEntry]:
+        """Return the last ``n`` entries on ``tape`` using bounded memory.
+
+        Streams the jsonl file line-by-line into a
+        :class:`collections.deque` with ``maxlen=n`` so memory usage is
+        bounded by ``n`` regardless of tape size. Time is O(file-lines)
+        which is acceptable for the CLI ``--tail`` path; a seek-backwards
+        implementation is premature optimisation.
+        """
+        if n <= 0:
+            return []
+        path = self._path(tape)
+        if not path.exists():
+            return []
+        window: deque[TapeEntry] = deque(maxlen=n)
+        with path.open("r", encoding="utf-8") as handle:
+            for raw in handle:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                parsed = _entry_from_dict(payload)
+                if parsed is not None:
+                    window.append(parsed)
+        return list(window)
 
     def _load(self, tape: str) -> list[TapeEntry]:
         path = self._path(tape)
@@ -506,6 +547,48 @@ class Session:
         """Return every entry currently on the tape."""
         raw: Iterable[TapeEntry] = await self._manager.query_tape(self._tape_name).all()
         return list(raw)
+
+    async def tail(self, n: int) -> list[TapeEntry]:
+        """Return the last ``n`` entries using the cheapest path available.
+
+        For file-backed tapes this streams the jsonl file into a bounded
+        :class:`collections.deque` — memory is O(n) regardless of tape
+        size. In-memory stores (memory, fork overlay) already hold
+        every entry in RAM; we slice ``entries()`` directly there
+        because the extra machinery buys nothing.
+
+        Args:
+            n: Maximum number of trailing entries to return. ``n <= 0``
+                returns an empty list.
+
+        Returns:
+            Up to ``n`` entries, preserving tape order.
+        """
+        if n <= 0:
+            return []
+        file_store = self._file_store()
+        if file_store is not None:
+            return file_store.tail(self._tape_name, n)
+        raw: Iterable[TapeEntry] = await self._manager.query_tape(self._tape_name).all()
+        entries = list(raw)
+        return entries[-n:]
+
+    def _file_store(self) -> _FileTapeStore | None:
+        """Return the underlying :class:`_FileTapeStore` when present.
+
+        The store is reached through the manager's private ``_tape_store``
+        attribute (republic exposes no public accessor) and, when that
+        attribute is an :class:`AsyncTapeStoreAdapter`, through the
+        adapter's wrapped sync store. Returns ``None`` for memory and
+        fork-overlay paths — those do not benefit from streaming tail.
+        """
+        store: Any = self._manager._tape_store  # pyright: ignore[reportPrivateUsage]
+        if isinstance(store, _FileTapeStore):
+            return store
+        wrapped = getattr(store, "_store", None)
+        if isinstance(wrapped, _FileTapeStore):
+            return wrapped
+        return None
 
     async def context(
         self,

--- a/src/yaya/kernel/session_persister.py
+++ b/src/yaya/kernel/session_persister.py
@@ -1,0 +1,282 @@
+"""Bus ↔ tape auto-persister (#32).
+
+A kernel-owned subscriber that mirrors bus events onto the active
+:class:`~yaya.kernel.session.Session` tape. The mapping is the table
+in ``docs/dev/plugin-protocol.md#sessions-and-tape``:
+
+    user.message.received  → message role=user
+    assistant.message.delta → (skipped — too chatty)
+    assistant.message.done  → message role=assistant
+    tool.call.request       → tool_call
+    tool.call.result        → tool_result
+    any other public kind   → event(name=<kind>, data=payload)
+
+Design rules (these exist for lesson reasons, tread carefully):
+
+* **Never re-publish on the bus.** The persister is itself a bus
+  subscriber; emitting an event from inside a handler would either
+  recurse (if the subscriber attribution were `kernel`) or flood the
+  FIFO. When a tape write fails we emit ``plugin.error`` with
+  ``source="kernel-session-persister"`` so the bus recursion guard
+  (lesson #2) still lets adapters see the incident.
+* **Honour the originating session id.** Events for session ``A``
+  land on tape ``A``'s store even though the subscription runs on
+  the ``"kernel"`` session. No cross-session contamination.
+* **Opt-out.** Any event whose ``envelope.payload`` carries a
+  ``persist=False`` key (or its ``meta``-style ``__persist__`` alias)
+  is skipped. Plugins can flag noisy ``x.<plugin>.*`` extension
+  events this way.
+* **Best-effort.** Tape-write failure logs at WARNING and continues —
+  losing one observational entry is strictly better than halting the
+  session worker.
+
+Layering: depends on :mod:`yaya.kernel.bus`, :mod:`yaya.kernel.events`,
+:mod:`yaya.kernel.session`, and the Python standard library. No
+imports from ``yaya.cli``, ``yaya.plugins``, or ``yaya.core``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from yaya.kernel.events import Event, new_event
+from yaya.kernel.session import Session
+
+if TYPE_CHECKING:  # pragma: no cover - type-only import
+    from yaya.kernel.bus import EventBus, Subscription
+
+__all__ = ["SessionPersister", "install_session_persister"]
+
+_SKIP_KINDS: frozenset[str] = frozenset({
+    # Streaming deltas are deliberately not persisted — too chatty and
+    # the final ``assistant.message.done`` captures the full answer.
+    "assistant.message.delta",
+    "llm.call.delta",
+    # Session lifecycle events mirror tape operations we already
+    # performed; persisting them would create duplicate anchors.
+    "session.started",
+    "session.handoff",
+    "session.reset",
+    "session.archived",
+    "session.forked",
+})
+"""Kinds the persister never writes to a tape."""
+
+_SOURCE = "kernel-session-persister"
+"""Subscription source — distinct from ``"kernel"`` so bus failure-routing
+does not hit the recursion guard. Mirrors the approval runtime's
+``"kernel-approval"`` convention."""
+
+
+_logger = logging.getLogger(__name__)
+
+
+class SessionPersister:
+    """Subscribe to every public kind and mirror matching events onto a tape.
+
+    The persister is bound to one :class:`~yaya.kernel.session.SessionStore`
+    plus a workspace path. When an event lands the persister looks up
+    (or opens) the session for ``ev.session_id`` and writes the
+    canonical entry. Sessions for ``session_id="kernel"`` are ignored
+    — they belong to the kernel's own plumbing.
+
+    Not thread-safe; the kernel drives it from one asyncio loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        bus: EventBus,
+        store: Any,
+        workspace: Any,
+    ) -> None:
+        """Bind the persister to ``bus`` / ``store`` / ``workspace``.
+
+        ``store`` is typed as :data:`Any` to keep a strict-mode
+        import boundary (avoiding a circular reference with
+        :mod:`yaya.kernel.session`); runtime checks ensure only a
+        :class:`~yaya.kernel.session.SessionStore` is passed.
+        """
+        self._bus = bus
+        self._store = store
+        self._workspace = workspace
+        self._subs: list[Subscription] = []
+        self._sessions: dict[str, Session] = {}
+        self._installed = False
+
+    async def start(self, kinds: list[str]) -> None:
+        """Subscribe to each ``kinds`` entry; open the default session."""
+        if self._installed:
+            return
+        self._installed = True
+        for kind in kinds:
+            sub = self._bus.subscribe(
+                kind,
+                self._on_event,
+                source=_SOURCE,
+            )
+            self._subs.append(sub)
+
+    async def stop(self) -> None:
+        """Drop every subscription. Idempotent."""
+        for sub in self._subs:
+            sub.unsubscribe()
+        self._subs.clear()
+        self._installed = False
+        self._sessions.clear()
+
+    async def _on_event(self, ev: Event) -> None:
+        """Bus handler — mirror ``ev`` onto the tape of its session."""
+        if ev.session_id == "kernel":
+            return
+        if ev.kind in _SKIP_KINDS:
+            return
+        if _opted_out(ev):
+            return
+        try:
+            session = await self._session_for(ev.session_id)
+            await _write_entry(session, ev)
+        except Exception as exc:
+            _logger.warning(
+                "session persister failed to write event %r on session %r: %s",
+                ev.kind,
+                ev.session_id,
+                exc,
+            )
+            await self._emit_failure(ev, exc)
+
+    async def _session_for(self, session_id: str) -> Session:
+        cached = self._sessions.get(session_id)
+        if cached is not None:
+            return cached
+        session: Session = await self._store.open(self._workspace, session_id)
+        # Bounded by the adapter's session churn — adapters are expected
+        # to reuse ids, so this is a small map. Still: lesson #6 —
+        # unbounded dicts leak. We cap at 1024 and evict FIFO.
+        if len(self._sessions) >= 1024:
+            first_key = next(iter(self._sessions))
+            self._sessions.pop(first_key, None)
+        self._sessions[session_id] = session
+        return session
+
+    async def _emit_failure(self, ev: Event, exc: Exception) -> None:
+        """Publish a ``plugin.error`` blaming the persister, not the kernel.
+
+        Routed on the ``"kernel"`` session so it does not interleave
+        with the originating session's FIFO, mirroring the bus's own
+        synthetic-error path.
+        """
+        try:
+            err = new_event(
+                "plugin.error",
+                {
+                    "name": _SOURCE,
+                    "error": f"tape_write_failed: {exc}",
+                    "kind": "tape_write",
+                },
+                session_id="kernel",
+                source=_SOURCE,
+            )
+            await self._bus.publish(err)
+        except Exception:
+            _logger.exception("session persister failed to emit plugin.error")
+
+        # Record the originating event id so log scrapers can correlate.
+        _logger.warning("session persister failure traceable via event id %s", ev.id)
+
+
+async def install_session_persister(
+    *,
+    bus: EventBus,
+    store: Any,
+    workspace: Any,
+    kinds: list[str],
+) -> SessionPersister:
+    """Construct, start, and return a :class:`SessionPersister`.
+
+    The caller owns teardown via :meth:`SessionPersister.stop`.
+
+    Args:
+        bus: The running :class:`~yaya.kernel.bus.EventBus`.
+        store: A :class:`~yaya.kernel.session.SessionStore`.
+        workspace: Workspace path the persister uses when opening
+            sessions.
+        kinds: Event kinds to subscribe to. Passed explicitly so
+            tests can scope the subscriber to a minimal set and so
+            the kernel boot path can pass the full closed catalog
+            minus :data:`_SKIP_KINDS`.
+
+    Returns:
+        The running :class:`SessionPersister`.
+    """
+    persister = SessionPersister(bus=bus, store=store, workspace=workspace)
+    await persister.start(kinds)
+    return persister
+
+
+def _opted_out(ev: Event) -> bool:
+    """True iff the event payload flags itself as non-persisted."""
+    payload = ev.payload
+    direct = payload.get("persist")
+    if isinstance(direct, bool) and not direct:
+        return True
+    meta_value = payload.get("__persist__")
+    return isinstance(meta_value, bool) and not meta_value
+
+
+async def _write_entry(session: Session, ev: Event) -> None:
+    """Translate one bus event into one tape entry per the contract table."""
+    writer = _WRITERS.get(ev.kind, _write_generic_event)
+    await writer(session, ev)
+
+
+async def _write_user_message(session: Session, ev: Event) -> None:
+    text = _string(ev.payload.get("text", ""))
+    await session.append_message("user", text, source=ev.source)
+
+
+async def _write_assistant_done(session: Session, ev: Event) -> None:
+    content = _string(ev.payload.get("content", ""))
+    await session.append_message("assistant", content, source=ev.source)
+
+
+async def _write_tool_call(session: Session, ev: Event) -> None:
+    payload = ev.payload
+    await session.append_tool_call({
+        "id": _string(payload.get("id", "")),
+        "name": _string(payload.get("name", "")),
+        "args": payload.get("args", {}) if isinstance(payload.get("args"), dict) else {},
+    })
+
+
+async def _write_tool_result(session: Session, ev: Event) -> None:
+    payload = ev.payload
+    result: dict[str, Any] = {
+        "ok": bool(payload.get("ok", False)),
+    }
+    if "value" in payload:
+        result["value"] = payload.get("value")
+    if "error" in payload:
+        result["error"] = payload.get("error")
+    await session.append_tool_result(
+        tool_call_id=_string(payload.get("id", "")),
+        result=result,
+    )
+
+
+async def _write_generic_event(session: Session, ev: Event) -> None:
+    await session.append_event(ev.kind, dict(ev.payload), source=ev.source)
+
+
+_WRITERS: dict[str, Callable[[Session, Event], Awaitable[None]]] = {
+    "user.message.received": _write_user_message,
+    "assistant.message.done": _write_assistant_done,
+    "tool.call.request": _write_tool_call,
+    "tool.call.result": _write_tool_result,
+}
+
+
+def _string(value: object) -> str:
+    return value if isinstance(value, str) else str(value)

--- a/src/yaya/kernel/tape_context.py
+++ b/src/yaya/kernel/tape_context.py
@@ -1,0 +1,204 @@
+"""Default tape-context selection: :class:`~republic.TapeEntry` → LLM messages.
+
+A :class:`~republic.TapeContext` is the "selection strategy" that
+derives an LLM chat history from the append-only tape. The default
+policy here mirrors the ``bub`` reference (see
+``vendor/bub/src/bub/builtin/context.py``) but re-implemented in-tree
+so the yaya kernel never depends on ``bub``:
+
+* ``message`` entries pass through (payload is already a
+  ``{"role", "content"}`` dict plus optional extras).
+* ``tool_call`` entries become one assistant message with the
+  ``tool_calls`` array set.
+* ``tool_result`` entries expand to one ``role="tool"`` message per
+  result, correlated by order with the previous ``tool_call`` entry.
+* ``anchor`` entries are boundary markers — skipped in the default
+  context so compaction / session-start anchors do not leak into
+  prompts. Callers that want anchor-aware context render it
+  themselves from the same tape.
+* ``event`` entries are skipped unless their ``meta`` flags
+  ``include_in_context=True`` — most observational events (bus
+  mirrors, plugin errors, …) should not inflate the LLM prompt.
+
+The selection is stateless and pure so it plays well with
+``TapeContext`` composition (``after_last_anchor`` etc.) and with
+replay-style testing.
+
+Layering: depends only on :mod:`republic` and the Python standard
+library. No imports from ``yaya.cli``, ``yaya.plugins``, or
+``yaya.core``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any, cast
+
+from republic import TapeContext, TapeEntry
+from republic.tape import AsyncTapeManager
+
+__all__ = [
+    "after_last_anchor",
+    "default_tape_context",
+    "select_messages",
+]
+
+
+def default_tape_context() -> TapeContext:
+    """Return the default :class:`~republic.TapeContext` for yaya.
+
+    The returned context routes entries through :func:`select_messages`
+    with no anchor filter, so callers who want
+    "post-compaction" views should compose it with an explicit
+    ``after_last_anchor`` or ``after_anchor`` query — see
+    :func:`after_last_anchor` for the helper.
+    """
+    return TapeContext(select=select_messages)
+
+
+def select_messages(
+    entries: Iterable[TapeEntry],
+    _context: TapeContext,
+) -> list[dict[str, Any]]:
+    """Project ``entries`` onto an OpenAI-style message list.
+
+    Args:
+        entries: Ordered tape entries (parent-first when the tape
+            overlays a fork, chronological otherwise).
+        _context: The calling :class:`~republic.TapeContext`. Unused
+            at this layer — kept in the signature so the callable is
+            compatible with ``TapeContext.select``.
+
+    Returns:
+        A list of plain dicts suitable to hand to an LLM provider.
+    """
+    messages: list[dict[str, Any]] = []
+    pending_calls: list[dict[str, Any]] = []
+
+    for entry in entries:
+        kind = entry.kind
+        if kind == "message":
+            _append_message(messages, entry)
+        elif kind == "tool_call":
+            pending_calls = _append_tool_call(messages, entry)
+        elif kind == "tool_result":
+            _append_tool_result(messages, pending_calls, entry)
+            pending_calls = []
+        elif kind == "event" and bool(entry.meta.get("include_in_context")):
+            _append_event(messages, entry)
+        # anchor / error / anything else: intentionally skipped.
+    return messages
+
+
+async def after_last_anchor(
+    manager: AsyncTapeManager,
+    tape_name: str,
+) -> list[TapeEntry]:
+    """Return every tape entry appended after the most recent anchor.
+
+    Post-compaction context queries hand these entries to
+    :func:`select_messages` to rebuild the LLM history without the
+    summarised prefix. Uses ``republic``'s built-in query composer so
+    fork overlays are honoured.
+
+    Args:
+        manager: The live tape manager.
+        tape_name: Stable identifier for the tape within ``manager``.
+
+    Returns:
+        A list of entries in insertion order. Empty when the tape
+        has no anchors yet.
+    """
+    entries = await manager.query_tape(tape_name).last_anchor().all()
+    return list(cast("list[TapeEntry]", entries))
+
+
+def _append_message(messages: list[dict[str, Any]], entry: TapeEntry) -> None:
+    payload = entry.payload
+    messages.append(dict(payload))
+
+
+def _append_tool_call(messages: list[dict[str, Any]], entry: TapeEntry) -> list[dict[str, Any]]:
+    calls = _normalise_calls(entry.payload.get("calls"))
+    if calls:
+        messages.append({"role": "assistant", "content": "", "tool_calls": calls})
+    return calls
+
+
+def _append_tool_result(
+    messages: list[dict[str, Any]],
+    pending_calls: list[dict[str, Any]],
+    entry: TapeEntry,
+) -> None:
+    results_value = entry.payload.get("results")
+    if not isinstance(results_value, list):
+        return
+    # mypy already infers ``list``; pyright keeps "Unknown" element types
+    # because republic ships without ``py.typed``. The helper hides the
+    # narrowed type from pyright so the resulting list elements are Any.
+    results: list[Any] = _as_any_list(results_value)
+    for index, result in enumerate(results):
+        messages.append(_build_tool_result_message(result, pending_calls, index))
+
+
+def _build_tool_result_message(
+    result: object,
+    pending_calls: list[dict[str, Any]],
+    index: int,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "tool", "content": _render_result(result)}
+    if index >= len(pending_calls):
+        return message
+    call = pending_calls[index]
+    call_id = call.get("id")
+    if isinstance(call_id, str) and call_id:
+        message["tool_call_id"] = call_id
+    function = call.get("function")
+    if isinstance(function, dict):
+        name = cast("dict[str, Any]", function).get("name")
+        if isinstance(name, str) and name:
+            message["name"] = name
+    return message
+
+
+def _append_event(messages: list[dict[str, Any]], entry: TapeEntry) -> None:
+    name = str(entry.payload.get("name", "event"))
+    data = entry.payload.get("data", {})
+    messages.append({
+        "role": "system",
+        "content": f"[event:{name}] {json.dumps(data, ensure_ascii=False, default=str)}",
+    })
+
+
+def _normalise_calls(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    # See ``_append_tool_result`` for the helper rationale.
+    items: list[Any] = _as_any_list(value)
+    calls: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            calls.append(dict(cast("dict[str, Any]", item)))
+    return calls
+
+
+def _as_any_list(value: Any) -> list[Any]:
+    """Promote an opaque iterable to ``list[Any]`` for both mypy and pyright.
+
+    pyright's narrowing turns ``isinstance(_, list)`` into ``list[Unknown]``
+    even when the source type is ``object``; mypy in turn rejects an
+    explicit ``cast`` as redundant. Hiding the conversion behind a
+    function boundary lets the return annotation be the source of truth
+    for both.
+    """
+    return list(cast("list[Any]", value))
+
+
+def _render_result(result: object) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except TypeError:
+        return str(result)

--- a/tests/bdd/features/kernel-session-tape.feature
+++ b/tests/bdd/features/kernel-session-tape.feature
@@ -1,0 +1,68 @@
+Feature: Kernel session + tape store
+
+  The kernel persists every session's bus events as an append-only
+  tape (republic primitives). LLM context is a derived view via
+  TapeContext; fork, reset, and compaction never rewrite past
+  entries. A kernel subscriber auto-persists bus events per the
+  table in docs/dev/plugin-protocol.md#sessions-and-tape.
+
+  Scenarios mirror specs/kernel-session-tape.spec Completion Criteria
+  and are kept in sync by scripts/check_feature_sync.py.
+
+  Scenario: AC-01 — fresh session seeds a session start anchor
+    Given no tape exists for workspace W and session S
+    When the session store opens the session
+    Then the tape has exactly one anchor named session slash start
+    And the anchor state includes owner human and workspace equal to the path
+
+  Scenario: AC-02 — bus events are persisted canonically
+    Given an open session and a running bus persister
+    When a user message received event with content hi is emitted
+    And an assistant message done event with content hello is emitted
+    Then the tape contains a message entry role user content hi
+    And a message entry role assistant content hello
+
+  Scenario: AC-03 — streaming deltas are not persisted
+    Given an open session and a running bus persister
+    When ten assistant message delta events are emitted
+    Then no new tape entries land on the tape beyond the bootstrap anchor
+
+  Scenario: AC-04 — persist false opts an event out
+    Given an open session and a running bus persister
+    When a user message received event is emitted with payload persist false
+    Then the tape contains no new message entry for that event
+
+  Scenario: AC-05 — archive plus reset round trip
+    Given a session with ten tape entries
+    When reset with archive true is called
+    Then a jsonl archive file exists under tapes archive
+    And the tape has exactly one anchor named session slash start
+
+  Scenario: AC-06 — workspace scoped naming isolates cross workspace tapes
+    Given two workspaces with the same session id default
+    When both sessions are opened
+    Then their tape names differ
+    And list sessions for each workspace returns one row
+
+  Scenario: AC-07 — fork overlay isolates writes
+    Given a parent session with five entries
+    When the parent forks a child subagent
+    And the child appends three entries
+    Then the parent tape still has five entries
+    And the child context sees eight entries
+
+  Scenario: AC-08 — post compaction context starts after the last anchor
+    Given a session with a compaction anchor followed by two new messages
+    When after last anchor is called
+    Then only the two post anchor messages are returned
+
+  Scenario: AC-09 — tape write failure does not kill the session
+    Given a persister whose session store raises on append
+    When a user message received event is emitted
+    Then a plugin error event is observed with source kernel session persister
+    And the bus keeps routing subsequent events
+
+  Scenario: AC-10 — kernel context exposes the active session to plugins
+    Given a kernel context wired with an open session
+    Then the context session property returns that session
+    And the property cannot be overwritten

--- a/tests/bdd/test_kernel_session.py
+++ b/tests/bdd/test_kernel_session.py
@@ -1,0 +1,462 @@
+"""Pytest-bdd execution of specs/kernel-session-tape.spec scenarios.
+
+The Gherkin text in ``features/kernel-session-tape.feature`` is the
+authoritative BDD contract. Each scenario binds to step definitions
+in this module via pytest-bdd; unmatched text fails the test with
+``StepDefinitionNotFoundError`` so the spec text and scenario
+implementations stay in lock-step.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from yaya.kernel import (
+    EventBus,
+    KernelContext,
+    MemoryTapeStore,
+    Session,
+    SessionStore,
+    after_last_anchor,
+    install_session_persister,
+    new_event,
+)
+
+scenarios("features/kernel-session-tape.feature")
+
+
+@dataclass
+class _Ctx:
+    """Per-scenario state container."""
+
+    loop: asyncio.AbstractEventLoop | None = None
+    store: SessionStore | None = None
+    session: Session | None = None
+    child: Session | None = None
+    persister: Any | None = None
+    bus: EventBus | None = None
+    workspace: Path | None = None
+    second_workspace: Path | None = None
+    second_session: Session | None = None
+    anchor_entries: list[Any] = field(default_factory=lambda: [])
+    parent_count_before: int = 0
+    extras: dict[str, Any] = field(default_factory=lambda: {})
+    plugin_errors: list[Any] = field(default_factory=lambda: [])
+
+
+@pytest.fixture
+def sctx(tmp_path: Path) -> _Ctx:
+    loop = asyncio.new_event_loop()
+    ctx = _Ctx(loop=loop, workspace=tmp_path / "ws")
+    assert ctx.workspace is not None
+    ctx.workspace.mkdir(parents=True, exist_ok=True)
+    yield ctx
+    if ctx.persister is not None:
+        loop.run_until_complete(ctx.persister.stop())
+    if ctx.bus is not None:
+        loop.run_until_complete(ctx.bus.close())
+    if ctx.store is not None:
+        loop.run_until_complete(ctx.store.close())
+    loop.close()
+
+
+def _run(ctx: _Ctx, coro: Any) -> Any:
+    assert ctx.loop is not None
+    return ctx.loop.run_until_complete(coro)
+
+
+# -- AC-01 ------------------------------------------------------------------
+
+
+@given("no tape exists for workspace W and session S")
+def _no_tape(sctx: _Ctx) -> None:
+    sctx.store = SessionStore(store=MemoryTapeStore())
+
+
+@when("the session store opens the session")
+def _open(sctx: _Ctx) -> None:
+    assert sctx.store is not None and sctx.workspace is not None
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "S"))
+
+
+@then("the tape has exactly one anchor named session slash start")
+def _one_anchor(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    anchors = [e for e in entries if e.kind == "anchor"]
+    assert len(anchors) == 1
+    assert anchors[0].payload.get("name") == "session/start"
+
+
+@then("the anchor state includes owner human and workspace equal to the path")
+def _anchor_state(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    anchors = [e for e in entries if e.kind == "anchor"]
+    state = anchors[0].payload.get("state") or {}
+    assert state.get("owner") == "human"
+    assert state.get("workspace") == str(sctx.workspace)
+
+
+# -- AC-02 / AC-03 / AC-04 --------------------------------------------------
+
+
+@given("an open session and a running bus persister")
+def _open_with_persister(sctx: _Ctx) -> None:
+    assert sctx.workspace is not None
+    sctx.bus = EventBus()
+    sctx.store = SessionStore(store=MemoryTapeStore())
+    sctx.persister = _run(
+        sctx,
+        install_session_persister(
+            bus=sctx.bus,
+            store=sctx.store,
+            workspace=sctx.workspace,
+            kinds=["user.message.received", "assistant.message.done"],
+        ),
+    )
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "default"))
+
+
+@when(parsers.parse("a user message received event with content {content} is emitted"))
+def _emit_user(sctx: _Ctx, content: str) -> None:
+    assert sctx.bus is not None
+    _run(
+        sctx,
+        sctx.bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": content},
+                session_id="default",
+                source="test",
+            )
+        ),
+    )
+
+
+@when(parsers.parse("an assistant message done event with content {content} is emitted"))
+def _emit_assistant(sctx: _Ctx, content: str) -> None:
+    assert sctx.bus is not None
+    _run(
+        sctx,
+        sctx.bus.publish(
+            new_event(
+                "assistant.message.done",
+                {"content": content, "tool_calls": []},
+                session_id="default",
+                source="kernel",
+            )
+        ),
+    )
+
+
+@then(parsers.parse("the tape contains a message entry role {role} content {content}"))
+def _tape_contains_message(sctx: _Ctx, role: str, content: str) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    messages = [e for e in entries if e.kind == "message"]
+    assert any(m.payload.get("role") == role and m.payload.get("content") == content for m in messages), (
+        f"no message {role!r}={content!r} in {[m.payload for m in messages]}"
+    )
+
+
+@then(parsers.parse("a message entry role {role} content {content}"))
+def _tape_contains_message2(sctx: _Ctx, role: str, content: str) -> None:
+    _tape_contains_message(sctx, role, content)
+
+
+@when("ten assistant message delta events are emitted")
+def _emit_ten_deltas(sctx: _Ctx) -> None:
+    assert sctx.bus is not None
+    for i in range(10):
+        _run(
+            sctx,
+            sctx.bus.publish(
+                new_event(
+                    "assistant.message.delta",
+                    {"content": f"chunk-{i}"},
+                    session_id="default",
+                    source="llm",
+                )
+            ),
+        )
+
+
+@then("no new tape entries land on the tape beyond the bootstrap anchor")
+def _no_new_entries(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    assert all(e.kind != "message" for e in entries)
+
+
+@when("a user message received event is emitted with payload persist false")
+def _emit_persist_false(sctx: _Ctx) -> None:
+    assert sctx.bus is not None
+    _run(
+        sctx,
+        sctx.bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "skip", "persist": False},
+                session_id="default",
+                source="test",
+            )
+        ),
+    )
+
+
+@then("the tape contains no new message entry for that event")
+def _no_message_entry(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    assert all(e.kind != "message" for e in entries)
+
+
+# -- AC-05 ------------------------------------------------------------------
+
+
+@given("a session with ten tape entries")
+def _ten_entries(sctx: _Ctx, tmp_path: Path) -> None:
+    assert sctx.workspace is not None
+    tapes_dir = tmp_path / "tapes"
+    sctx.store = SessionStore(tapes_dir=tapes_dir)
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "reset"))
+    for i in range(10):
+        _run(sctx, sctx.session.append_message("user", f"m-{i}"))
+    sctx.extras["tapes_dir"] = tapes_dir
+
+
+@when("reset with archive true is called")
+def _reset_archive_true(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    sctx.extras["archive_path"] = _run(sctx, sctx.session.reset(archive=True))
+
+
+@then("a jsonl archive file exists under tapes archive")
+def _archive_file_exists(sctx: _Ctx) -> None:
+    archive_path = sctx.extras.get("archive_path")
+    assert archive_path is not None
+    assert Path(archive_path).exists()
+
+
+# -- AC-06 ------------------------------------------------------------------
+
+
+@given("two workspaces with the same session id default")
+def _two_workspaces(sctx: _Ctx, tmp_path: Path) -> None:
+    sctx.workspace = tmp_path / "w1"
+    sctx.second_workspace = tmp_path / "w2"
+    sctx.workspace.mkdir()
+    sctx.second_workspace.mkdir()
+    sctx.store = SessionStore(store=MemoryTapeStore())
+
+
+@when("both sessions are opened")
+def _open_both(sctx: _Ctx) -> None:
+    assert sctx.store is not None
+    assert sctx.workspace is not None and sctx.second_workspace is not None
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "default"))
+    sctx.second_session = _run(sctx, sctx.store.open(sctx.second_workspace, "default"))
+
+
+@then("their tape names differ")
+def _names_differ(sctx: _Ctx) -> None:
+    assert sctx.session is not None and sctx.second_session is not None
+    assert sctx.session.tape_name != sctx.second_session.tape_name
+
+
+@then("list sessions for each workspace returns one row")
+def _one_row_each(sctx: _Ctx) -> None:
+    assert sctx.store is not None
+    assert sctx.workspace is not None and sctx.second_workspace is not None
+    rows1 = _run(sctx, sctx.store.list_sessions(sctx.workspace))
+    rows2 = _run(sctx, sctx.store.list_sessions(sctx.second_workspace))
+    assert len(rows1) == 1
+    assert len(rows2) == 1
+
+
+# -- AC-07 ------------------------------------------------------------------
+
+
+@given("a parent session with five entries")
+def _parent_five(sctx: _Ctx) -> None:
+    assert sctx.workspace is not None
+    sctx.store = SessionStore(store=MemoryTapeStore())
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "parent"))
+    # Session open seeds (anchor, handoff-event); add messages until we hit 5.
+    current = len(_run(sctx, sctx.session.entries()))
+    for i in range(max(0, 5 - current)):
+        _run(sctx, sctx.session.append_message("user", f"p-{i}"))
+    sctx.parent_count_before = len(_run(sctx, sctx.session.entries()))
+
+
+@when("the parent forks a child subagent")
+def _parent_fork(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    sctx.child = sctx.session.fork("subagent")
+
+
+@when("the child appends three entries")
+def _child_three(sctx: _Ctx) -> None:
+    assert sctx.child is not None
+    for i in range(3):
+        _run(sctx, sctx.child.append_message("user", f"c-{i}"))
+
+
+@then("the parent tape still has five entries")
+def _parent_still_five(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    entries = _run(sctx, sctx.session.entries())
+    assert len(entries) == sctx.parent_count_before
+
+
+@then("the child context sees eight entries")
+def _child_eight(sctx: _Ctx) -> None:
+    assert sctx.child is not None
+    entries = _run(sctx, sctx.child.entries())
+    assert len(entries) == sctx.parent_count_before + 3
+
+
+# -- AC-08 ------------------------------------------------------------------
+
+
+@given("a session with a compaction anchor followed by two new messages")
+def _session_with_compaction(sctx: _Ctx) -> None:
+    assert sctx.workspace is not None
+    sctx.store = SessionStore(store=MemoryTapeStore())
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "compact"))
+    _run(sctx, sctx.session.append_message("user", "pre-1"))
+    _run(sctx, sctx.session.handoff("compaction/0", state={"summary": "old"}))
+    _run(sctx, sctx.session.append_message("user", "post-1"))
+    _run(sctx, sctx.session.append_message("assistant", "post-2"))
+
+
+@when("after last anchor is called")
+def _after_last_anchor(sctx: _Ctx) -> None:
+    assert sctx.session is not None
+    sctx.anchor_entries = _run(
+        sctx,
+        after_last_anchor(sctx.session.manager, sctx.session.tape_name),
+    )
+
+
+@then("only the two post anchor messages are returned")
+def _two_post(sctx: _Ctx) -> None:
+    messages = [e for e in sctx.anchor_entries if e.kind == "message"]
+    assert len(messages) == 2
+
+
+# -- AC-09 ------------------------------------------------------------------
+
+
+@given("a persister whose session store raises on append")
+def _raising_persister(sctx: _Ctx) -> None:
+    assert sctx.workspace is not None
+    sctx.bus = EventBus()
+
+    real_store = SessionStore(store=MemoryTapeStore())
+    sctx.store = real_store
+
+    class _Raising:
+        async def open(self, workspace: Path, session_id: str) -> Session:
+            sess = await real_store.open(workspace, session_id)
+
+            async def _boom(*_a: Any, **_kw: Any) -> None:
+                raise RuntimeError("boom")
+
+            sess.append_message = _boom  # type: ignore[assignment]
+            return sess
+
+    async def capture(ev: Any) -> None:
+        sctx.plugin_errors.append(ev)
+
+    sctx.bus.subscribe("plugin.error", capture, source="test")
+    sctx.persister = _run(
+        sctx,
+        install_session_persister(
+            bus=sctx.bus,
+            store=_Raising(),
+            workspace=sctx.workspace,
+            kinds=["user.message.received"],
+        ),
+    )
+
+
+@when("a user message received event is emitted")
+def _emit_one_user(sctx: _Ctx) -> None:
+    assert sctx.bus is not None
+    _run(
+        sctx,
+        sctx.bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "boom"},
+                session_id="default",
+                source="test",
+            )
+        ),
+    )
+    # Give the kernel-session worker a tick to deliver the synthetic error.
+    _run(sctx, asyncio.sleep(0.01))
+
+
+@then(parsers.parse("a plugin error event is observed with source kernel session persister"))
+def _plugin_error_observed(sctx: _Ctx) -> None:
+    assert any(ev.payload.get("name") == "kernel-session-persister" for ev in sctx.plugin_errors), sctx.plugin_errors
+
+
+@then("the bus keeps routing subsequent events")
+def _bus_keeps_routing(sctx: _Ctx) -> None:
+    # Pub one more event; absence of raise is proof.
+    assert sctx.bus is not None
+    _run(
+        sctx,
+        sctx.bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "still alive"},
+                session_id="default",
+                source="test",
+            )
+        ),
+    )
+
+
+# -- AC-10 ------------------------------------------------------------------
+
+
+@given("a kernel context wired with an open session")
+def _ctx_with_session(sctx: _Ctx) -> None:
+    assert sctx.workspace is not None
+    sctx.store = SessionStore(store=MemoryTapeStore())
+    sctx.session = _run(sctx, sctx.store.open(sctx.workspace, "default"))
+    sctx.bus = EventBus()
+    sctx.extras["kctx"] = KernelContext(
+        bus=sctx.bus,
+        logger=None,
+        config={},
+        state_dir=sctx.workspace,
+        plugin_name="test-plugin",
+        session=sctx.session,
+    )
+
+
+@then("the context session property returns that session")
+def _ctx_returns_session(sctx: _Ctx) -> None:
+    kctx = sctx.extras.get("kctx")
+    assert kctx is not None
+    assert kctx.session is sctx.session
+
+
+@then("the property cannot be overwritten")
+def _ctx_session_readonly(sctx: _Ctx) -> None:
+    kctx = sctx.extras.get("kctx")
+    assert kctx is not None
+    with pytest.raises(AttributeError):
+        kctx.session = None

--- a/tests/cli/__snapshots__/test_help_snapshot.ambr
+++ b/tests/cli/__snapshots__/test_help_snapshot.ambr
@@ -22,6 +22,7 @@
   | version Print the installed version.
   | config Inspect resolved yaya configuration.
   | plugin Manage installed plugins.
+  | session Manage session tapes (persisted append-only event log).
   +---+
   
   '''

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -449,3 +449,44 @@ async def test_run_serve_calls_webbrowser_in_executor(
     # Sanity: the URL flowed through unchanged.
     args = next(a for n, a in recorded if n == "fake_browser_open")
     assert args and str(args[0]).startswith("http://127.0.0.1:")
+
+
+@pytest.mark.asyncio
+async def test_serve_resume_stashes_on_config(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--resume <id>`` lands on ``cfg.session.default_id`` (lesson #23).
+
+    A silent no-op on an accepted flag is banned; this test pins the
+    stash-on-config behaviour + the ``serve.resume.staged`` emission so a
+    future refactor cannot quietly regress to ``del resume``.
+    """
+    from yaya.kernel import KernelConfig
+
+    cfg = KernelConfig()
+    assert cfg.session.default_id is None
+
+    shutdown = asyncio.Event()
+    state = CLIState(json_output=True)
+    task = asyncio.create_task(
+        run_serve(
+            state,
+            port=0,
+            no_open=True,
+            strategy="react",
+            dev=False,
+            shutdown_event=shutdown,
+            kernel_config=cfg,
+            resume="mysession",
+        )
+    )
+    await asyncio.sleep(0.2)
+    shutdown.set()
+    code = await asyncio.wait_for(task, timeout=5.0)
+    assert code == 0
+    assert cfg.session.default_id == "mysession"
+
+    captured = capsys.readouterr()
+    joined = captured.out
+    assert '"action": "serve.resume.staged"' in joined
+    assert '"session_id": "mysession"' in joined

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -1,0 +1,122 @@
+"""CLI tests for ``yaya session {list,show,resume,archive}``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from yaya.kernel import SessionStore
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point session paths at a per-test tmp dir; never touch real XDG state."""
+    monkeypatch.setenv("YAYA_STATE_DIR", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _seed_session(workspace: Path, session_id: str, tapes_dir: Path) -> None:
+    """Create a file-backed session with a couple of messages so CLI has data."""
+
+    async def _run() -> None:
+        store = SessionStore(tapes_dir=tapes_dir)
+        try:
+            session = await store.open(workspace, session_id)
+            await session.append_message("user", "hello")
+            await session.append_message("assistant", "hi there")
+        finally:
+            await store.close()
+
+    asyncio.run(_run())
+
+
+def test_session_list_json_empty(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    result = runner.invoke(cli_app, ["--json", "session", "list"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["action"] == "session.list"
+    assert payload["sessions"] == []
+
+
+def test_session_list_json_populated(
+    runner: CliRunner,
+    cli_app: Any,
+    tmp_path: Path,
+) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(cli_app, ["--json", "session", "list"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert len(payload["sessions"]) == 1
+    assert payload["sessions"][0]["entry_count"] >= 2
+
+
+def test_session_list_text_table(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(cli_app, ["session", "list"])
+    assert result.exit_code == 0, result.stdout
+    assert "yaya sessions" in result.stdout
+
+
+def test_session_show_json_tail(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(cli_app, ["--json", "session", "show", "default", "--tail", "1"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["action"] == "session.show"
+    assert len(payload["entries"]) == 1
+
+
+def test_session_resume_missing_returns_error(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    result = runner.invoke(cli_app, ["--json", "session", "resume", "nope"])
+    assert result.exit_code == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "not found" in payload["error"]
+
+
+def test_session_resume_existing(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(cli_app, ["--json", "session", "resume", "default"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["session_id"] == "default"
+
+
+def test_session_archive_requires_yes_under_json(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(cli_app, ["--json", "session", "archive", "default"])
+    assert result.exit_code == 1, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"] == "confirmation_required"
+
+
+def test_session_archive_happy_path(runner: CliRunner, cli_app: Any, tmp_path: Path) -> None:
+    tapes_dir = tmp_path / "tapes"
+    _seed_session(tmp_path, "default", tapes_dir)
+    result = runner.invoke(
+        cli_app,
+        ["--json", "session", "archive", "default", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["action"] == "session.archive"
+    archive_path = Path(payload["archive_path"])
+    assert archive_path.exists()

--- a/tests/kernel/test_events.py
+++ b/tests/kernel/test_events.py
@@ -79,6 +79,11 @@ def test_public_catalog_matches_protocol_document() -> None:
         "kernel.ready",
         "kernel.shutdown",
         "kernel.error",
+        "session.started",
+        "session.handoff",
+        "session.reset",
+        "session.archived",
+        "session.forked",
     }
     assert expected == PUBLIC_EVENT_KINDS
 

--- a/tests/kernel/test_session.py
+++ b/tests/kernel/test_session.py
@@ -1,0 +1,238 @@
+"""Tests for :mod:`yaya.kernel.session` — SessionStore, Session, tape ops."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yaya.kernel import (
+    EventBus,
+    KernelContext,
+    MemoryTapeStore,
+    SessionInfo,
+    SessionStore,
+    after_last_anchor,
+    default_session_dir,
+    tape_name_for,
+)
+
+
+async def _open(
+    store: SessionStore,
+    workspace: Path,
+    session_id: str = "default",
+):
+    return await store.open(workspace, session_id)
+
+
+async def test_open_seeds_session_start_anchor(tmp_path: Path) -> None:
+    """AC-01 — opening a fresh session seeds a session/start anchor."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path)
+        entries = await session.entries()
+        anchors = [e for e in entries if e.kind == "anchor"]
+        assert len(anchors) == 1
+        assert anchors[0].payload.get("name") == "session/start"
+        state = anchors[0].payload.get("state")
+        assert isinstance(state, dict)
+        assert state.get("owner") == "human"
+        assert state.get("workspace") == str(tmp_path)
+    finally:
+        await store.close()
+
+
+async def test_reset_archives_then_clears(tmp_path: Path) -> None:
+    """AC-05 — reset(archive=True) dumps jsonl + clears + reseeds anchor."""
+    tapes_dir = tmp_path / "tapes"
+    store = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session = await _open(store, tmp_path, "reset-me")
+        for i in range(10):
+            await session.append_message("user", f"msg-{i}")
+        archive_path = await session.reset(archive=True)
+        assert archive_path is not None
+        assert archive_path.exists()
+        assert archive_path.parent == tapes_dir / ".archive"
+        entries = await session.entries()
+        anchors = [e for e in entries if e.kind == "anchor"]
+        assert len(anchors) == 1
+        assert anchors[0].payload.get("name") == "session/start"
+    finally:
+        await store.close()
+
+
+async def test_workspace_scoped_tape_names(tmp_path: Path) -> None:
+    """AC-06 — different workspaces with the same id get different tape names."""
+    ws1 = tmp_path / "w1"
+    ws2 = tmp_path / "w2"
+    ws1.mkdir()
+    ws2.mkdir()
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        s1 = await _open(store, ws1, "default")
+        s2 = await _open(store, ws2, "default")
+        assert s1.tape_name != s2.tape_name
+        await s1.append_message("user", "w1-only")
+        rows_ws1 = await store.list_sessions(ws1)
+        rows_ws2 = await store.list_sessions(ws2)
+        assert len(rows_ws1) == 1
+        assert len(rows_ws2) == 1
+        assert rows_ws1[0].tape_name != rows_ws2[0].tape_name
+    finally:
+        await store.close()
+
+
+async def test_fork_isolates_child_writes(tmp_path: Path) -> None:
+    """AC-07 — fork reads parent + own; writes never land on parent."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        parent = await _open(store, tmp_path, "parent")
+        for i in range(4):
+            await parent.append_message("user", f"p-{i}")
+        parent_before = await parent.info()
+        parent_count_before = parent_before.entry_count
+
+        child = parent.fork("child")
+        for i in range(3):
+            await child.append_message("user", f"c-{i}")
+
+        parent_after = await parent.info()
+        assert parent_after.entry_count == parent_count_before, "parent must remain untouched by child writes"
+        child_info = await child.info()
+        assert child_info.entry_count == parent_count_before + 3, "child sees parent + own entries"
+
+        child_msgs = await child.context()
+        # 4 parent message entries + 3 child message entries (anchor + handoff-event skipped).
+        assert len(child_msgs) == 7
+    finally:
+        await store.close()
+
+
+async def test_after_last_anchor_helper(tmp_path: Path) -> None:
+    """AC-08 — after_last_anchor returns only post-compaction entries."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "compact")
+        await session.append_message("user", "pre-compaction-1")
+        await session.append_message("assistant", "pre-compaction-2")
+        await session.handoff("compaction/0", state={"summary": "chat so far"})
+        await session.append_message("user", "post-1")
+        await session.append_message("assistant", "post-2")
+        post = await after_last_anchor(session.manager, session.tape_name)
+        messages = [e for e in post if e.kind == "message"]
+        assert len(messages) == 2
+        assert messages[0].payload.get("content") == "post-1"
+        assert messages[1].payload.get("content") == "post-2"
+    finally:
+        await store.close()
+
+
+async def test_kernel_context_exposes_session(tmp_path: Path) -> None:
+    """AC-10 — KernelContext.session returns the bound Session, read-only."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path)
+        bus = EventBus()
+        try:
+            ctx = KernelContext(
+                bus=bus,
+                logger=None,
+                config={},
+                state_dir=tmp_path,
+                plugin_name="test-plugin",
+                session=session,
+            )
+            assert ctx.session is session
+            with pytest.raises(AttributeError):
+                ctx.session = None  # type: ignore[misc]
+        finally:
+            await bus.close()
+    finally:
+        await store.close()
+
+
+async def test_info_reports_entry_and_anchor_counts(tmp_path: Path) -> None:
+    """`SessionInfo` tracks entries and the last anchor name."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path)
+        info = await session.info()
+        assert isinstance(info, SessionInfo)
+        # handoff appends (anchor, event) pair so bootstrap has 2 entries.
+        assert info.entry_count >= 1
+        assert info.last_anchor == "session/start"
+        before = info.entry_count
+        await session.append_message("user", "hi")
+        await session.handoff("checkpoint/1", state={})
+        info2 = await session.info()
+        assert info2.entry_count > before
+        assert info2.last_anchor == "checkpoint/1"
+    finally:
+        await store.close()
+
+
+async def test_append_tool_call_and_result_round_trip(tmp_path: Path) -> None:
+    """`append_tool_call` / `append_tool_result` land on the tape as expected."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path)
+        await session.append_tool_call({
+            "id": "call-1",
+            "name": "echo",
+            "args": {"text": "hi"},
+        })
+        await session.append_tool_result(
+            tool_call_id="call-1",
+            result={"ok": True, "value": "hi"},
+        )
+        entries = await session.entries()
+        kinds = [e.kind for e in entries]
+        assert "tool_call" in kinds
+        assert "tool_result" in kinds
+    finally:
+        await store.close()
+
+
+async def test_file_backed_store_roundtrip(tmp_path: Path) -> None:
+    """File-backed store persists + reloads across SessionStore instances."""
+    tapes_dir = tmp_path / "tapes"
+    store1 = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session = await store1.open(tmp_path, "persist-test")
+        await session.append_message("user", "saved")
+    finally:
+        await store1.close()
+
+    store2 = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session2 = await store2.open(tmp_path, "persist-test")
+        entries = await session2.entries()
+        messages = [e for e in entries if e.kind == "message"]
+        assert len(messages) == 1
+        assert messages[0].payload.get("content") == "saved"
+    finally:
+        await store2.close()
+
+
+def test_default_session_dir_honours_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`default_session_dir` respects YAYA_STATE_DIR override."""
+    monkeypatch.setenv("YAYA_STATE_DIR", str(tmp_path))
+    assert default_session_dir() == tmp_path / "tapes"
+
+
+def test_default_session_dir_falls_back_to_xdg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """`default_session_dir` uses XDG_STATE_HOME when YAYA_STATE_DIR is unset."""
+    monkeypatch.delenv("YAYA_STATE_DIR", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    assert default_session_dir() == tmp_path / "yaya" / "tapes"
+
+
+def test_tape_name_for_is_deterministic(tmp_path: Path) -> None:
+    """`tape_name_for` is stable for the same (workspace, session_id)."""
+    a = tape_name_for(tmp_path, "default")
+    b = tape_name_for(tmp_path, "default")
+    assert a == b
+    c = tape_name_for(tmp_path, "other")
+    assert a != c

--- a/tests/kernel/test_session.py
+++ b/tests/kernel/test_session.py
@@ -236,3 +236,119 @@ def test_tape_name_for_is_deterministic(tmp_path: Path) -> None:
     assert a == b
     c = tape_name_for(tmp_path, "other")
     assert a != c
+
+
+async def test_session_tail_bounded_memory(tmp_path: Path) -> None:
+    """File-backed ``Session.tail`` streams via a bounded deque (PR #88 finding).
+
+    Reproduces the ``yaya session show --tail N`` hot path: writes many
+    entries to the file store, asks for the last few, and asserts only
+    those come back. The deque cap is what makes this safe for 10 MB
+    tapes; the test does not try to measure RSS directly — it pins the
+    public contract (return order + count) so a regression to
+    ``entries()[-n:]`` would surface via the full-load sanity check
+    below.
+    """
+    tapes_dir = tmp_path / "tapes"
+    store = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session = await store.open(tmp_path, "tail-me")
+        for i in range(50):
+            await session.append_message("user", f"msg-{i}")
+        last5 = await session.tail(5)
+        assert len(last5) == 5
+        contents = [e.payload.get("content") for e in last5 if e.kind == "message"]
+        assert contents == ["msg-45", "msg-46", "msg-47", "msg-48", "msg-49"]
+        # n <= 0 is a no-op.
+        assert await session.tail(0) == []
+        assert await session.tail(-1) == []
+    finally:
+        await store.close()
+
+
+async def test_session_tail_delegates_for_memory_store(tmp_path: Path) -> None:
+    """Memory / fork-overlay stores fall back to ``entries()[-n:]``.
+
+    The deque-based streaming path is file-only; for in-memory stores
+    everything already sits in RAM, so ``Session.tail`` slices the
+    existing entry list. Verifying the count keeps the contract honest
+    without peering at private storage.
+    """
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await store.open(tmp_path, "mem-tail")
+        for i in range(10):
+            await session.append_message("user", f"m-{i}")
+        tail = await session.tail(3)
+        assert len(tail) == 3
+        contents = [e.payload.get("content") for e in tail if e.kind == "message"]
+        assert contents == ["m-7", "m-8", "m-9"]
+    finally:
+        await store.close()
+
+
+async def test_file_tape_store_append_is_constant_time(tmp_path: Path) -> None:
+    """Cached next-id keeps per-append latency flat (PR #88 finding).
+
+    Before the cache, ``_FileTapeStore.append`` re-parsed the whole jsonl
+    file on every write to compute ``next_id``; at 100 appends the last
+    call did ~100x the work of the first. This test is a loose regression
+    guard — a 5x ratio is plenty to catch re-introduction of the O(n)
+    path while staying robust against cold-import and filesystem jitter.
+    """
+    import time
+
+    tapes_dir = tmp_path / "tapes"
+    store = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session = await store.open(tmp_path, "perf")
+        # Warm the store / file-system caches before measuring.
+        await session.append_message("user", "warm")
+
+        timings: list[float] = []
+        for i in range(100):
+            t0 = time.perf_counter()
+            await session.append_message("user", f"m-{i}")
+            timings.append(time.perf_counter() - t0)
+        # Skip the first few samples — they swallow any residual cold-path
+        # cost (dir metadata caches, etc.). Tail average vs head average
+        # keeps the signal robust against per-call jitter.
+        head = sum(timings[5:15]) / 10
+        tail = sum(timings[-10:]) / 10
+        # Guard against division-by-zero on freakishly-fast runs.
+        ratio = tail / head if head > 0 else 1.0
+        assert ratio < 5.0, f"append latency grew {ratio:.1f}x head-to-tail (timings={timings!r})"
+    finally:
+        await store.close()
+
+
+async def test_file_tape_store_next_id_cache_invalidated_on_reset(tmp_path: Path) -> None:
+    """``reset()`` must drop the cached next-id so the next append restarts at 1.
+
+    Regression guard: leaving the cache in place after a wipe would stamp
+    fresh entries with stale, non-monotonic ids — and worse, it would
+    collide with surviving archive rows.
+    """
+    tapes_dir = tmp_path / "tapes"
+    store = SessionStore(tapes_dir=tapes_dir)
+    try:
+        session = await store.open(tmp_path, "cache-reset")
+        await session.append_message("user", "before-reset-1")
+        await session.append_message("user", "before-reset-2")
+        before = await session.entries()
+        ids_before = [e.id for e in before]
+        # Bootstrap (anchor + event) + 2 messages → 4 entries, ids 1..4.
+        assert ids_before == list(range(1, len(ids_before) + 1))
+
+        await session.reset(archive=False)
+        # After reset the file is gone and the cache entry has been dropped;
+        # the next append should start from id=1 again (after the re-seeded
+        # session/start anchor + its event).
+        await session.append_message("user", "after-reset")
+        after = await session.entries()
+        ids_after = [e.id for e in after]
+        assert ids_after == list(range(1, len(ids_after) + 1)), (
+            f"next-id cache not invalidated on reset; ids={ids_after!r}"
+        )
+    finally:
+        await store.close()

--- a/tests/kernel/test_session_bus.py
+++ b/tests/kernel/test_session_bus.py
@@ -1,0 +1,274 @@
+"""Tests for the session auto-persister — bus event → tape entry mapping."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from yaya.kernel import (
+    EventBus,
+    MemoryTapeStore,
+    SessionStore,
+    install_session_persister,
+    new_event,
+)
+
+_PERSISTED_KINDS = [
+    "user.message.received",
+    "assistant.message.done",
+    "tool.call.request",
+    "tool.call.result",
+    "assistant.message.delta",  # skipped but the persister still subscribes.
+    "memory.query",
+]
+
+
+async def _setup(
+    tmp_path: Path,
+    session_id: str = "default",
+) -> tuple[EventBus, SessionStore, Any]:
+    bus = EventBus()
+    store = SessionStore(store=MemoryTapeStore())
+    persister = await install_session_persister(
+        bus=bus,
+        store=store,
+        workspace=tmp_path,
+        kinds=_PERSISTED_KINDS,
+    )
+    # Pre-open the session so the bootstrap anchor does not race the first
+    # persisted event and the test assertions count only "post-bootstrap" rows.
+    await store.open(tmp_path, session_id)
+    return bus, store, persister
+
+
+async def test_user_and_assistant_events_round_trip(tmp_path: Path) -> None:
+    """AC-02 — user.message.received + assistant.message.done both persist."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "hi"},
+                session_id="default",
+                source="adapter-test",
+            )
+        )
+        await bus.publish(
+            new_event(
+                "assistant.message.done",
+                {"content": "hello", "tool_calls": []},
+                session_id="default",
+                source="kernel",
+            )
+        )
+        # Drain the bus.
+        await bus.close()
+        session = await store.open(tmp_path, "default")
+        entries = await session.entries()
+        messages = [e for e in entries if e.kind == "message"]
+        assert len(messages) == 2
+        assert messages[0].payload == {"role": "user", "content": "hi"}
+        assert messages[0].meta.get("source") == "adapter-test"
+        assert messages[1].payload == {"role": "assistant", "content": "hello"}
+        assert messages[1].meta.get("source") == "kernel"
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+async def test_assistant_delta_is_not_persisted(tmp_path: Path) -> None:
+    """AC-03 — assistant.message.delta is ignored by the persister."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        session = await store.open(tmp_path, "default")
+        before = len(await session.entries())
+        for i in range(10):
+            await bus.publish(
+                new_event(
+                    "assistant.message.delta",
+                    {"content": f"chunk-{i}"},
+                    session_id="default",
+                    source="llm-test",
+                )
+            )
+        await bus.close()
+        after = len(await session.entries())
+        assert after == before
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+async def test_persist_false_opts_out(tmp_path: Path) -> None:
+    """AC-04 — ``persist=False`` in payload suppresses the entry."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        session = await store.open(tmp_path, "default")
+        before = len(await session.entries())
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "skip me", "persist": False},
+                session_id="default",
+                source="adapter-test",
+            )
+        )
+        await bus.close()
+        after = len(await session.entries())
+        assert after == before
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+async def test_tool_call_and_result_persist(tmp_path: Path) -> None:
+    """tool.call.request and tool.call.result land as tool_call / tool_result."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        await bus.publish(
+            new_event(
+                "tool.call.request",
+                {"id": "c1", "name": "echo", "args": {"text": "hi"}},
+                session_id="default",
+                source="kernel",
+            )
+        )
+        await bus.publish(
+            new_event(
+                "tool.call.result",
+                {"id": "c1", "ok": True, "value": "hi"},
+                session_id="default",
+                source="tool-test",
+            )
+        )
+        await bus.close()
+        session = await store.open(tmp_path, "default")
+        entries = await session.entries()
+        kinds = [e.kind for e in entries]
+        assert "tool_call" in kinds
+        assert "tool_result" in kinds
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+async def test_kernel_session_events_skipped(tmp_path: Path) -> None:
+    """Events on session_id='kernel' never land on any tape."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "ignore"},
+                session_id="kernel",
+                source="adapter-test",
+            )
+        )
+        await bus.close()
+        tapes = await store.list_sessions(tmp_path)
+        for info in tapes:
+            # No tape should hold a user message from the kernel session.
+            session = await store.open(tmp_path, info.session_id)
+            msgs = [e for e in await session.entries() if e.kind == "message"]
+            for m in msgs:
+                assert m.payload.get("content") != "ignore"
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+async def test_generic_event_falls_through_as_event_entry(tmp_path: Path) -> None:
+    """Any public kind without a canonical writer lands as a generic event entry."""
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        await bus.publish(
+            new_event(
+                "memory.query",
+                {"query": "what is x", "k": 3},
+                session_id="default",
+                source="kernel",
+            )
+        )
+        await bus.close()
+        session = await store.open(tmp_path, "default")
+        events = [e for e in await session.entries() if e.kind == "event"]
+        assert any(e.payload.get("name") == "memory.query" for e in events)
+    finally:
+        await persister.stop()
+        await store.close()
+
+
+class _RaisingStore:
+    """SessionStore shim whose `.open` returns a session whose append raises."""
+
+    def __init__(self, store: SessionStore) -> None:
+        self._inner = store
+
+    async def open(self, workspace: Path, session_id: str):
+        session = await self._inner.open(workspace, session_id)
+
+        async def _raise(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("simulated tape write failure")
+
+        session.append_message = _raise  # type: ignore[assignment]
+        session.append_tool_call = _raise  # type: ignore[assignment]
+        session.append_tool_result = _raise  # type: ignore[assignment]
+        session.append_event = _raise  # type: ignore[assignment]
+        return session
+
+
+async def test_tape_failure_emits_plugin_error(tmp_path: Path) -> None:
+    """AC-09 — tape-write failure emits plugin.error, bus keeps routing."""
+    bus = EventBus()
+    inner = SessionStore(store=MemoryTapeStore())
+    raising = _RaisingStore(inner)
+    errors: list[Any] = []
+
+    async def capture(ev: Any) -> None:
+        errors.append(ev)
+
+    err_sub = bus.subscribe("plugin.error", capture, source="test")
+    persister = await install_session_persister(
+        bus=bus,
+        store=raising,
+        workspace=tmp_path,
+        kinds=["user.message.received"],
+    )
+    try:
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "boom"},
+                session_id="default",
+                source="adapter-test",
+            )
+        )
+        # Give the kernel-session worker a chance to drain the synthetic error.
+        await asyncio.sleep(0.01)
+        # Publish another event and verify the bus still routes it.
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "still alive"},
+                session_id="default",
+                source="adapter-test",
+            )
+        )
+        await asyncio.sleep(0.01)
+        assert any(ev.payload.get("name") == "kernel-session-persister" for ev in errors)
+    finally:
+        err_sub.unsubscribe()
+        await persister.stop()
+        await inner.close()
+        await bus.close()
+
+
+async def test_persister_stop_is_idempotent(tmp_path: Path) -> None:
+    bus, store, persister = await _setup(tmp_path)
+    try:
+        await persister.stop()
+        await persister.stop()
+    finally:
+        await store.close()
+        await bus.close()

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,43 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.96.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930 },
+]
+
+[[package]]
+name = "any-llm-sdk"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "openai" },
+    { name = "openresponses-types" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/4b/dea4eeeb5e4e3e55fa6b37a7ec033a18a2527aabf565bd598071d6308fbd/any_llm_sdk-1.13.0.tar.gz", hash = "sha256:967c5f4dd099f5f6cc9673f2888d5550f6e821d25341d31133a05741c1ce903e", size = 153753 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/a1/0106667efdf870595981a0fc3e807675d1f8ded8dc8c20e936e6c42bcd95/any_llm_sdk-1.13.0-py3-none-any.whl", hash = "sha256:7e456a843cec249ae1cb3a498aa89df5baff8aa62d76a24718babb3b8a51e495", size = 216557 },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -39,6 +76,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353 },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779 },
 ]
 
 [[package]]
@@ -57,6 +107,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684 },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320 },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487 },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049 },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793 },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300 },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244 },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828 },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926 },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328 },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650 },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687 },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773 },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013 },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354 },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480 },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584 },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443 },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437 },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487 },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726 },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195 },
 ]
 
 [[package]]
@@ -129,6 +212,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869 },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492 },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670 },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275 },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402 },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985 },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652 },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805 },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883 },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756 },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244 },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868 },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504 },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363 },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671 },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551 },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887 },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354 },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845 },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641 },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749 },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942 },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079 },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999 },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191 },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782 },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227 },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332 },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618 },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628 },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405 },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715 },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400 },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634 },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233 },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955 },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888 },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961 },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696 },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256 },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001 },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985 },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -144,6 +280,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484 },
 ]
 
 [[package]]
@@ -337,6 +482,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957 },
     { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690 },
     { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338 },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464 },
 ]
 
 [[package]]
@@ -650,6 +807,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openresponses-types"
+version = "2.3.0.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/5f/e16dad89ed24f586da5b01b9b206d3adbf21fe1af8e4dc55d5b93158fde6/openresponses_types-2.3.0.post1-py3-none-any.whl", hash = "sha256:88f6abcef9cad839203abff420dd080978bf6eb33cc06ddc5d78da4ccdba7613", size = 13847 },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -730,6 +899,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437 },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172 },
 ]
 
 [[package]]
@@ -1066,6 +1244,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722 },
+]
+
+[[package]]
+name = "republic"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "any-llm-sdk" },
+    { name = "authlib" },
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/40/9ebd36e489696c0904df18bf4da6edc4b87f203b55f6942d3f782c69530c/republic-0.5.7.tar.gz", hash = "sha256:74cb0a02c3dffaa3438a8f41d19b137b7c8310a7d6c2c821b81cf98d5167200a", size = 155715 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/33/26f4ad2665f96af4d02ae9c6f629e1d0c2538f22cecece3f8df6cd4c1da0/republic-0.5.7-py3-none-any.whl", hash = "sha256:702e2a3b662a91e68cc9c5b4893460dba01e02f081f309e6ce30d1e79c336db3", size = 62290 },
 ]
 
 [[package]]
@@ -1462,6 +1655,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "republic" },
     { name = "rich" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1500,6 +1694,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.52.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "republic", specifier = ">=0.5.4" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary

Implements issue #32 — replace ad-hoc in-memory session state with a
**tape**: append-only, anchor-aware event log persisted via `republic`'s
`AsyncTapeManager` / `TapeStore` primitives. Every session is a tape;
every relevant bus event is appended; anchors mark boundaries. LLM
context becomes a derived view (`TapeContext` + `select_messages`),
not mutable state — so fork / reset / compaction never mutate past
entries.

### Deliverables (11-item brief)

- [x] `republic>=0.5.4` runtime dep (with mypy override scoped to the
  three tape-touching kernel modules — republic ships without
  `py.typed`, so the override is preferred over weakening
  project-wide flags).
- [x] `src/yaya/kernel/session.py` — `SessionStore`, `Session`,
  `SessionInfo`, `MemoryTapeStore`, jsonl `_FileTapeStore`,
  `_ForkOverlayStore`.
- [x] `src/yaya/kernel/tape_context.py` — default selection +
  `after_last_anchor` helper.
- [x] `src/yaya/kernel/events.py` — `session.{started,handoff,reset,
  archived,forked}` lifecycle events + typed payloads.
- [x] Bus auto-persistence via `SessionPersister`. Subscribes to every
  public kind and translates per the bus → tape table. Honours
  `persist=False` / `__persist__=False` opt-out. Skips
  `assistant.message.delta` (too chatty) and the session lifecycle
  events themselves (no duplicate anchors). On tape-write failure
  emits `plugin.error` on the **kernel** session via a distinct
  `source` so the bus recursion guard does not fire on the
  originating FIFO (lesson #2 compliance).
- [x] `KernelContext.session` wired through `PluginRegistry`.
- [x] `src/yaya/cli/commands/session.py` — `yaya session list|show|
  resume|archive` Typer subapp registered on the root.
- [x] `SessionConfig` (`store` / `dir` / `default_id`) attached to
  `KernelConfig.session`.
- [x] `docs/dev/plugin-protocol.md` — "Sessions and tape" section.
- [x] `specs/kernel-session-tape.spec` + matching feature file.
- [x] Tests: 10 BDD acceptance scenarios, plus unit / integration
  coverage for every helper.

### Lesson #2 compliance (persister never re-publishes on success)

`SessionPersister._on_event` calls `Session.append_*` directly — those
write to the tape store, never to the bus. The only bus write is the
synthetic `plugin.error` on tape-write failure, routed on
`session_id="kernel"` and filtered out by the persister's own handler.

### Test plan
- [x] `just check` — ruff / mypy / pyright / agent-spec lifecycle all
  green. The 8 `.spec ↔ .feature` orphan failures are inherited from
  main and tracked in #86; this PR does not add an orphan
  (`kernel-session-tape.{spec,feature}` mirror cleanly).
- [x] `just test` — 472 passed (the 2 pre-existing
  `test_plugins.py` strategy_react failures are inherited from main).
- [x] Coverage: 88% (gate is 80%).
- [x] Manual: `yaya session list` / `yaya session show <id>` /
  `yaya session archive <id> --yes` exercised in CLI tests.

### CI status caveat

`scripts/check_feature_sync.py` is currently red on `main` because of 8
pre-existing orphan specs. That is being fixed in #86 (in another
worktree); this PR does not touch that script and its own
`.spec ↔ .feature` mirror is clean.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)