### PR TITLE
chore(ci): check_specs.sh hard-fails under CI when agent-spec missing (#99)

### DIFF
--- a/docs/dev/agent-spec.md
+++ b/docs/dev/agent-spec.md
@@ -122,8 +122,27 @@ Optional: install the corresponding agent skill for your runtime
 Cursor). Not required for CI.
 
 If you do not want to install Rust locally, skip it — the wrapper
-script prints a friendly notice and succeeds, and CI enforces the
-check on every PR.
+script prints a friendly notice and succeeds locally, and CI enforces
+the check on every PR.
+
+### Missing-binary behavior (decision tree)
+
+`scripts/check_specs.sh` resolves the "binary missing" case in this
+order:
+
+1. **Under `$CI` or `$GITHUB_ACTIONS`** — hard-fail (exit 1). A CI
+   run without `agent-spec` is always a CI config bug (cargo install
+   step dropped, cache-key drift, etc.); silently exiting 0 would let
+   spec drift land without enforcement. Fix the workflow, do not
+   route around it.
+2. **`SKIP_AGENT_SPEC=1`** — soft-skip (exit 0) with an info message.
+   Explicit opt-out for contributors who deliberately want to bypass
+   (e.g., doc-only branches, sandbox experiments). Preferred over
+   relying on the binary being absent.
+3. **Local, no opt-out, binary missing** — soft-skip (exit 0) with a
+   warning. Keeps the Rust-free contributor experience intact. This
+   default is scheduled to flip to hard-fail in a future release once
+   the toolchain is universally installed in the team dev shell.
 
 ## Task contract shape (`specs/<slug>.spec`)
 

--- a/scripts/check_specs.sh
+++ b/scripts/check_specs.sh
@@ -10,7 +10,9 @@
 # the SKIP total for visibility but do NOT fail the run on them.
 #
 # Locally without the binary: prints an install hint and exits 0 so a
-# commit is not blocked. CI always has it, so CI enforces.
+# commit is not blocked (set SKIP_AGENT_SPEC=1 to opt out explicitly).
+# Under $CI or $GITHUB_ACTIONS a missing binary hard-fails — a cargo
+# install step or cache-key drift must never let spec drift land silently.
 #
 # See docs/dev/agent-spec.md for install and semantics.
 set -euo pipefail
@@ -36,8 +38,21 @@ fi
 echo
 
 if ! command -v agent-spec >/dev/null 2>&1; then
-  echo "⚠️  agent-spec not installed; skipping spec enforcement."
+  if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "❌ agent-spec not installed but running under CI."
+    echo "   Install: cargo install agent-spec --version 0.2.7 --locked"
+    echo "   This is a CI configuration bug — specs cannot be enforced."
+    echo "   See docs/dev/agent-spec.md"
+    exit 1
+  fi
+  if [ -n "${SKIP_AGENT_SPEC:-}" ]; then
+    echo "ℹ️  agent-spec not installed; SKIP_AGENT_SPEC=1 set, skipping."
+    exit 0
+  fi
+  echo "⚠️  agent-spec not installed; spec enforcement skipped locally."
   echo "    Install: cargo install agent-spec --version 0.2.7 --locked"
+  echo "    Or set SKIP_AGENT_SPEC=1 to explicitly skip."
+  echo "    Local default will switch to hard-fail in a future release."
   echo "    See docs/dev/agent-spec.md"
   exit 0
 fi


### PR DESCRIPTION
## Summary

Closes #99 — structural hardening of `scripts/check_specs.sh`.

- Under `$CI` or `$GITHUB_ACTIONS` with a missing `agent-spec` binary: hard-fail (exit 1) with an actionable error message.
- Locally: soft-skip stays the default to preserve the Rust-free contributor experience.
- New `SKIP_AGENT_SPEC=1` env var is the explicit opt-out, replacing "binary happens to be absent" as the skip signal.
- `docs/dev/agent-spec.md` documents the new decision tree.

## Test plan

- [x] `CI=1` with missing binary → exit 1
- [x] Local with missing binary → exit 0 + warn (unchanged default)
- [x] `SKIP_AGENT_SPEC=1` with missing binary → exit 0 + info
- [x] Binary present → normal run, all 23 specs green
- [x] `just check && just test` green locally (coverage 90.95%, 622 tests pass)