### PR TITLE
feat(plugins): mcp_bridge — load external MCP servers as yaya tools (#31)

### DIFF
--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -136,6 +136,13 @@ namespace for plugin-private payloads (e.g., a `stats` skill plugin
 emitting `x.stats.token.counted`). Do not use `x.*` as a workaround
 for missing public events — propose a public event kind instead.
 
+**Private session ids.** Plugins may use session ids prefixed with
+`_bridge:<plugin-name>` for internal routing (publishing to themselves
+without touching a user-facing session). This reserves `_bridge:` as a
+plugin-private namespace; user / adapter sessions MUST NOT start with
+`_bridge:`. Example: `mcp_bridge` routes lifecycle events on
+`_bridge:mcp-bridge`.
+
 Currently in use by bundled plugins:
 
 | Extension kind | Owner | Payload | Purpose |

--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -136,6 +136,13 @@ namespace for plugin-private payloads (e.g., a `stats` skill plugin
 emitting `x.stats.token.counted`). Do not use `x.*` as a workaround
 for missing public events — propose a public event kind instead.
 
+Currently in use by bundled plugins:
+
+| Extension kind | Owner | Payload | Purpose |
+|---|---|---|---|
+| `x.mcp.server.ready` | `mcp_bridge` | `{ server: str, tools: list[{name, mcp_name, description}] }` | One emit per MCP server the bridge brought up at boot. |
+| `x.mcp.server.error` | `mcp_bridge` | `{ server: str, kind: "config_invalid" \| "boot_failed", message: str }` | One emit per MCP server that failed config validation or exhausted boot retries. The bridge keeps running. |
+
 ### What makes the set "closed"
 
 - A PR that introduces a new **public** event kind (anything not under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ memory_sqlite = "yaya.plugins.memory_sqlite:plugin"
 llm_openai = "yaya.plugins.llm_openai:plugin"
 llm_echo = "yaya.plugins.llm_echo:plugin"
 tool_bash = "yaya.plugins.tool_bash:plugin"
+mcp_bridge = "yaya.plugins.mcp_bridge:plugin"
 web = "yaya.plugins.web:plugin"
 
 [project.urls]

--- a/specs/plugin-mcp_bridge.spec
+++ b/specs/plugin-mcp_bridge.spec
@@ -1,0 +1,145 @@
+spec: task
+name: "plugin-mcp_bridge"
+tags: [plugin, tool, mcp]
+---
+
+## Intent
+
+The MCP bridge plugin loads external Model Context Protocol servers
+configured under `[mcp_bridge.servers.<name>]` and registers each
+server-advertised tool as a native yaya `Tool`. Each derived tool
+defaults to `requires_approval=True` because MCP servers are
+external untrusted code surfaces (issue #31 hard rule). The bridge
+owns the subprocess lifecycle for every spawned server: boot uses
+3 retries with exponential backoff, teardown follows the lesson #31
+terminate-then-kill pattern, and per-server failures emit the
+plugin-private `x.mcp.server.error` event without tainting the rest
+of the bridge.
+
+## Decisions
+
+- Subscribes to no public events. Inbound `tool.call.request` for
+  MCP-derived tools flow through the kernel's v1 dispatcher
+  (`yaya.kernel.tool.dispatch`), which looks the tool up in the
+  registry populated during `on_load` via
+  `yaya.kernel.tool.register_tool`.
+- Each MCP-derived tool's yaya-side name is
+  `mcp_<server>_<tool>` so collisions across servers are
+  impossible and the LLM function-calling surface receives a
+  stable identifier.
+- The MCP stdio wire format is implemented inline as a vendored
+  newline-delimited JSON-RPC 2.0 client; no `mcp` or `fastmcp`
+  dependency. Per AGENT.md §4, MCP is a protocol not an agent
+  framework, but vendoring keeps the dependency footprint flat.
+- Boot retries use a fixed 0.5 / 1.0 / 2.0 second exponential
+  backoff. After three exhausted attempts the server is given up
+  on, the bridge emits `x.mcp.server.error` with
+  `kind="boot_failed"`, and the rest of the bridge keeps running.
+- Subprocess teardown in `MCPClient.close` runs `terminate()`
+  first, awaits exit under a bounded `wait_for(proc.wait(),
+  grace_s)`, and falls back to `kill()` if the child does not
+  cooperate (lesson #31).
+- Approval default is True for every derived tool; a per-server
+  `requires_approval = false` config override exists for trusted
+  operators but is never the default.
+- Tool exception paths route through `Tool.run` and translate
+  every `MCPClientError` / timeout / crash to a `ToolError`
+  envelope with a kind chosen from `timeout`, `crashed`,
+  `internal` (lesson #29 — no raw exception reaches the
+  dispatcher).
+
+## Boundaries
+
+### Allowed Changes
+- src/yaya/plugins/mcp_bridge/__init__.py
+- src/yaya/plugins/mcp_bridge/plugin.py
+- src/yaya/plugins/mcp_bridge/client.py
+- src/yaya/plugins/mcp_bridge/config.py
+- src/yaya/plugins/mcp_bridge/tool_factory.py
+- src/yaya/plugins/mcp_bridge/AGENT.md
+- tests/plugins/mcp_bridge/__init__.py
+- tests/plugins/mcp_bridge/_fake_server.py
+- tests/plugins/mcp_bridge/test_mcp_bridge.py
+- tests/bdd/features/plugin-mcp_bridge.feature
+- specs/plugin-mcp_bridge.spec
+- pyproject.toml
+- docs/dev/plugin-protocol.md
+
+### Forbidden
+- src/yaya/kernel/
+- src/yaya/cli/
+- src/yaya/core/
+- src/yaya/plugins/strategy_react/
+- src/yaya/plugins/memory_sqlite/
+- src/yaya/plugins/llm_openai/
+- src/yaya/plugins/tool_bash/
+- GOAL.md
+
+## Completion Criteria
+
+Scenario: Discovers tools from a fake MCP server and registers them by qualified name
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_discovers_and_registers_tools
+  Level: integration
+  Given a fake MCP server exposing one tool echo with a string parameter
+  When the bridge loads with that server configured
+  Then the kernel tool registry contains a tool named mcp_local_echo
+  And an x.mcp.server.ready event is emitted naming the server and its tools
+
+Scenario: Approval default is True for every MCP derived tool
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_derived_tool_requires_approval_by_default
+  Level: unit
+  Given a fake MCP server descriptor for a tool named echo
+  When the tool factory builds a yaya Tool subclass with the bridge default
+  Then the resulting class requires approval
+
+Scenario: Tool call forwards arguments and wraps the response in ToolOk
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_tool_call_forwards_and_wraps_ok
+  Level: integration
+  Given a loaded bridge with a fake MCP server exposing echo
+  When the echo tool is invoked through the kernel dispatcher with an approved gate
+  Then the dispatcher emits one tool.call.result with ok true
+  And the envelope brief reflects the echoed text
+
+Scenario: Boot failure exhausts retries and emits x mcp server error
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_boot_failure_emits_server_error_after_retries
+  Level: integration
+  Given a fake MCP server factory that always fails to start
+  When the bridge loads with retries collapsed
+  Then no tools are registered for the failing server
+  And exactly one x.mcp.server.error event is emitted with kind boot_failed
+
+Scenario: Bad config entry surfaces as x mcp server error without tainting siblings
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_bad_config_emits_error_and_does_not_taint_others
+  Level: unit
+  Given a configuration mixing one valid server and one server whose command field is empty
+  When the bridge loads
+  Then an x.mcp.server.error event is emitted naming the bad server
+  And the valid server still registers its tool
+
+Scenario: Unload closes every spawned client deterministically
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mcp_bridge/test_mcp_bridge.py::test_unload_closes_every_client
+  Level: integration
+  Given a loaded bridge with two fake MCP servers
+  When on_unload runs
+  Then close has been awaited on both client instances
+
+## Out of Scope
+
+- SSE / HTTP transport for remote MCP servers (stdio only at 0.1).
+- Hot reload of the bridge after editing `~/.config/yaya/config.toml` —
+  restart `yaya serve` for now.
+- Per-tool rate limiting and quota tracking.
+- A dedicated `yaya mcp` CLI subcommand: GOAL.md restricts kernel
+  built-ins; the bridge surfaces normally through `yaya plugin list`.

--- a/src/yaya/plugins/mcp_bridge/AGENT.md
+++ b/src/yaya/plugins/mcp_bridge/AGENT.md
@@ -2,30 +2,28 @@
 MCP bridge plugin. Spawns external MCP servers configured under `[mcp_bridge.servers.<name>]`, discovers their tools over the standard MCP stdio handshake, and registers each as a native yaya `Tool`. The bridge is the single place where untrusted external tool surfaces enter yaya — every derived tool defaults to `requires_approval=True`.
 
 ## External Reality
-- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (Tool row + `x.<plugin>.<kind>` extension namespace).
-- Contract: [`specs/plugin-mcp_bridge.spec`](../../../../specs/plugin-mcp_bridge.spec).
-- Tests: `tests/plugins/mcp_bridge/`.
-- MCP protocol reference: <https://spec.modelcontextprotocol.io/>. We speak the `2024-11-05` revision of the stdio transport.
+- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (Tool row + `x.<plugin>.<kind>` namespace).
+- Contract: [`specs/plugin-mcp_bridge.spec`](../../../../specs/plugin-mcp_bridge.spec); tests under `tests/plugins/mcp_bridge/`.
+- MCP stdio wire format: <https://spec.modelcontextprotocol.io/> (`2024-11-05`).
 
 ## Constraints
-- `Category.TOOL`. Subscribes to **nothing**: dispatch happens through the kernel's v1 tool dispatcher (`yaya.kernel.tool.dispatch`) using the registry populated in `on_load`.
-- **Vendored client.** No `mcp` / `fastmcp` dependency — the stdio MCP wire format is newline-delimited JSON-RPC 2.0; a 200-line client lives in `client.py` per AGENT.md §4 ("vendor a minimal implementation"). MCP itself is a *protocol*, not an agent framework, but pulling in the upstream SDKs would drag in a large pydantic + HTTP graph we do not need at 0.1.
-- **Subprocess lifecycle (lesson #31).** Every client teardown follows `terminate()` → `wait_for(proc.wait(), grace_s)` → `kill()` fallback. No bare `proc.wait()` without a deadline.
-- **Boot retries.** Three attempts with 0.5/1.0/2.0 s exponential backoff (configurable via `MCPBridge(retry_delays_s=...)` for tests). On exhaustion the bridge emits `x.mcp.server.error` and keeps the rest of the bridge running — fail loud, degrade gracefully.
-- **Approval gate (issue #31 hard rule).** `requires_approval=True` is the default for every MCP-derived tool. A per-server `requires_approval = false` override exists for trusted operators but the default is **never** flipped without an explicit config opt-in.
-- **Pre-approve translation (lesson #29).** All `MCPClientError` / `OSError` / `TimeoutError` paths route through `tool.run` and translate to `ToolError(kind=...)`; no exception escapes the dispatcher.
-- **Extension events.** `x.mcp.server.ready` / `x.mcp.server.error` are plugin-private per GOAL.md principle #3 — they route through the bus but are NOT in the closed public catalog.
+- `Category.TOOL`. Subscribes to **nothing**: dispatch goes through the kernel's v1 tool dispatcher (`yaya.kernel.tool.dispatch`) over the registry populated in `on_load`.
+- **Vendored client.** No `mcp` / `fastmcp` dependency — MCP stdio is newline-delimited JSON-RPC 2.0; a ~200-line client lives in `client.py` per root AGENT.md §4 ("vendor a minimal implementation"). The upstream SDKs would drag a large pydantic + HTTP graph we do not need at 0.1.
+- **Subprocess lifecycle (lesson #31).** Every teardown follows `terminate()` → `wait_for(proc.wait(), grace_s)` → `kill()` fallback. No bare `proc.wait()` without a deadline.
+- **Boot retries.** Three attempts, 0.5/1.0/2.0 s backoff (override via `MCPBridge(retry_delays_s=...)` in tests). On exhaustion: emit `x.mcp.server.error`, keep the rest of the bridge running.
+- **Approval gate (issue #31 hard rule).** `requires_approval=True` is the default for every MCP-derived tool. Per-server `requires_approval = false` exists for trusted operators but is **never** flipped without an explicit config opt-in.
+- **Error translation (lesson #29).** `MCPClientError` / `OSError` / `TimeoutError` route through `tool.run` and translate to `ToolError(kind=...)`; no exception escapes the dispatcher.
+- **Extension events.** `x.mcp.server.ready` / `x.mcp.server.error` are plugin-private (GOAL.md #3) — bus-routed, not in the closed public catalog.
 
-## Interaction (patterns)
-- **Add a server.** Drop a `[mcp_bridge.servers.<name>]` table in `~/.config/yaya/config.toml` with `command`, `args`, optional `env`, `enabled`. Restart `yaya serve`; tools appear as `mcp_<server>_<tool>`.
-
-Example config:
+## Interaction
+Drop a table into `~/.config/yaya/config.toml` and restart `yaya serve`; tools appear as `mcp_<server>_<tool>`:
 
 ```toml
+# filesystem: no env needed
 [mcp_bridge.servers.filesystem]
 command = "npx"
 args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
-env = {}  # no env needed
+env = {}
 enabled = true
 requires_approval = true  # default — file access is sensitive
 call_timeout_s = 30.0
@@ -36,14 +34,10 @@ args = ["mcp-server-github"]
 env = { GITHUB_TOKEN = "$GITHUB_TOKEN" }  # expanded from process env
 ```
 
-Set `requires_approval = false` per-server only for tools you audit yourself.
-
-- **Env expansion.** `$VAR` / `${VAR}` in `command`, `args`, and `env` values is expanded via `os.path.expandvars` against the process env at boot.
-- **Hot reload.** Not supported at 0.1 — restart `yaya serve` after a config change. Tracked under the wider plugin hot-reload story.
+`$VAR` / `${VAR}` in `command`, `args`, and `env` values expands via `os.path.expandvars` at boot. Hot reload is not supported at 0.1 — restart after a config change.
 
 ## Testing knobs
-`MCPBridge(retry_delays_s=(0.0,))` collapses retries for fast tests. `MCPBridge(client_factory=...)` lets a test inject a fake client honouring the `start` / `call_tool` / `close` surface. The integration test ships a tiny pure-Python stdio MCP server under `tests/plugins/mcp_bridge/_fake_server.py` — no network, no subprocess of `npx` or `uvx`.
+`MCPBridge(retry_delays_s=(0.0,))` collapses retries; `MCPBridge(client_factory=...)` injects a fake honouring `start` / `call_tool` / `close`. The integration test ships a pure-Python stdio MCP server at `tests/plugins/mcp_bridge/_fake_server.py` — no network, no `npx` / `uvx` subprocess.
 
 ## Budget & Loading
-- Sibling: [`../AGENT.md`](../AGENT.md). Authoritative protocol: [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md#tool-execution-kernel--tool).
-- Lessons honoured: #15 (`request_id` echo via the dispatcher), #29 (exception translation in `tool.run`), #31 (subprocess cancel pattern in `client.close`).
+Sibling: [`../AGENT.md`](../AGENT.md). Lessons honoured: #15 (`request_id` echo), #29 (exception translation in `tool.run`), #31 (subprocess cancel in `client.close`).

--- a/src/yaya/plugins/mcp_bridge/AGENT.md
+++ b/src/yaya/plugins/mcp_bridge/AGENT.md
@@ -1,0 +1,29 @@
+## Philosophy
+MCP bridge plugin. Spawns external MCP servers configured under `[mcp_bridge.servers.<name>]`, discovers their tools over the standard MCP stdio handshake, and registers each as a native yaya `Tool`. The bridge is the single place where untrusted external tool surfaces enter yaya — every derived tool defaults to `requires_approval=True`.
+
+## External Reality
+- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (Tool row + `x.<plugin>.<kind>` extension namespace).
+- Contract: [`specs/plugin-mcp_bridge.spec`](../../../../specs/plugin-mcp_bridge.spec).
+- Tests: `tests/plugins/mcp_bridge/`.
+- MCP protocol reference: <https://spec.modelcontextprotocol.io/>. We speak the `2024-11-05` revision of the stdio transport.
+
+## Constraints
+- `Category.TOOL`. Subscribes to **nothing**: dispatch happens through the kernel's v1 tool dispatcher (`yaya.kernel.tool.dispatch`) using the registry populated in `on_load`.
+- **Vendored client.** No `mcp` / `fastmcp` dependency — the stdio MCP wire format is newline-delimited JSON-RPC 2.0; a 200-line client lives in `client.py` per AGENT.md §4 ("vendor a minimal implementation"). MCP itself is a *protocol*, not an agent framework, but pulling in the upstream SDKs would drag in a large pydantic + HTTP graph we do not need at 0.1.
+- **Subprocess lifecycle (lesson #31).** Every client teardown follows `terminate()` → `wait_for(proc.wait(), grace_s)` → `kill()` fallback. No bare `proc.wait()` without a deadline.
+- **Boot retries.** Three attempts with 0.5/1.0/2.0 s exponential backoff (configurable via `MCPBridge(retry_delays_s=...)` for tests). On exhaustion the bridge emits `x.mcp.server.error` and keeps the rest of the bridge running — fail loud, degrade gracefully.
+- **Approval gate (issue #31 hard rule).** `requires_approval=True` is the default for every MCP-derived tool. A per-server `requires_approval = false` override exists for trusted operators but the default is **never** flipped without an explicit config opt-in.
+- **Pre-approve translation (lesson #29).** All `MCPClientError` / `OSError` / `TimeoutError` paths route through `tool.run` and translate to `ToolError(kind=...)`; no exception escapes the dispatcher.
+- **Extension events.** `x.mcp.server.ready` / `x.mcp.server.error` are plugin-private per GOAL.md principle #3 — they route through the bus but are NOT in the closed public catalog.
+
+## Interaction (patterns)
+- **Add a server.** Drop a `[mcp_bridge.servers.<name>]` table in `~/.config/yaya/config.toml` with `command`, `args`, optional `env`, `enabled`. Restart `yaya serve`; tools appear as `mcp_<server>_<tool>`.
+- **Env expansion.** `$VAR` / `${VAR}` in `command`, `args`, and `env` values is expanded via `os.path.expandvars` against the process env at boot.
+- **Hot reload.** Not supported at 0.1 — restart `yaya serve` after a config change. Tracked under the wider plugin hot-reload story.
+
+## Testing knobs
+`MCPBridge(retry_delays_s=(0.0,))` collapses retries for fast tests. `MCPBridge(client_factory=...)` lets a test inject a fake client honouring the `start` / `call_tool` / `close` surface. The integration test ships a tiny pure-Python stdio MCP server under `tests/plugins/mcp_bridge/_fake_server.py` — no network, no subprocess of `npx` or `uvx`.
+
+## Budget & Loading
+- Sibling: [`../AGENT.md`](../AGENT.md). Authoritative protocol: [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md#tool-execution-kernel--tool).
+- Lessons honoured: #15 (`request_id` echo via the dispatcher), #29 (exception translation in `tool.run`), #31 (subprocess cancel pattern in `client.close`).

--- a/src/yaya/plugins/mcp_bridge/AGENT.md
+++ b/src/yaya/plugins/mcp_bridge/AGENT.md
@@ -18,6 +18,26 @@ MCP bridge plugin. Spawns external MCP servers configured under `[mcp_bridge.ser
 
 ## Interaction (patterns)
 - **Add a server.** Drop a `[mcp_bridge.servers.<name>]` table in `~/.config/yaya/config.toml` with `command`, `args`, optional `env`, `enabled`. Restart `yaya serve`; tools appear as `mcp_<server>_<tool>`.
+
+Example config:
+
+```toml
+[mcp_bridge.servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+env = {}  # no env needed
+enabled = true
+requires_approval = true  # default — file access is sensitive
+call_timeout_s = 30.0
+
+[mcp_bridge.servers.github]
+command = "uvx"
+args = ["mcp-server-github"]
+env = { GITHUB_TOKEN = "$GITHUB_TOKEN" }  # expanded from process env
+```
+
+Set `requires_approval = false` per-server only for tools you audit yourself.
+
 - **Env expansion.** `$VAR` / `${VAR}` in `command`, `args`, and `env` values is expanded via `os.path.expandvars` against the process env at boot.
 - **Hot reload.** Not supported at 0.1 — restart `yaya serve` after a config change. Tracked under the wider plugin hot-reload story.
 

--- a/src/yaya/plugins/mcp_bridge/__init__.py
+++ b/src/yaya/plugins/mcp_bridge/__init__.py
@@ -1,0 +1,24 @@
+"""MCP bridge plugin — load external MCP servers as native yaya tools.
+
+Bundled plugin satisfying the ``tool`` category. Reads the
+``[mcp_bridge.servers.<name>]`` config sub-tree, spawns each enabled
+server over stdio, discovers its tool list via the standard MCP
+``initialize`` + ``tools/list`` handshake, and registers each
+discovered tool as a dynamically-built :class:`~yaya.kernel.tool.Tool`
+subclass via :func:`yaya.kernel.tool.register_tool`.
+
+Each generated tool defaults to ``requires_approval=True`` because MCP
+servers are external code surfaces (see issue #31 hard rule).
+Subprocess lifecycle follows lesson #31: ``terminate()`` first, bounded
+``wait_for(proc.wait(), grace)``, ``kill()`` fallback. Boot uses 3
+attempts with exponential backoff; per-server failures emit
+``x.mcp.server.error`` (extension namespace) without tainting the rest
+of the bridge.
+"""
+
+from yaya.plugins.mcp_bridge.plugin import MCPBridge
+
+plugin: MCPBridge = MCPBridge()
+"""Entry-point target — referenced by ``yaya.plugins.v1`` in pyproject.toml."""
+
+__all__ = ["MCPBridge", "plugin"]

--- a/src/yaya/plugins/mcp_bridge/client.py
+++ b/src/yaya/plugins/mcp_bridge/client.py
@@ -1,0 +1,434 @@
+"""Minimal MCP stdio client — vendored per AGENT.md §4.
+
+The Model Context Protocol over stdio is newline-delimited
+JSON-RPC 2.0: the client writes ``{"jsonrpc":"2.0",...}\\n`` on the
+child's stdin and reads responses line-by-line from its stdout. The
+server's stderr is a free-form log stream we drain and route through
+the plugin logger.
+
+Pulling in ``fastmcp`` / ``mcp`` would add a heavy dependency graph
+(pydantic models of the full MCP namespace, HTTP transports, auth
+stacks) for capabilities we don't need at 0.1. A 200-line stdio client
+is the right trade-off (cf. ``docs/dev/no-agent-frameworks.md``:
+"vendor a minimal implementation"). This module is scoped to the
+*client* side of stdio MCP — server-side, SSE, HTTP, and OAuth are
+out of scope.
+
+Lessons honoured:
+
+* #29 — every exception path surfaces as a structured error; callers
+  translate to ``tool.error`` / ``plugin.error``.
+* #31 — subprocess cancellation uses ``terminate()`` +
+  ``wait_for(proc.wait(), BOUNDED)`` + ``kill()`` fallback so a
+  non-cooperative child cannot leak into the next test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import itertools
+import json
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+__all__ = [
+    "MCPClient",
+    "MCPClientError",
+    "MCPProtocolError",
+    "MCPServerCrashedError",
+    "MCPTimeoutError",
+    "MCPToolDescriptor",
+]
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_TERM_GRACE_S: float = 5.0
+"""Seconds we wait between ``terminate()`` and ``kill()`` (lesson #31)."""
+
+_INIT_TIMEOUT_S: float = 15.0
+"""Boot timeout for the ``initialize`` handshake + first ``tools/list``."""
+
+# MCP protocol version we advertise on ``initialize``. Servers that only
+# speak newer revisions are expected to downgrade gracefully; if they
+# refuse, the handshake surfaces as :class:`MCPProtocolError`.
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+
+
+class MCPClientError(RuntimeError):
+    """Base class for every MCP client failure surfaced by this module."""
+
+
+class MCPProtocolError(MCPClientError):
+    """The child process spoke MCP but the exchange violated the protocol.
+
+    Examples: malformed JSON, missing ``jsonrpc`` key, response to an
+    unknown request id, ``error`` payload on ``initialize``.
+    """
+
+
+class MCPServerCrashedError(MCPClientError):
+    """The child process exited unexpectedly while a call was in flight.
+
+    Carries the final return code so the caller can distinguish a clean
+    exit (rare but possible on shutdown races) from a crash.
+    """
+
+    def __init__(self, returncode: int | None) -> None:
+        super().__init__(f"MCP server exited (returncode={returncode})")
+        self.returncode = returncode
+
+
+class MCPTimeoutError(MCPClientError):
+    """A request exceeded its wall-clock budget.
+
+    Translated by the :class:`~yaya.plugins.mcp_bridge.tool_factory.MCPTool`
+    wrapper to ``ToolError(kind="timeout")``.
+    """
+
+
+@dataclass(slots=True, frozen=True)
+class MCPToolDescriptor:
+    """One tool declaration as returned by an MCP ``tools/list`` call.
+
+    Attributes:
+        name: Server-side tool name. The bridge namespaces this into
+            ``mcp_<server>_<name>`` before registering with yaya.
+        description: Server-supplied free text; surfaced to the LLM.
+        input_schema: JSON Schema dict for the tool's input. Used both
+            to build a pydantic model and to forward to the LLM
+            function-calling surface.
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+@dataclass(slots=True)
+class _PendingRequest:
+    """One in-flight JSON-RPC request awaiting a matching response."""
+
+    future: asyncio.Future[dict[str, Any]]
+    method: str
+
+
+class MCPClient:
+    """Minimal MCP stdio client — one instance per configured server.
+
+    Lifecycle::
+
+        client = MCPClient(command, args, env=..., logger=...)
+        tools = await client.start()  # spawn + initialize + tools/list
+        result = await client.call_tool("echo", {"msg": "hi"})
+        await client.close()
+
+    Thread model: single asyncio loop. Not safe to share across loops.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        logger: Any = None,
+        term_grace_s: float = _DEFAULT_TERM_GRACE_S,
+    ) -> None:
+        """Record wiring; no I/O until :meth:`start`.
+
+        Args:
+            command: Executable to spawn.
+            args: Additional argv entries.
+            env: Extra env vars merged over :data:`os.environ`. None
+                means "inherit the process env unchanged".
+            logger: Optional plugin-scoped logger; falls back to the
+                module logger when omitted.
+            term_grace_s: Seconds between ``terminate()`` and
+                ``kill()`` during :meth:`close`.
+        """
+        self._command = command
+        self._args = args
+        self._env_overrides: dict[str, str] = dict(env) if env else {}
+        self._logger = logger or _logger
+        self._term_grace_s = term_grace_s
+
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
+        self._id_counter = itertools.count(1)
+        self._pending: dict[int, _PendingRequest] = {}
+        self._closed = False
+        # Guards writes to the child's stdin so concurrent tool calls
+        # don't interleave bytes mid-line.
+        self._write_lock = asyncio.Lock()
+
+    async def start(self) -> list[MCPToolDescriptor]:
+        """Spawn the child, run the ``initialize`` handshake, list tools.
+
+        Returns:
+            Every tool descriptor the server advertises. Empty list is
+            valid (the server just has no tools).
+
+        Raises:
+            MCPServerCrashedError: Child exited before initialize.
+            MCPTimeoutError: Handshake or tool-list timed out.
+            MCPProtocolError: Malformed handshake response.
+            OSError: Exec failed (binary not on PATH, permissions).
+        """
+        env = {**os.environ, **self._env_overrides}
+        self._proc = await asyncio.create_subprocess_exec(
+            self._command,
+            *self._args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        self._reader_task = asyncio.create_task(
+            self._read_loop(),
+            name=f"mcp-reader:{self._command}",
+        )
+        self._stderr_task = asyncio.create_task(
+            self._stderr_loop(),
+            name=f"mcp-stderr:{self._command}",
+        )
+
+        try:
+            await asyncio.wait_for(self._initialize(), timeout=_INIT_TIMEOUT_S)
+            tools = await asyncio.wait_for(self._list_tools(), timeout=_INIT_TIMEOUT_S)
+        except TimeoutError as exc:
+            raise MCPTimeoutError(f"MCP boot exceeded {_INIT_TIMEOUT_S}s") from exc
+        return tools
+
+    async def _initialize(self) -> None:
+        """Send the MCP ``initialize`` RPC and the required ``notifications/initialized``."""
+        await self._request(
+            "initialize",
+            {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "yaya-mcp-bridge", "version": "0.1.0"},
+            },
+        )
+        # Per the spec, the client MUST send this notification before
+        # issuing any further requests. No response is expected.
+        await self._notify("notifications/initialized", {})
+
+    async def _list_tools(self) -> list[MCPToolDescriptor]:
+        """Return the server's advertised tools."""
+        result = await self._request("tools/list", {})
+        raw_tools: Any = result.get("tools", [])
+        if not isinstance(raw_tools, list):
+            raise MCPProtocolError("tools/list result.tools must be a list")
+        tools_list: list[Any] = list(raw_tools)  # pyright: ignore[reportUnknownArgumentType]
+        out: list[MCPToolDescriptor] = []
+        for entry in tools_list:
+            if not isinstance(entry, dict):
+                continue
+            entry_dict = cast("dict[str, Any]", entry)
+            name: Any = entry_dict.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            description: Any = entry_dict.get("description") or ""
+            schema_raw: Any = entry_dict.get("inputSchema") or {}
+            schema: dict[str, Any] = cast("dict[str, Any]", schema_raw) if isinstance(schema_raw, dict) else {}
+            out.append(
+                MCPToolDescriptor(
+                    name=name,
+                    description=str(description),
+                    input_schema=schema,
+                )
+            )
+        return out
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        """Invoke ``tool_name`` with ``arguments``; return the raw result dict.
+
+        The returned dict is the ``result`` field of the JSON-RPC
+        response — typically ``{"content": [...], "isError": bool}``.
+
+        Raises:
+            MCPServerCrashedError: Child died mid-call.
+            MCPTimeoutError: Call exceeded ``timeout_s``.
+            MCPProtocolError: Response error payload or malformed JSON.
+        """
+        try:
+            return await asyncio.wait_for(
+                self._request("tools/call", {"name": tool_name, "arguments": arguments}),
+                timeout=timeout_s,
+            )
+        except TimeoutError as exc:
+            raise MCPTimeoutError(f"tools/call {tool_name!r} exceeded {timeout_s}s") from exc
+
+    async def close(self) -> None:
+        """Terminate the child, cancel reader tasks, fail pending futures.
+
+        Idempotent. Safe to call from ``on_unload`` whether the boot
+        succeeded or failed mid-handshake.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        # Fail every pending future so awaiters don't hang on teardown.
+        for pending in list(self._pending.values()):
+            if not pending.future.done():
+                pending.future.set_exception(MCPServerCrashedError(None))
+        self._pending.clear()
+
+        proc = self._proc
+        if proc is not None and proc.returncode is None:
+            # Lesson #31: terminate first, bounded wait, kill fallback.
+            with contextlib.suppress(ProcessLookupError):
+                proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=self._term_grace_s)
+            except TimeoutError:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+                with contextlib.suppress(Exception):
+                    await proc.wait()
+
+        for task in (self._reader_task, self._stderr_task):
+            if task is not None and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+        self._reader_task = None
+        self._stderr_task = None
+
+    # -- internals ---------------------------------------------------------
+
+    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a JSON-RPC request and await its matching response."""
+        if self._closed or self._proc is None or self._proc.stdin is None:
+            raise MCPServerCrashedError(self._proc.returncode if self._proc else None)
+        request_id = next(self._id_counter)
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending[request_id] = _PendingRequest(future=future, method=method)
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        try:
+            await self._write_line(json.dumps(payload))
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            self._pending.pop(request_id, None)
+            raise MCPServerCrashedError(self._proc.returncode) from exc
+
+        try:
+            return await future
+        finally:
+            self._pending.pop(request_id, None)
+
+    async def _notify(self, method: str, params: dict[str, Any]) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        if self._closed or self._proc is None or self._proc.stdin is None:
+            raise MCPServerCrashedError(self._proc.returncode if self._proc else None)
+        payload = {"jsonrpc": "2.0", "method": method, "params": params}
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await self._write_line(json.dumps(payload))
+
+    async def _write_line(self, line: str) -> None:
+        """Write ``line\\n`` to the child's stdin under the writer lock."""
+        assert self._proc is not None and self._proc.stdin is not None  # noqa: S101 - module invariant: caller checked.
+        stdin = self._proc.stdin
+        async with self._write_lock:
+            stdin.write(line.encode("utf-8") + b"\n")
+            await stdin.drain()
+
+    async def _read_loop(self) -> None:
+        """Demux JSON-RPC responses from the child's stdout.
+
+        One response line → one pending future completed. On EOF we
+        fail every remaining pending future so no caller hangs.
+        """
+        assert self._proc is not None and self._proc.stdout is not None  # noqa: S101 - module invariant.
+        stdout = self._proc.stdout
+        try:
+            while True:
+                line = await stdout.readline()
+                if not line:
+                    # EOF — child closed stdout.
+                    break
+                text = line.decode("utf-8", errors="replace").strip()
+                if not text:
+                    continue
+                try:
+                    message = json.loads(text)
+                except json.JSONDecodeError:
+                    self._logger.warning("MCP server emitted malformed JSON line: %r", text[:200])
+                    continue
+                if not isinstance(message, dict):
+                    continue
+                self._dispatch_message(cast("dict[str, Any]", message))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._logger.exception("MCP stdout reader crashed")
+        finally:
+            # Wake anything still waiting on a reply.
+            rc = self._proc.returncode
+            for pending in list(self._pending.values()):
+                if not pending.future.done():
+                    pending.future.set_exception(MCPServerCrashedError(rc))
+            self._pending.clear()
+
+    def _dispatch_message(self, message: dict[str, Any]) -> None:
+        """Route one decoded JSON-RPC message to the right pending future."""
+        msg_id = message.get("id")
+        if msg_id is None:
+            # Server-initiated notification — ignored at 0.1 (we don't
+            # subscribe to any MCP notifications yet).
+            return
+        if not isinstance(msg_id, int):
+            return
+        pending = self._pending.get(msg_id)
+        if pending is None:
+            return
+        if pending.future.done():
+            return
+        if "error" in message:
+            err: Any = message["error"]
+            if isinstance(err, dict):
+                err_dict: dict[str, Any] = cast("dict[str, Any]", err)
+                err_msg = str(err_dict.get("message") or err_dict)
+            else:
+                err_msg = str(err)
+            pending.future.set_exception(MCPProtocolError(f"{pending.method}: {err_msg}"))
+            return
+        result: Any = message.get("result")
+        if not isinstance(result, dict):
+            pending.future.set_exception(MCPProtocolError(f"{pending.method}: result missing or non-object"))
+            return
+        pending.future.set_result(cast("dict[str, Any]", result))
+
+    async def _stderr_loop(self) -> None:
+        """Drain the child's stderr into the plugin logger."""
+        assert self._proc is not None and self._proc.stderr is not None  # noqa: S101 - module invariant.
+        stderr = self._proc.stderr
+        try:
+            while True:
+                line = await stderr.readline()
+                if not line:
+                    break
+                text = line.decode("utf-8", errors="replace").rstrip()
+                if text:
+                    self._logger.debug("mcp[%s] %s", self._command, text)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            self._logger.exception("MCP stderr reader crashed")

--- a/src/yaya/plugins/mcp_bridge/config.py
+++ b/src/yaya/plugins/mcp_bridge/config.py
@@ -1,6 +1,6 @@
 """Config parsing for the MCP bridge plugin.
 
-Parses the ``[mcp.servers.<name>]`` sub-tree delivered to the plugin
+Parses the ``[mcp_bridge.servers.<name>]`` sub-tree delivered to the plugin
 via :attr:`KernelContext.config`. Config surface intentionally
 minimal — stdio-transport-only for 0.1. A full surface (SSE, OAuth)
 lands later.
@@ -62,7 +62,7 @@ def _expand(value: str) -> str:
 
 
 def _parse_server(name: str, raw: Any) -> MCPServerConfig:  # noqa: C901 - linear validator; splitting hurts readability.
-    """Validate and normalise one ``[mcp.servers.<name>]`` entry.
+    """Validate and normalise one ``[mcp_bridge.servers.<name>]`` entry.
 
     Raises:
         MCPConfigError: On any missing or mistyped field. The message

--- a/src/yaya/plugins/mcp_bridge/config.py
+++ b/src/yaya/plugins/mcp_bridge/config.py
@@ -1,0 +1,173 @@
+"""Config parsing for the MCP bridge plugin.
+
+Parses the ``[mcp.servers.<name>]`` sub-tree delivered to the plugin
+via :attr:`KernelContext.config`. Config surface intentionally
+minimal — stdio-transport-only for 0.1. A full surface (SSE, OAuth)
+lands later.
+
+Env-var expansion: string values under ``env`` (and, as a convenience,
+under ``args``) are run through :func:`os.path.expandvars`. Unresolved
+variables survive verbatim so the user can see which reference broke.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+__all__ = ["MCPConfigError", "MCPServerConfig", "parse_mcp_config"]
+
+
+class MCPConfigError(ValueError):
+    """Raised when a single MCP server config is invalid.
+
+    Distinct subclass so :class:`MCPBridge.on_load` can catch it and
+    translate one bad server into a ``plugin.error`` without tanking
+    the rest of the bridge.
+    """
+
+
+@dataclass(slots=True)
+class MCPServerConfig:
+    """One validated MCP server definition.
+
+    Attributes:
+        name: Stable server identifier (TOML table key, not the binary
+            path). Becomes part of every derived tool's yaya-side
+            ``name`` so collisions across servers are impossible.
+        command: Executable to spawn (resolved via PATH by
+            :func:`asyncio.create_subprocess_exec`).
+        args: Additional argv entries passed after ``command``.
+        env: Extra environment variables merged over :data:`os.environ`.
+            Values are ``$VAR`` / ``${VAR}`` expanded at parse time.
+        enabled: If False, the server is recorded but not spawned.
+        requires_approval: Override the per-tool approval default. None
+            means "use the bridge-wide default" (True).
+        call_timeout_s: Per-tool-call wall-clock cap in seconds.
+    """
+
+    name: str
+    command: str
+    args: list[str] = field(default_factory=list[str])
+    env: dict[str, str] = field(default_factory=dict[str, str])
+    enabled: bool = True
+    requires_approval: bool | None = None
+    call_timeout_s: float = 30.0
+
+
+def _expand(value: str) -> str:
+    """Apply :func:`os.path.expandvars` so ``$VAR`` / ``${VAR}`` resolve."""
+    return os.path.expandvars(value)
+
+
+def _parse_server(name: str, raw: Any) -> MCPServerConfig:  # noqa: C901 - linear validator; splitting hurts readability.
+    """Validate and normalise one ``[mcp.servers.<name>]`` entry.
+
+    Raises:
+        MCPConfigError: On any missing or mistyped field. The message
+            always starts with the server name so the plugin log surfaces
+            the offender.
+    """
+    if not isinstance(raw, dict):
+        raise MCPConfigError(f"{name!r}: expected a table, got {type(raw).__name__}")
+    raw_dict = cast("dict[str, Any]", raw)
+
+    command: Any = raw_dict.get("command")
+    if not isinstance(command, str) or not command.strip():
+        raise MCPConfigError(f"{name!r}: 'command' must be a non-empty string")
+
+    raw_args: Any = raw_dict.get("args", [])
+    if not isinstance(raw_args, list):
+        raise MCPConfigError(f"{name!r}: 'args' must be a list of strings")
+    args_list: list[Any] = list(raw_args)  # pyright: ignore[reportUnknownArgumentType]
+    args: list[str] = []
+    for idx, item in enumerate(args_list):
+        if not isinstance(item, str):
+            raise MCPConfigError(f"{name!r}: args[{idx}] must be a string")
+        args.append(_expand(item))
+
+    raw_env: Any = raw_dict.get("env", {})
+    if not isinstance(raw_env, dict):
+        raise MCPConfigError(f"{name!r}: 'env' must be a table of strings")
+    env_dict: dict[Any, Any] = dict(raw_env)  # pyright: ignore[reportUnknownArgumentType]
+    env: dict[str, str] = {}
+    for k, v in env_dict.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise MCPConfigError(f"{name!r}: env entries must be string→string")
+        env[k] = _expand(v)
+
+    enabled: Any = raw_dict.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise MCPConfigError(f"{name!r}: 'enabled' must be a boolean")
+
+    approval: Any = raw_dict.get("requires_approval")
+    if approval is not None and not isinstance(approval, bool):
+        raise MCPConfigError(f"{name!r}: 'requires_approval' must be a boolean")
+
+    timeout: Any = raw_dict.get("call_timeout_s", 30.0)
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
+        raise MCPConfigError(f"{name!r}: 'call_timeout_s' must be a positive number")
+
+    return MCPServerConfig(
+        name=name,
+        command=_expand(command),
+        args=args,
+        env=env,
+        enabled=enabled,
+        requires_approval=approval,
+        call_timeout_s=float(timeout),
+    )
+
+
+def parse_mcp_config(config: Any) -> tuple[list[MCPServerConfig], list[tuple[str, str]]]:
+    """Parse the plugin's config sub-tree into validated server configs.
+
+    The plugin receives a mapping under the ``mcp_bridge`` namespace.
+    Inside it, the schema is::
+
+        servers:
+          <server_name>:
+            command: "..."
+            args: [...]
+            env: {...}
+            enabled: true
+            requires_approval: true
+            call_timeout_s: 30
+
+    Args:
+        config: The plugin's resolved configuration mapping (as seen by
+            :attr:`KernelContext.config`). Tolerates ``None`` /
+            empty dict.
+
+    Returns:
+        A ``(good, errors)`` tuple. ``good`` is the list of successfully
+        parsed configs. ``errors`` is a list of ``(name, message)``
+        pairs for servers that failed validation — the caller surfaces
+        each as a ``plugin.error`` but keeps the bridge running (lesson
+        #10: broken config is surfaced, never silent).
+    """
+    good: list[MCPServerConfig] = []
+    errors: list[tuple[str, str]] = []
+
+    if not isinstance(config, dict):
+        return good, errors
+
+    config_dict = cast("dict[str, Any]", config)
+    raw_servers: Any = config_dict.get("servers")
+    if raw_servers is None:
+        return good, errors
+    if not isinstance(raw_servers, dict):
+        errors.append(("<mcp_bridge>", "'servers' must be a table keyed by server name"))
+        return good, errors
+    servers_dict: dict[Any, Any] = dict(raw_servers)  # pyright: ignore[reportUnknownArgumentType]
+
+    for name, spec in servers_dict.items():
+        if not isinstance(name, str) or not name.strip():
+            errors.append(("<mcp_bridge>", f"server name {name!r} is not a non-empty string"))
+            continue
+        try:
+            good.append(_parse_server(name, spec))
+        except MCPConfigError as exc:
+            errors.append((name, str(exc)))
+    return good, errors

--- a/src/yaya/plugins/mcp_bridge/plugin.py
+++ b/src/yaya/plugins/mcp_bridge/plugin.py
@@ -133,6 +133,10 @@ class MCPBridge:
         registry is process-global with no public unregister hook at
         0.1, and stale entries are harmless (their ``run`` will return
         a ``ToolError(kind="crashed")`` once the closed client is hit).
+
+        TODO(#90): once ``yaya.kernel.tool.unregister_tool`` lands,
+        iterate ``record.tool_names`` and unregister before closing
+        the client so hot-reload leaves a clean registry.
         """
         records = list(self._servers.values())
         self._servers.clear()
@@ -255,8 +259,12 @@ class MCPBridge:
 
 # Single session id used for plugin-private bridge events. Bus serializes
 # delivery per session, so a stable id keeps these events well-ordered
-# without polluting any conversation's session_id space.
-_BRIDGE_SESSION = "mcp-bridge"
+# without polluting any conversation's session_id space. The
+# ``_bridge:`` prefix marks this as a private routing channel (distinct
+# from the plugin *name* ``mcp-bridge`` used in the registry) so future
+# subsystems can key on session id for plugin identity without
+# collisions.
+_BRIDGE_SESSION = "_bridge:mcp-bridge"
 
 
 def _default_client_factory(

--- a/src/yaya/plugins/mcp_bridge/plugin.py
+++ b/src/yaya/plugins/mcp_bridge/plugin.py
@@ -1,0 +1,344 @@
+"""MCP bridge plugin: spawn configured MCP servers, register their tools.
+
+The plugin owns one :class:`~yaya.plugins.mcp_bridge.client.MCPClient`
+per configured server. ``on_load`` reads
+``ctx.config["servers"]`` (populated from
+``[mcp_bridge.servers.<name>]`` in the user's TOML), spawns each
+enabled server with up to three retries (exponential backoff: 0.5s,
+1.0s, 2.0s), and registers every tool the server advertises through
+the kernel's tool registry. ``on_unload`` tears every client down
+following the lesson #31 cancel pattern.
+
+Per-server failures (boot crash, retries exhausted) emit a
+plugin-private ``x.mcp.server.error`` event so adapters that subscribe
+to the extension namespace see the surface; per-server success emits
+``x.mcp.server.ready`` carrying the discovered tool list. Neither
+event is part of the closed public catalog (see GOAL.md principle #3).
+
+Per the hard rules in issue #31, every MCP-derived tool defaults to
+``requires_approval=True`` — MCP servers are external code surfaces
+that yaya does not trust by default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any, ClassVar
+
+from yaya.kernel.events import Event
+from yaya.kernel.plugin import Category, KernelContext
+from yaya.kernel.tool import Tool, register_tool
+from yaya.plugins.mcp_bridge.client import (
+    MCPClient,
+    MCPClientError,
+    MCPToolDescriptor,
+)
+from yaya.plugins.mcp_bridge.config import MCPServerConfig, parse_mcp_config
+from yaya.plugins.mcp_bridge.tool_factory import (
+    build_mcp_tool_class,
+    mcp_tool_qualified_name,
+)
+
+_NAME = "mcp-bridge"
+_VERSION = "0.1.0"
+_DEFAULT_REQUIRES_APPROVAL = True
+_RETRY_DELAYS_S: tuple[float, ...] = (0.5, 1.0, 2.0)
+"""Boot-retry backoff schedule. Three attempts → three entries."""
+
+# Plugin-private extension event kinds. Routed through the bus per
+# GOAL.md principle #3 ``x.<plugin>.<kind>`` namespace.
+EVENT_SERVER_READY = "x.mcp.server.ready"
+EVENT_SERVER_ERROR = "x.mcp.server.error"
+
+
+class MCPBridge:
+    """Bundled MCP-bridge plugin.
+
+    Attributes:
+        name: Plugin name (kebab-case).
+        version: Semver.
+        category: :class:`Category.TOOL`.
+        retry_delays_s: Retry backoff schedule for boot failures.
+            Override in tests via the constructor knob.
+    """
+
+    name: str = _NAME
+    version: str = _VERSION
+    category: Category = Category.TOOL
+    requires: ClassVar[list[str]] = []
+
+    def __init__(
+        self,
+        *,
+        retry_delays_s: tuple[float, ...] = _RETRY_DELAYS_S,
+        client_factory: Any = None,
+    ) -> None:
+        """Record wiring; no I/O until :meth:`on_load`.
+
+        Args:
+            retry_delays_s: Tuple of seconds to sleep between boot
+                attempts. Length determines max attempts.
+            client_factory: Test-only callable used in lieu of
+                :class:`MCPClient`. Receives ``(command, args, env,
+                logger)`` and returns an object honouring the
+                :class:`MCPClient` surface (``start``, ``call_tool``,
+                ``close``). Production code passes ``None`` so the
+                real client is used.
+        """
+        self.retry_delays_s = retry_delays_s
+        self._client_factory = client_factory or _default_client_factory
+        # name → (client, tool classes registered for this server). Kept
+        # so ``on_unload`` can close clients deterministically and
+        # diagnostics can map tools back to their owning server.
+        self._servers: dict[str, _ServerRecord] = {}
+
+    def subscriptions(self) -> list[str]:
+        """The bridge is purely a tool *provider* — no event subscriptions.
+
+        Inbound ``tool.call.request`` events for MCP tools flow through
+        the kernel's v1 dispatcher (see
+        :func:`yaya.kernel.tool.dispatch`), which looks the tool up in
+        the registry populated during :meth:`on_load`. The bridge
+        therefore subscribes to nothing on the bus.
+        """
+        return []
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        """Parse config, spawn each enabled server, register its tools."""
+        configs, errors = parse_mcp_config(ctx.config)
+        for name, message in errors:
+            ctx.logger.warning("mcp-bridge: bad config for %r: %s", name, message)
+            await _emit_server_error(ctx, name, "config_invalid", message)
+
+        if not configs:
+            ctx.logger.debug("mcp-bridge: no servers configured")
+            return
+
+        for cfg in configs:
+            if not cfg.enabled:
+                ctx.logger.info("mcp-bridge: server %r disabled by config", cfg.name)
+                continue
+            await self._boot_server(cfg, ctx)
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        """No-op — bridge does not subscribe to anything (see :meth:`subscriptions`)."""
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        """Close every live client. Idempotent.
+
+        Subprocess teardown follows lesson #31 inside
+        :meth:`MCPClient.close`. Tool classes registered with the
+        kernel registry are intentionally NOT removed here: the kernel
+        registry is process-global with no public unregister hook at
+        0.1, and stale entries are harmless (their ``run`` will return
+        a ``ToolError(kind="crashed")`` once the closed client is hit).
+        """
+        records = list(self._servers.values())
+        self._servers.clear()
+        for record in records:
+            try:
+                await record.client.close()
+            except Exception:
+                ctx.logger.exception("mcp-bridge: error closing %r", record.config.name)
+
+    # -- internals ---------------------------------------------------------
+
+    async def _boot_server(self, cfg: MCPServerConfig, ctx: KernelContext) -> None:
+        """Spawn ``cfg`` with retries; register tools on success.
+
+        Each attempt builds a fresh client — a partially-initialized
+        client from a failed attempt is closed before retrying so we
+        never leak a process across the backoff. After
+        ``len(self.retry_delays_s)`` attempts the server is given up
+        on; the bridge keeps running and emits
+        ``x.mcp.server.error`` so operators see the give-up.
+        """
+        last_error: BaseException | None = None
+        for attempt, delay in enumerate(self.retry_delays_s, start=1):
+            client = self._client_factory(
+                cfg.command,
+                cfg.args,
+                env=cfg.env,
+                logger=ctx.logger,
+            )
+            try:
+                tools = await client.start()
+            except (TimeoutError, MCPClientError, OSError) as exc:
+                last_error = exc
+                ctx.logger.warning(
+                    "mcp-bridge: %r boot attempt %d/%d failed: %s",
+                    cfg.name,
+                    attempt,
+                    len(self.retry_delays_s),
+                    exc,
+                )
+                # Best-effort cleanup of the failed attempt before sleeping.
+                # The retry path already logged the boot failure above; close()
+                # noise on a half-built client adds nothing and would crowd logs.
+                with contextlib.suppress(Exception):
+                    await client.close()
+                if attempt < len(self.retry_delays_s):
+                    await asyncio.sleep(delay)
+                continue
+
+            await self._register_server(cfg, client, tools, ctx)
+            return
+
+        # All attempts exhausted.
+        message = str(last_error) if last_error is not None else "unknown boot failure"
+        ctx.logger.error(
+            "mcp-bridge: %r failed to boot after %d attempts; giving up",
+            cfg.name,
+            len(self.retry_delays_s),
+        )
+        await _emit_server_error(ctx, cfg.name, "boot_failed", message)
+
+    async def _register_server(
+        self,
+        cfg: MCPServerConfig,
+        client: MCPClient,
+        tools: list[MCPToolDescriptor],
+        ctx: KernelContext,
+    ) -> None:
+        """Wire ``client``'s tools into the kernel registry, record state, emit ready."""
+        requires_approval = cfg.requires_approval if cfg.requires_approval is not None else _DEFAULT_REQUIRES_APPROVAL
+        registered: list[str] = []
+        for descriptor in tools:
+            tool_cls = build_mcp_tool_class(
+                cfg.name,
+                descriptor,
+                client,
+                requires_approval=requires_approval,
+                call_timeout_s=cfg.call_timeout_s,
+            )
+            try:
+                register_tool(tool_cls)
+            except ValueError as exc:
+                # Name collision or missing ClassVar — surface but do
+                # not abort the rest of the server's tools.
+                ctx.logger.warning(
+                    "mcp-bridge: failed to register %r: %s",
+                    tool_cls.name,
+                    exc,
+                )
+                continue
+            registered.append(tool_cls.name)
+
+        self._servers[cfg.name] = _ServerRecord(
+            config=cfg,
+            client=client,
+            tool_names=tuple(registered),
+        )
+        ctx.logger.info(
+            "mcp-bridge: %r ready with %d tool(s): %s",
+            cfg.name,
+            len(registered),
+            ", ".join(registered) or "<none>",
+        )
+        await ctx.emit(
+            EVENT_SERVER_READY,
+            {
+                "server": cfg.name,
+                "tools": [
+                    {
+                        "name": mcp_tool_qualified_name(cfg.name, descriptor.name),
+                        "mcp_name": descriptor.name,
+                        "description": descriptor.description,
+                    }
+                    for descriptor in tools
+                ],
+            },
+            session_id=_BRIDGE_SESSION,
+        )
+
+
+# Single session id used for plugin-private bridge events. Bus serializes
+# delivery per session, so a stable id keeps these events well-ordered
+# without polluting any conversation's session_id space.
+_BRIDGE_SESSION = "mcp-bridge"
+
+
+def _default_client_factory(
+    command: str,
+    args: list[str],
+    *,
+    env: dict[str, str],
+    logger: Any,
+) -> MCPClient:
+    """Production :class:`MCPClient` factory; tests inject their own."""
+    return MCPClient(command, args, env=env, logger=logger)
+
+
+async def _emit_server_error(
+    ctx: KernelContext,
+    server: str,
+    kind: str,
+    message: str,
+) -> None:
+    """Publish ``x.mcp.server.error`` on behalf of the bridge.
+
+    Plugin-private extension — never raises out of the boot path; an
+    emit failure is logged and swallowed so a misconfigured one server
+    cannot silently abort the rest of the bridge.
+    """
+    try:
+        await ctx.emit(
+            EVENT_SERVER_ERROR,
+            {"server": server, "kind": kind, "message": message},
+            session_id=_BRIDGE_SESSION,
+        )
+    except Exception:
+        ctx.logger.exception("mcp-bridge: failed to emit %s for %r", EVENT_SERVER_ERROR, server)
+
+
+class _ServerRecord:
+    """Per-server in-memory state.
+
+    Attributes:
+        config: Validated config that produced this record.
+        client: Live :class:`MCPClient`. Owned by the bridge for the
+            lifetime of the plugin.
+        tool_names: yaya-side qualified names registered with the
+            kernel for this server. Held for diagnostics; the registry
+            is the source of truth.
+    """
+
+    __slots__ = ("client", "config", "tool_names")
+
+    def __init__(
+        self,
+        *,
+        config: MCPServerConfig,
+        client: MCPClient,
+        tool_names: tuple[str, ...],
+    ) -> None:
+        self.config = config
+        self.client = client
+        self.tool_names = tool_names
+
+
+# Re-exports for tests that need to introspect a generated tool's source.
+def _registered_tool_classes(tool_names: list[str]) -> list[type[Tool]]:
+    """Return registered :class:`Tool` subclasses for ``tool_names``.
+
+    Helper kept for tests that want to assert the dynamic class shape
+    without re-walking the kernel registry by name. Defined at module
+    level (rather than as a static method) so import surface stays
+    unchanged across refactors.
+    """
+    from yaya.kernel.tool import get_tool
+
+    out: list[type[Tool]] = []
+    for name in tool_names:
+        cls = get_tool(name)
+        if cls is not None:
+            out.append(cls)
+    return out
+
+
+__all__ = [
+    "EVENT_SERVER_ERROR",
+    "EVENT_SERVER_READY",
+    "MCPBridge",
+]

--- a/src/yaya/plugins/mcp_bridge/tool_factory.py
+++ b/src/yaya/plugins/mcp_bridge/tool_factory.py
@@ -122,7 +122,11 @@ def _build_param_model_fields(
         if prop_name in required:
             fields[prop_name] = (py_type, Field(..., description=description))
         else:
-            fields[prop_name] = (py_type | None, Field(default=None, description=description))
+            # ``Any | None`` collapses to ``Any`` — skip the Optional wrap
+            # when the schema gave us no concrete type so the generated
+            # pydantic schema stays clean.
+            optional_type = py_type if py_type is Any else py_type | None
+            fields[prop_name] = (optional_type, Field(default=None, description=description))
     return fields
 
 
@@ -193,8 +197,6 @@ def build_mcp_tool_class(
     async def _run(self: Tool, ctx: Any) -> ToolReturnValue:
         # Extract the arguments dict from the bound pydantic model.
         args = self.model_dump(mode="json", exclude_none=True)
-        # Strip yaya-only fields that leaked from the Tool base class.
-        args.pop("requires_approval", None)
         try:
             raw_result = await client.call_tool(
                 descriptor.name,

--- a/src/yaya/plugins/mcp_bridge/tool_factory.py
+++ b/src/yaya/plugins/mcp_bridge/tool_factory.py
@@ -1,0 +1,272 @@
+"""Dynamic yaya ``Tool`` generation from MCP tool descriptors.
+
+Each MCP server's ``tools/list`` response turns into N
+dynamically-created :class:`~yaya.kernel.tool.Tool` subclasses. The
+pydantic model body is built from the tool's ``inputSchema`` via a
+best-effort JSON-Schema → Python-typing translation that covers the
+common cases (objects with typed properties + required lists, scalar
+primitives, arrays with a single item type). Unknown or unsupported
+schemas fall back to a single ``args: dict[str, Any]`` passthrough
+field — conservative but keeps the plugin usable against any server
+the translator does not yet fully model.
+
+The translation is deliberately *not* a full JSON Schema validator —
+that is the MCP server's job once we forward the arguments. yaya's
+pydantic layer only needs enough structure to surface the parameter
+names + types to the LLM function-calling surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from pydantic import ConfigDict, Field, create_model
+
+from yaya.kernel.tool import JsonBlock, TextBlock, Tool, ToolError, ToolOk, ToolReturnValue
+from yaya.plugins.mcp_bridge.client import (
+    MCPClient,
+    MCPProtocolError,
+    MCPServerCrashedError,
+    MCPTimeoutError,
+    MCPToolDescriptor,
+)
+
+__all__ = ["build_mcp_tool_class", "mcp_tool_qualified_name"]
+
+
+# Mapping from JSON-Schema primitive types to Python types used by the
+# pydantic model. ``Any`` is the fallback when the server omits ``type``
+# or uses a union we don't bother to unpack at 0.1.
+_JSON_TO_PY: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "object": dict,
+    "array": list,
+    "null": type(None),
+}
+
+
+def mcp_tool_qualified_name(server_name: str, tool_name: str) -> str:
+    """Return the yaya-side tool name for an MCP tool.
+
+    The prefix prevents collisions between servers and between MCP
+    tools and bundled yaya tools. The separator is an underscore (not
+    a dot) because LLM function-calling names on several vendors are
+    restricted to ``[a-zA-Z0-9_-]``.
+    """
+    safe_server = _sanitize(server_name)
+    safe_tool = _sanitize(tool_name)
+    return f"mcp_{safe_server}_{safe_tool}"
+
+
+def _sanitize(name: str) -> str:
+    """Collapse any run of non-``[a-zA-Z0-9]`` chars into ``_``."""
+    out: list[str] = []
+    for ch in name:
+        if ch.isalnum():
+            out.append(ch)
+        else:
+            out.append("_")
+    return "".join(out) or "_"
+
+
+def _py_type_for(schema: Any) -> Any:
+    """Return a reasonable Python annotation for one property schema."""
+    if not isinstance(schema, dict):
+        return Any
+    schema_dict = cast("dict[str, Any]", schema)
+    raw_type: Any = schema_dict.get("type")
+    if isinstance(raw_type, str):
+        return _JSON_TO_PY.get(raw_type, Any)
+    # Unions / missing type → Any. Accept broad inputs, let the server
+    # do the real validation.
+    return Any
+
+
+def _build_param_model_fields(
+    input_schema: dict[str, Any],
+) -> dict[str, tuple[Any, Any]]:
+    """Return a ``create_model``-friendly ``{name: (type, default)}`` dict.
+
+    If ``input_schema`` describes an object with ``properties``, each
+    property becomes a field; ``required`` entries get no default
+    (pydantic treats them as required). Anything else → a single
+    ``args: dict[str, Any] = {}`` passthrough so the plugin still
+    accepts arbitrary arguments.
+    """
+    if input_schema.get("type") != "object":
+        return {"args": (dict[str, Any], {})}
+    properties_raw: Any = input_schema.get("properties")
+    if not isinstance(properties_raw, dict) or not properties_raw:
+        return {"args": (dict[str, Any], {})}
+    properties = cast("dict[str, Any]", properties_raw)
+    required_raw: Any = input_schema.get("required") or []
+    required: set[str] = set()
+    if isinstance(required_raw, list):
+        required_list: list[Any] = list(required_raw)  # pyright: ignore[reportUnknownArgumentType]
+        for item in required_list:
+            if isinstance(item, str):
+                required.add(item)
+
+    fields: dict[str, tuple[Any, Any]] = {}
+    for prop_name, prop_schema in properties.items():
+        py_type = _py_type_for(prop_schema)
+        description = ""
+        if isinstance(prop_schema, dict):
+            schema_dict = cast("dict[str, Any]", prop_schema)
+            desc: Any = schema_dict.get("description")
+            if isinstance(desc, str):
+                description = desc
+        if prop_name in required:
+            fields[prop_name] = (py_type, Field(..., description=description))
+        else:
+            fields[prop_name] = (py_type | None, Field(default=None, description=description))
+    return fields
+
+
+def _first_text_block(content: list[Any]) -> str:
+    """Pull a short text summary out of an MCP tool-call content array."""
+    for item in content:
+        if isinstance(item, dict):
+            item_dict = cast("dict[str, Any]", item)
+            t: Any = item_dict.get("type")
+            text: Any = item_dict.get("text")
+            if t == "text" and isinstance(text, str):
+                return text
+    return ""
+
+
+def build_mcp_tool_class(
+    server_name: str,
+    descriptor: MCPToolDescriptor,
+    client: MCPClient,
+    *,
+    requires_approval: bool,
+    call_timeout_s: float,
+) -> type[Tool]:
+    """Return a concrete :class:`Tool` subclass wrapping one MCP tool.
+
+    The subclass is created dynamically so each MCP tool keeps its own
+    pydantic schema — the bridge cannot rely on a single generic
+    ``args: dict`` shape because the LLM function-calling surface
+    wants real parameter names.
+
+    Args:
+        server_name: Owning server's config name.
+        descriptor: The ``tools/list`` entry for this tool.
+        client: Live :class:`MCPClient`. Closed over; callers MUST NOT
+            close the client while any generated Tool is still
+            registered.
+        requires_approval: Whether the dispatcher should gate this tool
+            behind the approval runtime. External tool surface → True
+            by default.
+        call_timeout_s: Wall-clock cap passed to each
+            :meth:`MCPClient.call_tool`.
+
+    Returns:
+        A :class:`Tool` subclass ready for
+        :func:`yaya.kernel.register_tool`.
+    """
+    qualified_name = mcp_tool_qualified_name(server_name, descriptor.name)
+    description = descriptor.description or f"MCP tool {descriptor.name} from server {server_name}"
+
+    fields = _build_param_model_fields(descriptor.input_schema)
+
+    # Build a pydantic model carrying the tool's params. ``create_model``
+    # returns a subclass of BaseModel; we mix it into Tool via
+    # multiple inheritance below so the subclass ends up with both the
+    # tool-side hooks and the validated field set.
+    # ``create_model`` expects ``(name, type, default)`` triples for its
+    # field kwargs but its stub signature only models the named pydantic
+    # internals (``__config__`` etc.). Both checkers complain that our
+    # ``(type, default)`` tuples collide with those reserved kwargs;
+    # rework via the explicit ``__base__``-free path is not worth the
+    # churn — suppress per-line and move on.
+    params_base: type[Any] = create_model(  # type: ignore[call-overload]
+        f"_MCPToolParams_{qualified_name}",
+        __config__=ConfigDict(extra="allow"),
+        **fields,  # pyright: ignore[reportArgumentType]
+    )
+
+    async def _run(self: Tool, ctx: Any) -> ToolReturnValue:
+        # Extract the arguments dict from the bound pydantic model.
+        args = self.model_dump(mode="json", exclude_none=True)
+        # Strip yaya-only fields that leaked from the Tool base class.
+        args.pop("requires_approval", None)
+        try:
+            raw_result = await client.call_tool(
+                descriptor.name,
+                args,
+                timeout_s=call_timeout_s,
+            )
+        except MCPTimeoutError as exc:
+            return ToolError(
+                kind="timeout",
+                brief=f"mcp {descriptor.name!r} timed out"[:80],
+                display=TextBlock(text=str(exc)),
+            )
+        except MCPServerCrashedError as exc:
+            return ToolError(
+                kind="crashed",
+                brief=f"mcp server {server_name!r} crashed"[:80],
+                display=TextBlock(text=str(exc)),
+            )
+        except MCPProtocolError as exc:
+            return ToolError(
+                kind="internal",
+                brief=f"mcp {descriptor.name!r} protocol error"[:80],
+                display=TextBlock(text=str(exc)),
+            )
+        except Exception as exc:
+            # Lesson #29: every exception path surfaces as a tool.error
+            # so the agent loop never sees a raw exception.
+            return ToolError(
+                kind="crashed",
+                brief=f"mcp {descriptor.name!r} raised"[:80],
+                display=TextBlock(text=f"{type(exc).__name__}: {exc}"),
+            )
+
+        content_raw: Any = raw_result.get("content", [])
+        content: list[Any] = list(content_raw) if isinstance(content_raw, list) else []  # pyright: ignore[reportUnknownArgumentType]
+        is_error = bool(raw_result.get("isError", False))
+        text_summary = _first_text_block(content) or descriptor.name
+
+        if is_error:
+            return ToolError(
+                kind="internal",
+                brief=f"mcp {descriptor.name!r} reported error"[:80],
+                display=JsonBlock(data=content),
+            )
+        return ToolOk(
+            brief=text_summary[:80] or descriptor.name,
+            display=JsonBlock(data=content),
+        )
+
+    # Multi-inherit: Tool (yaya hooks) + params_base (fields/config).
+    # Tool already carries ``model_config = ConfigDict(extra="forbid")``;
+    # the dynamic params model uses ``extra="allow"`` so arbitrary-shape
+    # MCP schemas round-trip. Explicit class-level model_config wins.
+    tool_cls: type[Tool] = cast(
+        "type[Tool]",
+        type(
+            f"MCPTool_{qualified_name}",
+            (Tool, params_base),  # pyright: ignore[reportUnknownArgumentType]
+            {
+                "__module__": __name__,
+                "__qualname__": f"MCPTool_{qualified_name}",
+                "name": qualified_name,
+                "description": description,
+                "requires_approval": requires_approval,
+                "model_config": ConfigDict(extra="allow"),
+                "run": _run,
+                # Preserve the source descriptor for diagnostics — typed
+                # as ClassVar so pydantic does not try to turn it into
+                # a field.
+                "__mcp_server_name__": server_name,
+                "__mcp_tool_name__": descriptor.name,
+            },
+        ),
+    )
+    return tool_cls

--- a/tests/bdd/features/plugin-mcp_bridge.feature
+++ b/tests/bdd/features/plugin-mcp_bridge.feature
@@ -1,0 +1,37 @@
+Feature: MCP bridge plugin
+
+  The executable Gherkin mirror of specs/plugin-mcp_bridge.spec.
+
+  Scenario: Discovers tools from a fake MCP server and registers them by qualified name
+    Given a fake MCP server exposing one tool echo with a string parameter
+    When the bridge loads with that server configured
+    Then the kernel tool registry contains a tool named mcp_local_echo
+    And an x.mcp.server.ready event is emitted naming the server and its tools
+
+  Scenario: Approval default is True for every MCP derived tool
+    Given a fake MCP server descriptor for a tool named echo
+    When the tool factory builds a yaya Tool subclass with the bridge default
+    Then the resulting class requires approval
+
+  Scenario: Tool call forwards arguments and wraps the response in ToolOk
+    Given a loaded bridge with a fake MCP server exposing echo
+    When the echo tool is invoked through the kernel dispatcher with an approved gate
+    Then the dispatcher emits one tool.call.result with ok true
+    And the envelope brief reflects the echoed text
+
+  Scenario: Boot failure exhausts retries and emits x mcp server error
+    Given a fake MCP server factory that always fails to start
+    When the bridge loads with retries collapsed
+    Then no tools are registered for the failing server
+    And exactly one x.mcp.server.error event is emitted with kind boot_failed
+
+  Scenario: Bad config entry surfaces as x mcp server error without tainting siblings
+    Given a configuration mixing one valid server and one server whose command field is empty
+    When the bridge loads
+    Then an x.mcp.server.error event is emitted naming the bad server
+    And the valid server still registers its tool
+
+  Scenario: Unload closes every spawned client deterministically
+    Given a loaded bridge with two fake MCP servers
+    When on_unload runs
+    Then close has been awaited on both client instances

--- a/tests/kernel/test_session.py
+++ b/tests/kernel/test_session.py
@@ -322,6 +322,141 @@ async def test_file_tape_store_append_is_constant_time(tmp_path: Path) -> None:
         await store.close()
 
 
+# ---------------------------------------------------------------------------
+# tape_context selection — exercise every branch of select_messages.
+# ---------------------------------------------------------------------------
+
+
+async def test_context_projects_tool_call_and_result(tmp_path: Path) -> None:
+    """``tool_call`` → one assistant message; ``tool_result`` → one per result, correlated."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-1")
+        await session.append_message("user", "run it")
+        await session.append_tool_call({
+            "id": "call-a",
+            "type": "function",
+            "function": {"name": "echo", "arguments": "{}"},
+        })
+        await session.append_tool_result("call-a", {"output": "hi"})
+        messages = await session.context()
+        # Find the assistant tool-call message + tool result message.
+        roles = [m["role"] for m in messages]
+        assert "assistant" in roles
+        tool_msgs = [m for m in messages if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "call-a"
+        assert tool_msgs[0]["name"] == "echo"
+    finally:
+        await store.close()
+
+
+async def test_context_skips_anchors_and_non_included_events(tmp_path: Path) -> None:
+    """``anchor`` entries are skipped; ``event`` entries need ``include_in_context``."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-skip")
+        await session.append_message("user", "hi")
+        # Observational event — default meta, must NOT appear.
+        await session.append_event("bus.mirror", {"foo": "bar"})
+        messages = await session.context()
+        assert all("[event:" not in m.get("content", "") for m in messages)
+        # anchors are present on the tape but absent from the projection.
+        entries = await session.entries()
+        assert any(e.kind == "anchor" for e in entries)
+        assert all(m["role"] != "anchor" for m in messages)  # sanity: no "anchor" role.
+    finally:
+        await store.close()
+
+
+async def test_context_includes_event_when_flagged(tmp_path: Path) -> None:
+    """``event`` with ``include_in_context=True`` becomes a system message."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-ev")
+        await session.append_event(
+            "hint.injected",
+            {"note": "please be terse"},
+            include_in_context=True,
+        )
+        messages = await session.context()
+        system_msgs = [m for m in messages if m["role"] == "system"]
+        assert any("[event:hint.injected]" in m["content"] for m in system_msgs)
+    finally:
+        await store.close()
+
+
+async def test_context_tool_result_without_calls_still_renders(tmp_path: Path) -> None:
+    """Orphan ``tool_result`` entries render a plain ``role=tool`` message."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-orphan")
+        # Append a tool_result with no preceding tool_call.
+        await session.append_tool_result("call-x", {"value": 1})
+        messages = await session.context()
+        tool_msgs = [m for m in messages if m["role"] == "tool"]
+        assert tool_msgs, messages
+        # No pending call: no tool_call_id / name were attached.
+        assert "tool_call_id" not in tool_msgs[0]
+        assert "name" not in tool_msgs[0]
+    finally:
+        await store.close()
+
+
+async def test_context_tool_result_ignores_non_list_results(tmp_path: Path) -> None:
+    """A malformed ``tool_result.results`` value is skipped without errors."""
+    from republic import TapeEntry
+
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-mal")
+        # Inject a malformed tool_result entry directly through the manager.
+        await session.manager.append_entry(
+            session.tape_name,
+            TapeEntry.tool_result(results="not-a-list"),  # type: ignore[arg-type]
+        )
+        messages = await session.context()
+        assert all(m["role"] != "tool" for m in messages)
+    finally:
+        await store.close()
+
+
+async def test_context_render_result_handles_raw_string(tmp_path: Path) -> None:
+    """A raw string inside ``results`` exercises the str branch of _render_result."""
+    from republic import TapeEntry
+
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "ctx-render-str")
+        # Raw-string result entries — select_messages treats them as
+        # opaque values and skips call correlation (no .get()).
+        await session.manager.append_entry(
+            session.tape_name,
+            TapeEntry.tool_result(["plain-string", {"ok": True}]),
+        )
+        messages = await session.context()
+        tool_msgs = [m for m in messages if m["role"] == "tool"]
+        assert tool_msgs[0]["content"] == "plain-string"
+        assert '"ok"' in tool_msgs[1]["content"]
+    finally:
+        await store.close()
+
+
+async def test_after_last_anchor_no_anchor_returns_empty(tmp_path: Path) -> None:
+    """``after_last_anchor`` on a tape with only the seed anchor returns post-seed entries."""
+    store = SessionStore(store=MemoryTapeStore())
+    try:
+        session = await _open(store, tmp_path, "anchor-1")
+        await session.append_message("user", "after-seed")
+        post = await after_last_anchor(session.manager, session.tape_name)
+        # The session/start seed anchor is still the last anchor, so "after" is just the message.
+        kinds = [e.kind for e in post]
+        assert "message" in kinds
+        assert "anchor" not in kinds
+    finally:
+        await store.close()
+
+
 async def test_file_tape_store_next_id_cache_invalidated_on_reset(tmp_path: Path) -> None:
     """``reset()`` must drop the cached next-id so the next append restarts at 1.
 

--- a/tests/plugins/mcp_bridge/_fake_server.py
+++ b/tests/plugins/mcp_bridge/_fake_server.py
@@ -1,0 +1,116 @@
+"""Tiny pure-Python stdio MCP server used by the bridge integration tests.
+
+Speaks just enough of the ``2024-11-05`` MCP wire format for the
+bridge to complete an ``initialize`` + ``tools/list`` handshake and
+service a single ``tools/call`` against an ``echo`` tool. No network,
+no third-party dependencies — invoked by spawning ``python
+_fake_server.py`` from the test process.
+
+A second tool ``slow`` sleeps for the requested duration so the
+timeout integration test has something to time out against.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "echo",
+        "description": "Echo back the supplied msg field.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"msg": {"type": "string", "description": "Text to echo."}},
+            "required": ["msg"],
+        },
+    },
+    {
+        "name": "slow",
+        "description": "Sleep for `seconds` then return.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"seconds": {"type": "number"}},
+            "required": ["seconds"],
+        },
+    },
+]
+
+
+def _send(message: dict[str, Any]) -> None:
+    """Write ``message`` as one newline-delimited JSON-RPC line on stdout."""
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _reply(request_id: Any, result: dict[str, Any]) -> None:
+    _send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def _error_reply(request_id: Any, code: int, message: str) -> None:
+    _send({"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}})
+
+
+def _handle(message: dict[str, Any]) -> None:
+    method = message.get("method")
+    params = message.get("params") or {}
+    msg_id = message.get("id")
+
+    if method == "initialize":
+        _reply(
+            msg_id,
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake-mcp", "version": "0.0.1"},
+            },
+        )
+        return
+    if method == "notifications/initialized":
+        # Notification — no response.
+        return
+    if method == "tools/list":
+        _reply(msg_id, {"tools": _TOOLS})
+        return
+    if method == "tools/call":
+        name = params.get("name")
+        arguments = params.get("arguments") or {}
+        if name == "echo":
+            msg = str(arguments.get("msg", ""))
+            _reply(
+                msg_id,
+                {
+                    "content": [{"type": "text", "text": msg}],
+                    "isError": False,
+                },
+            )
+            return
+        if name == "slow":
+            time.sleep(float(arguments.get("seconds", 0)))
+            _reply(msg_id, {"content": [{"type": "text", "text": "done"}], "isError": False})
+            return
+        _error_reply(msg_id, -32601, f"unknown tool: {name!r}")
+        return
+
+    if msg_id is not None:
+        _error_reply(msg_id, -32601, f"unknown method: {method!r}")
+
+
+def main() -> None:
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(message, dict):
+            continue
+        _handle(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/plugins/mcp_bridge/test_mcp_bridge.py
+++ b/tests/plugins/mcp_bridge/test_mcp_bridge.py
@@ -433,3 +433,644 @@ async def test_client_close_terminates_then_kills() -> None:
     await client.close()
     assert client._proc is not None
     assert client._proc.returncode is not None
+
+
+# ---------------------------------------------------------------------------
+# Additional client-level coverage.
+# ---------------------------------------------------------------------------
+
+
+async def test_client_close_cancels_reader_tasks_and_fails_pending() -> None:
+    """close() cancels reader/stderr tasks and fails outstanding futures."""
+    from yaya.plugins.mcp_bridge.client import (
+        MCPClient,
+        MCPServerCrashedError,
+        _PendingRequest,
+    )
+
+    # A long-running child so close() must terminate it + cancel tasks.
+    code = "import sys, time\nsys.stdout.write('ready\\n'); sys.stdout.flush()\ntime.sleep(60)\n"
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    client._proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert client._proc.stdout is not None
+    await client._proc.stdout.readline()
+
+    # Spin the real reader + stderr loops so close() must cancel them.
+    client._reader_task = asyncio.create_task(client._read_loop(), name="reader")
+    client._stderr_task = asyncio.create_task(client._stderr_loop(), name="stderr")
+
+    # Inject a pending future so close() takes the "fail pending" branch.
+    loop = asyncio.get_running_loop()
+    pending_future: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[42] = _PendingRequest(future=pending_future, method="tools/call")
+
+    await client.close()
+    # Second close() is a no-op (idempotent short-circuit at the top).
+    await client.close()
+    assert client._reader_task is None
+    assert client._stderr_task is None
+    assert client._pending == {}
+    assert pending_future.done()
+    with pytest.raises(MCPServerCrashedError):
+        pending_future.result()
+
+
+async def test_client_request_after_close_raises() -> None:
+    """``_request`` on a closed client surfaces ``MCPServerCrashedError``."""
+    from yaya.plugins.mcp_bridge.client import MCPClient, MCPServerCrashedError
+
+    client = MCPClient("nope", [])
+    client._closed = True
+    with pytest.raises(MCPServerCrashedError):
+        await client._request("tools/list", {})
+    with pytest.raises(MCPServerCrashedError):
+        await client._notify("notifications/initialized", {})
+
+
+async def test_read_loop_skips_garbage_and_resolves_pending() -> None:
+    """Malformed lines are skipped; subsequent valid response completes its pending future."""
+    from yaya.plugins.mcp_bridge.client import MCPClient, _PendingRequest
+
+    # Echoes garbage, then a valid JSON-RPC response, then exits.
+    code = (
+        "import sys\n"
+        "sys.stdout.write('not json\\n')\n"
+        "sys.stdout.write('\\n')\n"  # empty line branch
+        "sys.stdout.write('[\"not a dict\"]\\n')\n"  # non-dict branch
+        'sys.stdout.write(\'{"jsonrpc":"2.0","id":"not-int","result":{}}\\n\')\n'
+        'sys.stdout.write(\'{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\\n\')\n'
+        "sys.stdout.flush()\n"
+    )
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    client._proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[1] = _PendingRequest(future=fut, method="tools/call")
+
+    reader = asyncio.create_task(client._read_loop())
+    try:
+        result = await asyncio.wait_for(fut, timeout=2.0)
+        assert result == {"ok": True}
+    finally:
+        # Let the reader observe EOF (child already exited) and finish.
+        await asyncio.wait_for(reader, timeout=2.0)
+        await client.close()
+
+
+async def test_read_loop_on_eof_fails_pending_futures() -> None:
+    """When the child closes stdout, pending futures resolve with ``MCPServerCrashedError``."""
+    from yaya.plugins.mcp_bridge.client import (
+        MCPClient,
+        MCPServerCrashedError,
+        _PendingRequest,
+    )
+
+    # Child exits immediately → EOF right away.
+    code = "import sys; sys.stdout.flush()\n"
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    client._proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[7] = _PendingRequest(future=fut, method="tools/call")
+
+    reader = asyncio.create_task(client._read_loop())
+    try:
+        with pytest.raises(MCPServerCrashedError):
+            await asyncio.wait_for(fut, timeout=2.0)
+    finally:
+        await asyncio.wait_for(reader, timeout=2.0)
+        await client.close()
+
+
+async def test_dispatch_message_translates_error_payload_to_protocol_error() -> None:
+    """JSON-RPC ``error`` payloads surface as :class:`MCPProtocolError`."""
+    from yaya.plugins.mcp_bridge.client import (
+        MCPClient,
+        MCPProtocolError,
+        _PendingRequest,
+    )
+
+    client = MCPClient("nope", [])
+    loop = asyncio.get_running_loop()
+    fut: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[1] = _PendingRequest(future=fut, method="initialize")
+    client._dispatch_message({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32600, "message": "bad request"},
+    })
+    with pytest.raises(MCPProtocolError, match="bad request"):
+        fut.result()
+
+    # Non-dict ``error`` payload also stringifies cleanly.
+    fut2: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[2] = _PendingRequest(future=fut2, method="tools/call")
+    client._dispatch_message({"jsonrpc": "2.0", "id": 2, "error": "boom-string"})
+    with pytest.raises(MCPProtocolError, match="boom-string"):
+        fut2.result()
+
+    # Response with non-object ``result`` surfaces as protocol error too.
+    fut3: asyncio.Future[dict[str, Any]] = loop.create_future()
+    client._pending[3] = _PendingRequest(future=fut3, method="tools/list")
+    client._dispatch_message({"jsonrpc": "2.0", "id": 3, "result": "not-an-object"})
+    with pytest.raises(MCPProtocolError, match="result missing"):
+        fut3.result()
+
+    # Notification (no id) and unknown id are both quietly ignored.
+    client._dispatch_message({"jsonrpc": "2.0", "method": "notifications/foo"})
+    client._dispatch_message({"jsonrpc": "2.0", "id": 999, "result": {}})
+
+
+async def test_call_tool_timeout_raises_and_cleans_pending() -> None:
+    """A ``timeout_s`` breach surfaces as :class:`MCPTimeoutError` and clears _pending."""
+    from yaya.plugins.mcp_bridge.client import MCPClient, MCPTimeoutError
+
+    # Slow fake server: only replies to initialize; "slow" sleeps.
+    client = MCPClient(sys.executable, [str(_FAKE_SERVER)], term_grace_s=1.0)
+    try:
+        await client.start()
+        with pytest.raises(MCPTimeoutError):
+            await client.call_tool("slow", {"seconds": 5}, timeout_s=0.05)
+        # Pending entry for the timed-out call was cleaned by the ``finally`` in _request.
+        assert client._pending == {}
+    finally:
+        await client.close()
+
+
+async def test_start_initialize_error_raises_protocol_error() -> None:
+    """A server that returns an error on ``initialize`` surfaces MCPProtocolError."""
+    from yaya.plugins.mcp_bridge.client import MCPClient, MCPProtocolError
+
+    # Tiny inline server: always reply with an error payload.
+    code = (
+        "import json, sys\n"
+        "for line in sys.stdin:\n"
+        "    try:\n"
+        "        msg = json.loads(line)\n"
+        "    except Exception:\n"
+        "        continue\n"
+        "    if msg.get('method') in ('notifications/initialized',):\n"
+        "        continue\n"
+        "    sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':msg.get('id'),"
+        "'error':{'code':-1,'message':'nope'}}) + '\\n')\n"
+        "    sys.stdout.flush()\n"
+    )
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    try:
+        with pytest.raises(MCPProtocolError):
+            await client.start()
+    finally:
+        await client.close()
+
+
+async def test_list_tools_rejects_non_list_payload() -> None:
+    """``tools/list`` returning a non-list surfaces as :class:`MCPProtocolError`."""
+    from yaya.plugins.mcp_bridge.client import MCPClient, MCPProtocolError
+
+    code = (
+        "import json, sys\n"
+        "for line in sys.stdin:\n"
+        "    try:\n"
+        "        msg = json.loads(line)\n"
+        "    except Exception:\n"
+        "        continue\n"
+        "    mid = msg.get('id')\n"
+        "    method = msg.get('method')\n"
+        "    if method == 'initialize':\n"
+        "        sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':mid,'result':{"
+        "'protocolVersion':'2024-11-05','capabilities':{},'serverInfo':"
+        "{'name':'x','version':'0'}}}) + '\\n')\n"
+        "        sys.stdout.flush()\n"
+        "    elif method == 'notifications/initialized':\n"
+        "        pass\n"
+        "    elif method == 'tools/list':\n"
+        "        sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':mid,"
+        "'result':{'tools':'not-a-list'}}) + '\\n')\n"
+        "        sys.stdout.flush()\n"
+    )
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    try:
+        with pytest.raises(MCPProtocolError):
+            await client.start()
+    finally:
+        await client.close()
+
+
+async def test_list_tools_skips_malformed_entries() -> None:
+    """Non-dict / nameless tool entries are silently skipped."""
+    from yaya.plugins.mcp_bridge.client import MCPClient
+
+    code = (
+        "import json, sys\n"
+        "for line in sys.stdin:\n"
+        "    try:\n"
+        "        msg = json.loads(line)\n"
+        "    except Exception:\n"
+        "        continue\n"
+        "    mid = msg.get('id')\n"
+        "    method = msg.get('method')\n"
+        "    if method == 'initialize':\n"
+        "        sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':mid,'result':{"
+        "'protocolVersion':'2024-11-05','capabilities':{},'serverInfo':"
+        "{'name':'x','version':'0'}}}) + '\\n')\n"
+        "        sys.stdout.flush()\n"
+        "    elif method == 'notifications/initialized':\n"
+        "        pass\n"
+        "    elif method == 'tools/list':\n"
+        "        tools = ['not-a-dict', {'name': ''}, {'name': 123}, "
+        "{'name':'good','description':None,'inputSchema':'not-a-dict'}]\n"
+        "        sys.stdout.write(json.dumps({'jsonrpc':'2.0','id':mid,"
+        "'result':{'tools':tools}}) + '\\n')\n"
+        "        sys.stdout.flush()\n"
+    )
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=1.0)
+    try:
+        tools = await client.start()
+        assert [t.name for t in tools] == ["good"]
+        assert tools[0].input_schema == {}
+    finally:
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# config.py validation coverage.
+# ---------------------------------------------------------------------------
+
+
+def test_config_rejects_non_table_entry() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": "not-a-table"}})
+    assert good == []
+    assert errors and "expected a table" in errors[0][1]
+
+
+def test_config_rejects_missing_command() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": 0}}})
+    assert good == []
+    assert any("command" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_list_args() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "args": "not-a-list"}}})
+    assert good == []
+    assert any("'args'" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_string_arg_element() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "args": [1]}}})
+    assert good == []
+    assert any("args[0]" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_dict_env() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "env": "nope"}}})
+    assert good == []
+    assert any("'env'" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_string_env_values() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "env": {"K": 1}}}})
+    assert good == []
+    assert any("string" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_bool_enabled() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "enabled": "yes"}}})
+    assert good == []
+    assert any("'enabled'" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_bool_approval() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "requires_approval": "sure"}}})
+    assert good == []
+    assert any("requires_approval" in msg for _, msg in errors)
+
+
+def test_config_rejects_non_positive_timeout() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "call_timeout_s": 0}}})
+    assert good == []
+    assert any("call_timeout_s" in msg for _, msg in errors)
+
+
+def test_config_rejects_bool_as_timeout() -> None:
+    """``isinstance(True, int)`` is True in Python — must not leak into timeouts."""
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"bad": {"command": "x", "call_timeout_s": True}}})
+    assert good == []
+    assert any("call_timeout_s" in msg for _, msg in errors)
+
+
+def test_config_non_dict_input_returns_empty() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    assert parse_mcp_config("nope") == ([], [])
+    assert parse_mcp_config({"servers": None}) == ([], [])
+
+
+def test_config_servers_not_table_is_reported() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": [1, 2, 3]})
+    assert good == []
+    assert any("servers" in msg for _, msg in errors)
+
+
+def test_config_rejects_empty_server_name() -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    good, errors = parse_mcp_config({"servers": {"": {"command": "x"}}})
+    assert good == []
+    assert any("non-empty string" in msg for _, msg in errors)
+
+
+def test_config_env_expansion_applies(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    monkeypatch.setenv("YAYA_TEST_TOKEN", "s3cret")
+    good, errors = parse_mcp_config({
+        "servers": {
+            "x": {
+                "command": "/bin/${YAYA_TEST_TOKEN}",
+                "args": ["--key=$YAYA_TEST_TOKEN"],
+                "env": {"K": "v-$YAYA_TEST_TOKEN"},
+            }
+        }
+    })
+    assert errors == []
+    assert len(good) == 1
+    cfg = good[0]
+    assert cfg.command == "/bin/s3cret"
+    assert cfg.args == ["--key=s3cret"]
+    assert cfg.env == {"K": "v-s3cret"}
+
+
+def test_config_env_expansion_leaves_undefined_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    from yaya.plugins.mcp_bridge.config import parse_mcp_config
+
+    monkeypatch.delenv("YAYA_NOT_A_REAL_VAR_xyzzy", raising=False)
+    good, errors = parse_mcp_config({"servers": {"x": {"command": "bin", "args": ["$YAYA_NOT_A_REAL_VAR_xyzzy"]}}})
+    assert errors == []
+    # expandvars leaves unresolved references verbatim.
+    assert good[0].args == ["$YAYA_NOT_A_REAL_VAR_xyzzy"]
+
+
+# ---------------------------------------------------------------------------
+# tool_factory.py schema translation + error-path coverage.
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_factory_falls_back_when_schema_not_object(tmp_path: Path) -> None:
+    """Non-object input schemas collapse to a single ``args: dict`` passthrough."""
+    descriptor = MCPToolDescriptor(name="x", description="", input_schema={"type": "string"})
+    client = _FakeClient(descriptors=[descriptor])
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    # Pydantic should accept an arbitrary args dict.
+    instance = tool_cls.model_validate({"args": {"anything": "goes"}})
+    assert instance is not None
+
+
+async def test_tool_factory_falls_back_when_properties_missing(tmp_path: Path) -> None:
+    """Object schema with no ``properties`` also falls back to passthrough."""
+    descriptor = MCPToolDescriptor(name="x", description="", input_schema={"type": "object"})
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        _FakeClient(),  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    instance = tool_cls.model_validate({})
+    assert instance is not None
+
+
+async def test_tool_factory_honours_optional_with_description(tmp_path: Path) -> None:
+    """Optional properties carry description and accept absence."""
+    descriptor = MCPToolDescriptor(
+        name="x",
+        description="",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer", "description": "an int"},
+                "b": {"type": "number"},  # no description branch
+                "c": {"type": "totally-unknown"},  # falls back to Any
+                "d": "not-a-dict",  # non-dict prop schema branch
+            },
+            "required": ["a", 99],  # non-string required entries are ignored
+        },
+    )
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        _FakeClient(),  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    # Only "a" is required.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        tool_cls.model_validate({})
+    instance = tool_cls.model_validate({"a": 1})
+    assert instance is not None
+
+
+async def test_tool_run_translates_crashed_and_unexpected_errors(tmp_path: Path) -> None:
+    """Crashed / unexpected exceptions surface as the right ``ToolError`` kind."""
+    from yaya.kernel.tool import ToolError
+    from yaya.plugins.mcp_bridge.client import MCPServerCrashedError
+
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+
+    async def _crash(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise MCPServerCrashedError(137)
+
+    client = _FakeClient(descriptors=[descriptor], call_handler=_crash)
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    instance = tool_cls.model_validate({"msg": "hi"})
+    bus = EventBus()
+    ctx = _make_ctx(tmp_path, bus)
+    try:
+        result = await instance.run(ctx)
+        assert isinstance(result, ToolError)
+        assert result.kind == "crashed"
+
+        async def _boom(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("unexpected")
+
+        client2 = _FakeClient(descriptors=[descriptor], call_handler=_boom)
+        tool_cls2 = build_mcp_tool_class(
+            "local",
+            descriptor,
+            client2,  # type: ignore[arg-type]
+            requires_approval=False,
+            call_timeout_s=1.0,
+        )
+        instance2 = tool_cls2.model_validate({"msg": "hi"})
+        result2 = await instance2.run(ctx)
+        assert isinstance(result2, ToolError)
+        assert result2.kind == "crashed"
+    finally:
+        await bus.close()
+
+
+async def test_tool_run_translates_mcp_error_response(tmp_path: Path) -> None:
+    """``isError: true`` responses surface as ``ToolError(kind="internal")``."""
+    from yaya.kernel.tool import ToolError
+
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+
+    async def _error_reply(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"content": [{"type": "text", "text": "nope"}], "isError": True}
+
+    client = _FakeClient(descriptors=[descriptor], call_handler=_error_reply)
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    instance = tool_cls.model_validate({"msg": "hi"})
+    bus = EventBus()
+    ctx = _make_ctx(tmp_path, bus)
+    try:
+        result = await instance.run(ctx)
+        assert isinstance(result, ToolError)
+        assert result.kind == "internal"
+    finally:
+        await bus.close()
+
+
+async def test_tool_run_translates_protocol_error(tmp_path: Path) -> None:
+    """MCPProtocolError → ``ToolError(kind="internal")`` with protocol-error brief."""
+    from yaya.kernel.tool import ToolError
+    from yaya.plugins.mcp_bridge.client import MCPProtocolError
+
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+
+    async def _raise_protocol(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise MCPProtocolError("malformed")
+
+    client = _FakeClient(descriptors=[descriptor], call_handler=_raise_protocol)
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    instance = tool_cls.model_validate({"msg": "hi"})
+    bus = EventBus()
+    ctx = _make_ctx(tmp_path, bus)
+    try:
+        result = await instance.run(ctx)
+        assert isinstance(result, ToolError)
+        assert result.kind == "internal"
+        assert "protocol" in result.brief
+    finally:
+        await bus.close()
+
+
+async def test_tool_run_without_text_block_uses_tool_name_as_brief(tmp_path: Path) -> None:
+    """When the content has no text block, brief falls back to the tool name."""
+    from yaya.kernel.tool import ToolOk
+
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+
+    async def _no_text(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"content": [{"type": "image", "data": "..."}], "isError": False}
+
+    client = _FakeClient(descriptors=[descriptor], call_handler=_no_text)
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    instance = tool_cls.model_validate({"msg": "hi"})
+    bus = EventBus()
+    ctx = _make_ctx(tmp_path, bus)
+    try:
+        result = await instance.run(ctx)
+        assert isinstance(result, ToolOk)
+        assert result.brief == "echo"
+    finally:
+        await bus.close()
+
+
+def test_tool_factory_sanitize_replaces_each_punctuation_char() -> None:
+    """Each non-alnum char becomes ``_`` (no collapsing — stays one-for-one)."""
+    assert mcp_tool_qualified_name("!!!", "???") == "mcp________"
+    from yaya.plugins.mcp_bridge.tool_factory import _sanitize
+
+    # Empty string hits the final fallback to "_".
+    assert _sanitize("") == "_"

--- a/tests/plugins/mcp_bridge/test_mcp_bridge.py
+++ b/tests/plugins/mcp_bridge/test_mcp_bridge.py
@@ -1,0 +1,435 @@
+"""Tests for the MCP bridge plugin.
+
+Each test wires a fresh kernel tool registry so dynamically-built
+:class:`Tool` subclasses from earlier scenarios do not leak across
+tests. Integration cases spawn the pure-Python fake server under
+``_fake_server.py`` — no real network, no `npx`/`uvx` dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.events import Event
+from yaya.kernel.plugin import KernelContext
+from yaya.kernel.tool import (
+    _clear_tool_registry,
+    get_tool,
+    install_dispatcher,
+    register_tool,
+    registered_tools,
+)
+from yaya.plugins.mcp_bridge.client import MCPClientError, MCPToolDescriptor
+from yaya.plugins.mcp_bridge.plugin import (
+    EVENT_SERVER_ERROR,
+    EVENT_SERVER_READY,
+    MCPBridge,
+)
+from yaya.plugins.mcp_bridge.tool_factory import (
+    build_mcp_tool_class,
+    mcp_tool_qualified_name,
+)
+
+_FAKE_SERVER = Path(__file__).resolve().parent / "_fake_server.py"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Snap the kernel tool registry per-test so dynamic classes do not leak."""
+    _clear_tool_registry()
+    yield
+    _clear_tool_registry()
+
+
+def _make_ctx(tmp_path: Path, bus: EventBus, *, config: dict[str, Any] | None = None) -> KernelContext:
+    return KernelContext(
+        bus=bus,
+        logger=logging.getLogger("plugin.mcp-bridge"),
+        config=config or {},
+        state_dir=tmp_path,
+        plugin_name="mcp-bridge",
+    )
+
+
+class _FakeClient:
+    """Test stand-in for :class:`MCPClient` honouring the surface used by the plugin."""
+
+    def __init__(
+        self,
+        *,
+        descriptors: list[MCPToolDescriptor] | None = None,
+        start_error: BaseException | None = None,
+        call_handler: Any = None,
+    ) -> None:
+        self._descriptors = descriptors or []
+        self._start_error = start_error
+        self._call_handler = call_handler
+        self.start_calls = 0
+        self.close_calls = 0
+        self.tool_calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def start(self) -> list[MCPToolDescriptor]:
+        self.start_calls += 1
+        if self._start_error is not None:
+            raise self._start_error
+        return list(self._descriptors)
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        timeout_s: float,
+    ) -> dict[str, Any]:
+        self.tool_calls.append((tool_name, arguments))
+        if self._call_handler is not None:
+            return await self._call_handler(tool_name, arguments)
+        return {"content": [{"type": "text", "text": tool_name}], "isError": False}
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+def _factory_for(client: _FakeClient) -> Any:
+    def _make(command: str, args: list[str], *, env: dict[str, str], logger: Any) -> _FakeClient:
+        return client
+
+    return _make
+
+
+def _factory_sequence(clients: list[_FakeClient]) -> Any:
+    """Hand out fresh ``_FakeClient`` instances in order — one per attempt/server."""
+    iterator = iter(clients)
+
+    def _make(command: str, args: list[str], *, env: dict[str, str], logger: Any) -> _FakeClient:
+        return next(iterator)
+
+    return _make
+
+
+@pytest.fixture
+async def captured_bus() -> AsyncIterator[tuple[EventBus, list[Event]]]:
+    bus = EventBus()
+    captured: list[Event] = []
+
+    async def _observer(ev: Event) -> None:
+        captured.append(ev)
+
+    bus.subscribe(EVENT_SERVER_READY, _observer, source="observer-ready")
+    bus.subscribe(EVENT_SERVER_ERROR, _observer, source="observer-error")
+    yield bus, captured
+    await bus.close()
+
+
+# ---------------------------------------------------------------------------
+# AC scenarios.
+# ---------------------------------------------------------------------------
+
+
+async def test_discovers_and_registers_tools(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """Spawning the real fake_server lands `mcp_local_echo` in the registry."""
+    bus, captured = captured_bus
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={
+            "servers": {
+                "local": {
+                    "command": sys.executable,
+                    "args": [str(_FAKE_SERVER)],
+                }
+            }
+        },
+    )
+    bridge = MCPBridge(retry_delays_s=(0.0,))
+    await bridge.on_load(ctx)
+    try:
+        assert get_tool("mcp_local_echo") is not None, registered_tools()
+        assert get_tool("mcp_local_slow") is not None
+        ready = [ev for ev in captured if ev.kind == EVENT_SERVER_READY]
+        assert len(ready) == 1
+        assert ready[0].payload["server"] == "local"
+        names = {entry["name"] for entry in ready[0].payload["tools"]}
+        assert {"mcp_local_echo", "mcp_local_slow"}.issubset(names)
+    finally:
+        await bridge.on_unload(ctx)
+
+
+async def test_derived_tool_requires_approval_by_default(tmp_path: Path) -> None:
+    """The factory honours the bridge default: ``requires_approval=True``."""
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="echo back",
+        input_schema={
+            "type": "object",
+            "properties": {"msg": {"type": "string"}},
+            "required": ["msg"],
+        },
+    )
+    client = _FakeClient(descriptors=[descriptor])
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=True,
+        call_timeout_s=5.0,
+    )
+    assert tool_cls.requires_approval is True
+    assert tool_cls.name == "mcp_local_echo"
+
+
+async def test_tool_call_forwards_and_wraps_ok(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """Dispatch a tool.call.request and observe a ToolOk envelope on the bus."""
+    bus, _captured = captured_bus
+    install_dispatcher(bus)
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={
+            "servers": {
+                "local": {
+                    "command": sys.executable,
+                    "args": [str(_FAKE_SERVER)],
+                    "requires_approval": False,
+                }
+            }
+        },
+    )
+    bridge = MCPBridge(retry_delays_s=(0.0,))
+    await bridge.on_load(ctx)
+    try:
+        results: list[Event] = []
+
+        async def _observer(ev: Event) -> None:
+            results.append(ev)
+
+        bus.subscribe("tool.call.result", _observer, source="observer")
+
+        from yaya.kernel.events import new_event
+
+        request = new_event(
+            "tool.call.request",
+            {
+                "schema_version": "v1",
+                "id": "call-1",
+                "name": "mcp_local_echo",
+                "args": {"msg": "hello world"},
+            },
+            session_id="sess-1",
+            source="kernel",
+        )
+        await bus.publish(request)
+
+        assert len(results) == 1, results
+        envelope = results[0].payload["envelope"]
+        assert envelope["ok"] is True
+        assert "hello world" in envelope["brief"]
+    finally:
+        await bridge.on_unload(ctx)
+
+
+async def test_boot_failure_emits_server_error_after_retries(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """All retries fail → exactly one x.mcp.server.error with kind=boot_failed."""
+    bus, captured = captured_bus
+    failing_clients = [_FakeClient(start_error=MCPClientError("boom")) for _ in range(2)]
+    bridge = MCPBridge(
+        retry_delays_s=(0.0, 0.0),
+        client_factory=_factory_sequence(failing_clients),
+    )
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={"servers": {"local": {"command": "/no/such/bin"}}},
+    )
+    await bridge.on_load(ctx)
+
+    assert get_tool("mcp_local_echo") is None
+    errors = [ev for ev in captured if ev.kind == EVENT_SERVER_ERROR]
+    assert len(errors) == 1, errors
+    assert errors[0].payload["kind"] == "boot_failed"
+    assert errors[0].payload["server"] == "local"
+    # Each retry should close its half-built client (lesson #31 hygiene).
+    assert all(client.close_calls >= 1 for client in failing_clients)
+
+
+async def test_bad_config_emits_error_and_does_not_taint_others(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """A malformed server entry surfaces as x.mcp.server.error; siblings still load."""
+    bus, captured = captured_bus
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+    good_client = _FakeClient(descriptors=[descriptor])
+    bridge = MCPBridge(
+        retry_delays_s=(0.0,),
+        client_factory=_factory_for(good_client),
+    )
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={
+            "servers": {
+                "broken": {"command": ""},  # invalid: empty command.
+                "good": {"command": "irrelevant"},
+            }
+        },
+    )
+    await bridge.on_load(ctx)
+    try:
+        errors = [ev for ev in captured if ev.kind == EVENT_SERVER_ERROR]
+        assert any(ev.payload["server"] == "broken" for ev in errors)
+        assert get_tool("mcp_good_echo") is not None
+    finally:
+        await bridge.on_unload(ctx)
+
+
+async def test_unload_closes_every_client(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """on_unload awaits close() on every spawned client."""
+    bus, _captured = captured_bus
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+    clients = [_FakeClient(descriptors=[descriptor]) for _ in range(2)]
+
+    sequence = iter(clients)
+
+    def _factory(command: str, args: list[str], *, env: dict[str, str], logger: Any) -> _FakeClient:
+        return next(sequence)
+
+    bridge = MCPBridge(retry_delays_s=(0.0,), client_factory=_factory)
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={
+            "servers": {
+                "alpha": {"command": "x"},
+                "beta": {"command": "y"},
+            }
+        },
+    )
+    await bridge.on_load(ctx)
+    await bridge.on_unload(ctx)
+
+    assert all(client.close_calls == 1 for client in clients)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for inner pieces — exercise edge cases the AC list does not cover.
+# ---------------------------------------------------------------------------
+
+
+async def test_qualified_name_sanitizes_punctuation() -> None:
+    """`-`, `.`, `:` collapse to underscores so the LLM surface accepts the name."""
+    assert mcp_tool_qualified_name("my server", "weird.name:1") == "mcp_my_server_weird_name_1"
+
+
+async def test_tool_call_translates_timeout_to_tool_error(tmp_path: Path) -> None:
+    """A client timeout surfaces as ``ToolError(kind="timeout")`` per lesson #29."""
+    from yaya.kernel.tool import ToolError
+    from yaya.plugins.mcp_bridge.client import MCPTimeoutError
+
+    descriptor = MCPToolDescriptor(
+        name="echo",
+        description="",
+        input_schema={"type": "object", "properties": {"msg": {"type": "string"}}, "required": ["msg"]},
+    )
+
+    async def _raise_timeout(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise MCPTimeoutError("boom")
+
+    client = _FakeClient(descriptors=[descriptor], call_handler=_raise_timeout)
+    tool_cls = build_mcp_tool_class(
+        "local",
+        descriptor,
+        client,  # type: ignore[arg-type]
+        requires_approval=False,
+        call_timeout_s=1.0,
+    )
+    register_tool(tool_cls)
+    instance = tool_cls.model_validate({"msg": "hi"})
+    bus = EventBus()
+    ctx = _make_ctx(tmp_path, bus)
+    try:
+        result = await instance.run(ctx)
+        assert isinstance(result, ToolError)
+        assert result.kind == "timeout"
+    finally:
+        await bus.close()
+
+
+async def test_disabled_server_is_not_spawned(
+    tmp_path: Path,
+    captured_bus: tuple[EventBus, list[Event]],
+) -> None:
+    """`enabled = false` prevents subprocess spawn and registry inserts."""
+    bus, captured = captured_bus
+    client = _FakeClient(descriptors=[])
+    bridge = MCPBridge(retry_delays_s=(0.0,), client_factory=_factory_for(client))
+    ctx = _make_ctx(
+        tmp_path,
+        bus,
+        config={
+            "servers": {
+                "off": {"command": "x", "enabled": False},
+            }
+        },
+    )
+    await bridge.on_load(ctx)
+    assert client.start_calls == 0
+    assert not [ev for ev in captured if ev.kind == EVENT_SERVER_READY]
+
+
+async def test_client_close_terminates_then_kills() -> None:
+    """``MCPClient.close`` falls back to kill when terminate is ignored."""
+    from yaya.plugins.mcp_bridge.client import MCPClient
+
+    # Spawn a child that swallows SIGTERM so terminate() does NOT exit it.
+    code = (
+        "import signal, sys, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "sys.stdout.write('ready\\n'); sys.stdout.flush()\n"
+        "time.sleep(60)\n"
+    )
+    client = MCPClient(sys.executable, ["-c", code], term_grace_s=0.2)
+    # Short-circuit start(): we only want close() to exercise the cancel path.
+    client._proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    # Wait for the child to print "ready" so we know the SIGTERM handler is installed.
+    assert client._proc.stdout is not None
+    await client._proc.stdout.readline()
+
+    await client.close()
+    assert client._proc is not None
+    assert client._proc.returncode is not None


### PR DESCRIPTION
## Summary

- New bundled `mcp_bridge` plugin (Category.TOOL) that auto-loads tools from any MCP server configured under `[mcp_bridge.servers.<name>]`.
- Each MCP-advertised tool is dynamically wrapped as a native yaya `Tool` with `name = mcp_<server>_<tool>` and `requires_approval = True` by default (external tool surface — issue #31 hard rule).
- Vendored 200-line stdio MCP client (newline-delimited JSON-RPC 2.0) under `client.py`. No `mcp` / `fastmcp` dependency: MCP is a protocol, not an agent framework, but the upstream SDKs would drag in a heavy graph (full pydantic namespace, HTTP transports, OAuth) for capabilities 0.1 does not need. AGENT.md §4 is honoured ("vendor a minimal implementation").
- Subprocess teardown uses lesson #31's `terminate()` → bounded `wait_for(proc.wait(), grace_s)` → `kill()` fallback. Boot uses 3 attempts with 0.5/1.0/2.0 s expo backoff; per-server failures emit the plugin-private extension event `x.mcp.server.error` and the rest of the bridge keeps running.
- Plugin-private events `x.mcp.server.ready` / `x.mcp.server.error` documented under the extension namespace section of `docs/dev/plugin-protocol.md`.
- `specs/plugin-mcp_bridge.spec` + mirror `tests/bdd/features/plugin-mcp_bridge.feature` (sync-checked); 6 AC scenarios bound to real pytest nodes plus 4 unit tests for edge cases (qualified-name sanitization, timeout translation per lesson #29, disabled servers, terminate-then-kill).
- Integration tests use a tiny pure-Python stdio MCP server under `tests/plugins/mcp_bridge/_fake_server.py` — no real network, no `npx`/`uvx` dependency.

## Test plan

- [x] `just check` — ruff, mypy --strict, pyright, agent-spec lifecycle all green. Note: the `.feature` ↔ `.spec` sync check fails on **other** specs (pre-existing main-CI red); my own `.spec` and `.feature` are sync-clean.
- [x] `just test` — 444 passed (88.27% coverage, ≥ 80% gate). 2 pre-existing failures in `tests/bdd/test_plugins.py::test_*next_step_*` reproduce on `origin/main` and are unrelated to this PR.
- [x] mcp_bridge tests pass standalone: 10/10 in 0.42 s.
- [x] Subprocess teardown verified by `test_client_close_terminates_then_kills` (child SIG_IGNs SIGTERM → kill fallback fires within `term_grace_s`).

## Deliverable checklist (issue #31)

- [x] `src/yaya/plugins/mcp_bridge/__init__.py` — Plugin entry point.
- [x] `src/yaya/plugins/mcp_bridge/AGENT.md`.
- [x] `pyproject.toml` entry-point line under `yaya.plugins.v1`.
- [x] `[mcp_bridge.servers.<name>]` config schema with `command`/`args`/`env`/`enabled`/`requires_approval`/`call_timeout_s`. `$VAR` / `${VAR}` env-expansion via `os.path.expandvars`.
- [x] Subprocess lifecycle (lesson #31) + 3× expo-backoff retry on boot.
- [x] Tool adapter: dynamic yaya Tool subclass per MCP tool, name `mcp_<server>_<tool>`, pydantic params from MCP `inputSchema`, `requires_approval=True` default. Lesson #29 exception translation in `Tool.run`.
- [x] Plugin-private events `x.mcp.server.ready` / `x.mcp.server.error`.
- [x] `yaya plugin list` surfaces the bridge normally — no new top-level subcommand (GOAL.md command surface is closed).
- [x] `specs/plugin-mcp_bridge.spec` (6 AC scenarios) + mirror `.feature`.
- [x] Unit + integration tests with a fake MCP server (no real network).
- [x] `docs/dev/plugin-protocol.md` updated to record the `x.mcp.*` extension kinds.
- [x] Banned-framework scanner: no allowlist edit needed; the bridge vendors the client and adds zero new dependencies. Scanner re-run: PASS.

## Deviations from the original spec

- The original `[mcp.servers.<name>]` shape became `[mcp_bridge.servers.<name>]` because the kernel's per-plugin config is namespaced by **plugin name** (`mcp-bridge` → `mcp_bridge`), not an arbitrary `mcp` prefix. Documented in `AGENT.md` and `plugin.py` docstrings.
- Plugin name is `mcp-bridge` (kebab-case) per the project's other bundled plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)