### PR TITLE
ci(spec): wire agent-spec guard into pre-commit and CI (#39)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -35,7 +35,7 @@ Accountability is to the **artifact**, not to the user's approval.
 
 - `just check` (ruff + mypy) and `just test` (pytest + coverage) are ground truth.
 - CI is the final gate — `gh pr checks --watch` green before reporting done.
-- Every non-trivial feature PR is backed by a `specs/<slug>.spec` contract verified with [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec). Run `agent-spec lifecycle` through `scripts/check_specs.sh`; CI runs the same wrapper.
+- Every non-trivial feature PR is backed by a `specs/<slug>.spec` contract verified with [`ZhangHanDong/agent-spec`](https://github.com/ZhangHanDong/agent-spec). `scripts/check_specs.sh` runs `agent-spec lifecycle` with the guard semantics (lint + quality + owning-spec boundary hard-gated) from `just check`, pre-commit (on staged `.spec` changes), and CI; see [docs/dev/agent-spec.md](docs/dev/agent-spec.md) for why we wrap `lifecycle` instead of calling `agent-spec guard` directly.
 - Folder-local `AGENT.md` is ground truth for that folder. If code contradicts it, one of them is wrong — fix before merging.
 
 ## 4. Constraints

--- a/docs/dev/agent-spec.md
+++ b/docs/dev/agent-spec.md
@@ -22,6 +22,27 @@ hook for staged `specs/*.spec` changes, and the CI `check` job.
 and pre-commit for staged `.spec` / `.feature` changes so executable
 Gherkin cannot drift from the task contract.
 
+### Why `lifecycle` and not raw `agent-spec guard`?
+
+Upstream ships two CI-oriented entry points. `agent-spec guard` lints
+every spec and runs the full verify layer against a git change scope
+in one shot. It is attractive on paper but currently unusable as a
+merge gate for this repo: the `verify` layer needs an AI backend, and
+without one it emits `skip` verdicts on every scenario — `guard` exits
+non-zero on those skips, so a raw `guard` invocation would block
+every PR even when nothing is wrong.
+
+`agent-spec lifecycle` exposes the same pipeline (lint → boundary →
+verify → report) per spec and returns structured JSON we can
+classify. `scripts/check_specs.sh` + `scripts/_parse_spec_result.py`
+implement the guard semantics the harness promises (lint and quality
+hard-gated, owning-spec boundary hard-gated, non-owning boundary and
+verify skips soft-reported) on top of that JSON. When an AI backend
+lands and `verify` starts emitting real verdicts, we will switch the
+wrapper to raw `guard` and drop the parser. Until then, the wrapper
+IS the guard for this repo. Regression coverage for the decision
+logic lives in `tests/scripts/test_check_spec_result.py`.
+
 **Hard-fail (blocks merge):**
 
 - Parse error — bad frontmatter, unresolved `inherits:`, malformed

--- a/tests/scripts/test_check_spec_result.py
+++ b/tests/scripts/test_check_spec_result.py
@@ -1,0 +1,173 @@
+"""Regression tests for ``scripts/_parse_spec_result.py``.
+
+The parser classifies ``agent-spec lifecycle --format json`` output
+into hard-fail (blocks merge) and soft-report (visible only). Issue
+#39 demands that the harness actually enforces what the docs promise:
+
+* AC-02 — a boundary violation on the **owning** spec fails the build.
+* AC-03 — an unbound scenario (manifests as ``verdict=fail`` on a
+  real, non-boundary scenario name) fails the build.
+
+Both ACs are pure functions of the parser's decision logic, so we
+invoke the script as a subprocess with hand-written JSON payloads
+that mirror the real shapes emitted by ``agent-spec``. This gives us
+a fast, hermetic regression net without needing the Rust toolchain in
+the test environment. The tests also cover the soft-report paths so
+future changes cannot accidentally upgrade non-owning boundary noise
+to a hard fail.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "_parse_spec_result.py"
+
+
+def _run(payload: dict[str, object], *, spec: str, owning_spec: str = "") -> subprocess.CompletedProcess[str]:
+    """Invoke the parser script with ``payload`` on stdin.
+
+    Returns the completed process so tests can assert on both exit
+    code and the single-line summary written to stdout.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--spec",
+            spec,
+            "--min-score",
+            "0.6",
+            "--owning-spec",
+            owning_spec,
+        ],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _ok_payload(**overrides: object) -> dict[str, object]:
+    """Return a green lifecycle payload, overridable for regressions."""
+    base: dict[str, object] = {
+        "lint_issues": 0,
+        "quality_score": 1.0,
+        "verification": {"results": []},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_clean_payload_is_ok() -> None:
+    """Baseline — a clean lifecycle run exits 0 with ``status=OK``."""
+    result = _run(_ok_payload(), spec="specs/example.spec")
+    assert result.returncode == 0
+    assert "status=OK" in result.stdout
+
+
+def test_parse_error_hard_fails() -> None:
+    """Bad JSON means agent-spec itself exploded — never silently pass."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--spec", "specs/example.spec", "--min-score", "0.6", "--owning-spec", ""],
+        input="not json",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "status=PARSE_ERROR" in result.stdout
+
+
+def test_quality_below_floor_hard_fails() -> None:
+    """Sloppy spec authoring (quality < 0.6) must block merge."""
+    payload = _ok_payload(quality_score=0.5)
+    result = _run(payload, spec="specs/example.spec")
+    assert result.returncode == 1
+    assert "status=HARD_FAIL" in result.stdout
+    assert "quality=0.50<min=0.60" in result.stdout
+
+
+def test_unbound_scenario_hard_fails() -> None:
+    """AC-03 — a real scenario with verdict=fail blocks the build.
+
+    ``agent-spec`` reports an unbound scenario (one whose ``Test:``
+    selector does not resolve) as ``verdict=fail`` with a scenario
+    name that is NOT the ``[boundaries]`` pseudo-scenario. The parser
+    must treat that as a hard fail so CI catches it.
+    """
+    payload = _ok_payload(
+        verification={
+            "results": [
+                {"scenario_name": "happy path", "verdict": "fail"},
+            ],
+        }
+    )
+    result = _run(payload, spec="specs/example.spec")
+    assert result.returncode == 1
+    assert "status=HARD_FAIL" in result.stdout
+    assert "scenario_fail(happy path)" in result.stdout
+
+
+def test_owning_spec_boundary_violation_hard_fails() -> None:
+    """AC-02 — a boundary violation on the owning spec blocks the build.
+
+    The wrapper detects the owning spec via
+    ``scripts/_detect_owning_spec.py`` and passes it through as
+    ``--owning-spec``. When ``--spec`` matches, boundary pseudo-
+    scenario failures promote from soft to hard.
+    """
+    payload = _ok_payload(
+        verification={
+            "results": [
+                {"scenario_name": "[boundaries] Allowed", "verdict": "fail"},
+            ],
+        }
+    )
+    result = _run(payload, spec="specs/owned.spec", owning_spec="specs/owned.spec")
+    assert result.returncode == 1
+    assert "status=HARD_FAIL" in result.stdout
+    assert "boundary_fail=1" in result.stdout
+
+
+def test_non_owning_spec_boundary_violation_is_soft() -> None:
+    """Cross-cutting PR — boundary noise on a non-owning spec is soft.
+
+    Without this carve-out every cross-cutting PR would fail N-1
+    specs. The soft-report path is load-bearing; lock it in so
+    future refactors cannot accidentally hard-fail these again.
+    """
+    payload = _ok_payload(
+        verification={
+            "results": [
+                {"scenario_name": "[boundaries] Forbidden", "verdict": "fail"},
+            ],
+        }
+    )
+    result = _run(payload, spec="specs/other.spec", owning_spec="specs/owned.spec")
+    assert result.returncode == 0
+    assert "status=OK" in result.stdout
+    assert "soft:boundary_fail=1" in result.stdout
+
+
+def test_skip_verdicts_are_soft_reported() -> None:
+    """Verify SKIPs require an AI backend — they must never hard-fail."""
+    payload = _ok_payload(
+        verification={
+            "results": [
+                {"scenario_name": "happy path", "verdict": "skip"},
+                {"scenario_name": "edge", "verdict": "skip"},
+            ],
+        }
+    )
+    result = _run(payload, spec="specs/example.spec")
+    assert result.returncode == 0
+    assert "status=OK" in result.stdout
+    assert "skipped=2" in result.stdout


### PR DESCRIPTION
## Summary

Closes the doc/harness gap called out in #39. The harness *was*
already wiring `agent-spec` into pre-commit and CI (via
`scripts/check_specs.sh` + `scripts/_parse_spec_result.py`), but
the docs used the word "guard" while the implementation called
`agent-spec lifecycle`, and the decision logic had no regression
coverage. This PR:

- Adds `tests/scripts/test_check_spec_result.py` — direct regression
  coverage for the parser that implements the guard semantics
  (AC-02 owning-spec boundary hard-fail, AC-03 unbound scenario
  hard-fail, plus quality-floor, parse-error, and both soft-report
  paths).
- Documents in `docs/dev/agent-spec.md` why we wrap `lifecycle`
  instead of calling `agent-spec guard` directly: raw `guard`
  runs the verify layer unconditionally, and without an AI
  backend every scenario returns `skip` and `guard` exits 1 on
  every PR. We keep the guard semantics and swap the entry
  point once an AI backend lands.
- Tightens `AGENT.md` §3 to name the guard semantics and point
  reviewers at the rationale.

## Finding on `agent-spec guard`

`agent-spec guard` is a real upstream subcommand (`agent-spec 0.2.7`),
not fiction — but it has no `--layers` flag and always runs verify.
With no AI backend, `guard --change-scope worktree` produces
`22 check(s) failed` (all SKIPs) at HEAD even though every spec is
green. The `lifecycle`+parser wrapper gives us the guard's intended
hard-gate behavior (lint, quality, owning-spec boundary, real
scenario fails) without the false positives.

## Verification

- `bash scripts/check_specs.sh` at HEAD: all 22 specs OK, one
  expected soft-reported non-owning boundary for the doc+test
  changes in this PR.
- Live AC-02 replay: `agent-spec lifecycle ... --change src/yaya/__init__.py`
  with the seed spec forced as owning spec exits 1 with
  `hard:boundary_fail=1` — boundary enforcement fires when it
  should.
- `just check` green.
- `just test` green — 609 passed, coverage 90.46% (floor 88%).

## Test plan

- [x] `uv run python -m pytest tests/scripts/test_check_spec_result.py` (7 passed)
- [x] `just check`
- [x] `just test`
- [x] Manual: force a boundary violation on the seed spec and confirm
      the wrapper exits 1.

Closes #39