### PR TITLE
test(coverage): ratchet fail_under to 90 + per-module gates (#43)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: uv run python -m pytest --cov --cov-report=xml --cov-report=term
+      - name: Enforce per-module coverage gates
+        run: uv run python scripts/check_coverage.py --xml coverage.xml
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/AGENT.md
+++ b/AGENT.md
@@ -40,7 +40,7 @@ Accountability is to the **artifact**, not to the user's approval.
 
 ## 4. Constraints
 
-- Python 3.14+, `uv` envs, `just` tasks, `ruff`, `mypy --strict`, `pytest`, coverage ≥88%.
+- Python 3.14+, `uv` envs, `just` tasks, `ruff`, `mypy --strict`, `pytest`, global coverage ≥90% (`fail_under`), plus per-module gates (kernel ≥93.5% ratcheting to 95%, core ≥90%, cli ≥85%, each bundled plugin ≥ its current floor) enforced by `scripts/check_coverage.py` in `just test` and CI. Ratchet policy in [docs/dev/testing.md](docs/dev/testing.md#ratchet-policy).
 - English-only in code, comments, commits, docs. Chinese only in user-facing chat.
 - Conventional Commits with `(#N)` + `Closes #N`. Never `--no-verify`.
 - Layout: `cli/` depends on `core/`, never the reverse.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -51,7 +51,7 @@
    `plugins/web/` below 85%), the gate sits at *reality minus 0.5*;
    a follow-up issue raises coverage first, then the gate. Never set
    a gate you cannot meet today.
-4. The `ratchet→` column in `check_coverage.py`'s output names the
+4. The `ratchet->` column in `check_coverage.py`'s output names the
    value a gate could be raised to right now. Watch for it in PR
    logs — free ratchet opportunities are ratchet opportunities missed.
 - **Prefer integration over mocks.** Reach for real objects, `tmp_path`, and

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -7,11 +7,53 @@
 ## Rules
 
 - **No public function/class without a test.** Coverage must not regress on any PR.
-- **Coverage floor: 88%.** Enforced by `fail_under = 88` in `pyproject.toml`.
-  Ratchet policy — every merge to `main` that raises global coverage by
-  ≥1 point must raise `fail_under` to `(new_value − 0.5)` in the same PR.
-  Never lower a floor without a `governance` issue. Per-module gates
-  (kernel ≥95%, core ≥90%, cli ≥85%) are tracked in #43.
+- **Global coverage floor: 90%.** Enforced by `fail_under = 90` in
+  `pyproject.toml` (applied by `pytest-cov` against combined line +
+  branch coverage).
+- **Per-module gates** enforced by `scripts/check_coverage.py` against
+  the `coverage.xml` that `pytest --cov-report=xml` produces.
+  The script runs locally via `just test` and in CI after the test
+  step on every OS in the matrix, so platform-specific regressions
+  surface at PR time. Current gates (line coverage):
+
+  | Prefix | Gate | Aspirational target |
+  | --- | --- | --- |
+  | `<global>` (line + branch via `fail_under`) | 90.0% | rise with reality |
+  | `src/yaya/kernel/` | 93.5% | 95% |
+  | `src/yaya/core/` | 90.0% | 90% |
+  | `src/yaya/cli/` | 85.0% | 85% |
+  | `src/yaya/plugins/agent_tool/` | 95.0% | 95% |
+  | `src/yaya/plugins/llm_echo/` | 95.0% | 95% |
+  | `src/yaya/plugins/llm_openai/` | 79.5% | 85% |
+  | `src/yaya/plugins/mcp_bridge/` | 90.0% | 90% |
+  | `src/yaya/plugins/memory_sqlite/` | 89.5% | 90% |
+  | `src/yaya/plugins/strategy_react/` | 95.0% | 95% |
+  | `src/yaya/plugins/tool_bash/` | 95.0% | 95% |
+  | `src/yaya/plugins/web/` | 84.0% | 85% |
+
+  Gates tagged below their aspirational target track the ratchet
+  convention *"reality minus 0.5"* — they rise as coverage improves
+  and never drop without a `governance` issue. The tables in
+  `scripts/check_coverage.py` are the source of truth; the table here
+  is a mirror for readers who are not reading the script.
+
+### Ratchet policy
+
+1. After any merge to `main` that raises a prefix's coverage above
+   `gate + 0.5`, bump its gate in `scripts/check_coverage.py` (and the
+   global `fail_under` in `pyproject.toml`) to `floor(actual − 0.5)`
+   rounded down to the nearest 0.5. Do this in the same PR or an
+   immediate follow-up.
+2. Gates **never retreat**. Lowering a gate — or relaxing the global
+   floor — requires a dedicated issue labelled `governance` and owner
+   sign-off.
+3. If current reality is below an aspirational target (e.g.
+   `plugins/web/` below 85%), the gate sits at *reality minus 0.5*;
+   a follow-up issue raises coverage first, then the gate. Never set
+   a gate you cannot meet today.
+4. The `ratchet→` column in `check_coverage.py`'s output names the
+   value a gate could be raised to right now. Watch for it in PR
+   logs — free ratchet opportunities are ratchet opportunities missed.
 - **Prefer integration over mocks.** Reach for real objects, `tmp_path`, and
   recorded fixtures before `unittest.mock`.
 - **Tests must fail before they pass.** Write the failing test first, then

--- a/justfile
+++ b/justfile
@@ -44,10 +44,12 @@ fmt:
     uv run ruff format .
     uv run ruff check --fix .
 
-# Run unit + CLI tests (default suite)
+# Run unit + CLI tests (default suite) + per-module coverage gates
 test:
     @echo "🧪 Running pytest"
-    uv run python -m pytest --cov --cov-report=term-missing
+    uv run python -m pytest --cov --cov-report=term-missing --cov-report=xml
+    @echo "📊 Enforcing per-module coverage gates"
+    uv run python scripts/check_coverage.py
 
 # Build wheel, install into a fresh venv, run post-install smoke
 test-e2e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ branch = true
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-fail_under = 88
+fail_under = 90
 exclude_also = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",

--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -12,6 +12,7 @@ Release-time and CI helper scripts. Not imported by the package.
 ## Constraints
 - `check_version_tag.py` — verifies the git tag matches `pyproject.toml` version at release time.
 - `check_banned_frameworks.py` — enforces AGENT.md §4 (no third-party agent frameworks). Scans `pyproject.toml` declared deps and AST imports under `src/` + `tests/` against a hardcoded ban list. Stdlib only. Takes `--json` for CI integration. Wired into pre-commit + the `Lint & type check` CI job.
+- `check_coverage.py` — per-module coverage gates. Parses `coverage.xml` from `pytest --cov-report=xml` and fails with exit code 1 if any prefix (kernel / core / cli / each bundled plugin) falls below its gate. Stdlib only. Runs after pytest in `just test` and on every OS in the CI test matrix. Ratchet policy in [../docs/dev/testing.md](../docs/dev/testing.md#ratchet-policy).
 - Scripts are **standalone**: runnable with `python scripts/<name>.py` using only stdlib (or clearly documented deps available in the CI environment).
 - No imports from `yaya.*` unless strictly required — scripts may run before install in CI.
 - Every script has a module-level docstring stating: what it does, when it runs, exit-code semantics.

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -227,12 +227,15 @@ def format_summary(
 
     Returns:
         A multi-line string suitable for stdout, with one row per gate.
-        The ``ratchet→`` column names the gate value a future PR could
+        The ``ratchet->`` column names the gate value a future PR could
         raise the threshold to, so maintainers can see regressions and
         ratchet opportunities at a glance.
     """
     lines = ["Coverage gates:", ""]
-    header = f"  {'prefix':<30} {'covered/total':>14} {'actual':>8} {'gate':>7} {'status':>8} {'ratchet→':>10}"
+    # ASCII-only header: Windows' default cp1252 stdout cannot encode
+    # arrow / em-dash glyphs and the CI log loses them. Keep the
+    # summary portable; the docs render the prose version instead.
+    header = f"  {'prefix':<30} {'covered/total':>14} {'actual':>8} {'gate':>7} {'status':>8} {'ratchet->':>10}"
     lines.append(header)
     lines.append("  " + "-" * (len(header) - 2))
 
@@ -242,7 +245,7 @@ def format_summary(
         # Suggested ratchet: actual - 0.5, floored to 0.5 grid. Only
         # emit a ratchet suggestion when it would raise the gate.
         grid = (int(cov.percent * 2) - 1) / 2  # floor(actual) - 0.5
-        suggestion = f"{grid:.1f}" if grid > result.threshold else "—"
+        suggestion = f"{grid:.1f}" if grid > result.threshold else "--"
         return (
             f"  {result.coverage.prefix:<30} "
             f"{cov.covered:>6}/{cov.total:<7} "

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Per-module coverage gate.
+
+Runs after ``pytest --cov-report=xml`` and parses ``coverage.xml`` to
+enforce **per-module** coverage thresholds in addition to the global
+``fail_under`` in ``pyproject.toml``. Coverage regressions in the
+kernel (which every plugin depends on) must not be hidden by high
+overall coverage in plugin code.
+
+When it runs
+    * ``just test`` (invoked after pytest via the justfile recipe) so
+      local runs fail fast on regression.
+    * CI ``tests`` job on every PR / push, across all three OS matrix
+      entries — platform-specific dips surface at PR time.
+
+Exit codes
+    0  every module meets or exceeds its gate.
+    1  one or more modules are below their gate. The failing modules
+       and their coverage are listed in stderr.
+    2  usage error (missing ``coverage.xml``).
+
+Ratchet policy (documented in ``docs/dev/testing.md``):
+    * After any merge to ``main`` that raises a module's coverage
+      above ``gate + 0.5``, raise its gate to ``actual - 0.5`` in the
+      same PR or an immediate follow-up. Rounding is ``floor`` to the
+      nearest 0.5.
+    * Gates never retreat without a ``governance`` issue.
+
+Only the Python standard library may be imported — this script runs
+before ``uv sync`` in some CI contexts and must have no third-party
+deps. See ``scripts/AGENT.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# ---------------------------------------------------------------------------
+# Gate table
+# ---------------------------------------------------------------------------
+# Each gate is ``(prefix, minimum_percent)`` where ``prefix`` is matched
+# against the ``filename`` attribute of ``<class>`` nodes in
+# ``coverage.xml`` (paths are relative to ``src/yaya``). A gate that is
+# LOWER than the current reported coverage on ``main`` is not allowed —
+# see the ratchet policy above. If a gate looks low, it is because the
+# module is currently below its aspirational target; raising the gate
+# requires raising the coverage first.
+
+GLOBAL_GATE = 90.0
+"""Global coverage floor (also enforced by ``fail_under`` in pyproject)."""
+
+MODULE_GATES: tuple[tuple[str, float], ...] = (
+    # Kernel is the contract: bugs here blow up every plugin. Aspirational
+    # gate is 95% (issue #43); current reality on main is ~94.46%, so the
+    # gate sits at floor(94.46 - 0.5) = 93.5 until coverage rises.
+    ("kernel/", 93.5),
+    ("core/", 90.0),
+    # CLI branches include rich-text / tty paths that resist coverage.
+    ("cli/", 85.0),
+)
+"""Per-area gates for non-plugin source trees."""
+
+PLUGIN_GATES: tuple[tuple[str, float], ...] = (
+    # Each bundled plugin is gated independently — aggregating plugins
+    # hides a 60% plugin behind a 95% neighbor. Gates reflect current
+    # reality minus 0.5 where the 85% target is not yet met (ratchet up
+    # when coverage rises). Aspirational floor per bundled plugin: 85%.
+    ("plugins/agent_tool/", 95.0),
+    ("plugins/llm_echo/", 95.0),
+    # llm_openai exercises many provider error paths that the suite
+    # does not yet hit. Gate tracks reality (~80.16%) - 0.5.
+    ("plugins/llm_openai/", 79.5),
+    ("plugins/mcp_bridge/", 90.0),
+    ("plugins/memory_sqlite/", 89.5),
+    ("plugins/strategy_react/", 95.0),
+    ("plugins/tool_bash/", 95.0),
+    # Web adapter has WS lifecycle branches that are hard to cover in
+    # unit tests. Gate tracks reality (~84.86%) - 0.5 until a dedicated
+    # WS-state test pass lands.
+    ("plugins/web/", 84.0),
+)
+"""Per-bundled-plugin gates."""
+
+
+@dataclass(frozen=True)
+class ModuleCoverage:
+    """Aggregated coverage for a prefix group.
+
+    Attributes:
+        prefix: Path prefix that identified the group.
+        covered: Number of executed lines across the group.
+        total: Number of executable lines across the group.
+    """
+
+    prefix: str
+    covered: int
+    total: int
+
+    @property
+    def percent(self) -> float:
+        """Return line coverage as a percentage, 100.0 for empty groups."""
+        if self.total == 0:
+            return 100.0
+        return self.covered / self.total * 100.0
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Outcome of checking a single gate.
+
+    Attributes:
+        coverage: The coverage roll-up for the gate's prefix.
+        threshold: The required minimum percent.
+    """
+
+    coverage: ModuleCoverage
+    threshold: float
+
+    @property
+    def passed(self) -> bool:
+        """True when coverage meets or exceeds the threshold."""
+        return self.coverage.percent >= self.threshold
+
+
+def parse_coverage(path: Path) -> dict[str, tuple[int, int]]:
+    """Return per-file ``(covered, total)`` lines from a coverage XML file.
+
+    Args:
+        path: Path to the ``coverage.xml`` produced by ``pytest-cov``.
+
+    Returns:
+        Mapping of file path (as reported in the XML, relative to the
+        ``<source>`` root) to a ``(covered, total)`` line tuple.
+    """
+    # ``xml.etree`` parses untrusted input; ``coverage.xml`` is produced
+    # by our own test run so defusedxml is not required here.
+    tree = ET.parse(path)  # noqa: S314
+    root = tree.getroot()
+    out: dict[str, tuple[int, int]] = {}
+    for cls in root.iter("class"):
+        filename = cls.get("filename", "")
+        if not filename:
+            continue
+        lines_node = cls.find("lines")
+        if lines_node is None:
+            continue
+        total = 0
+        covered = 0
+        for line in lines_node.findall("line"):
+            total += 1
+            if int(line.get("hits", "0")) > 0:
+                covered += 1
+        out[filename] = (covered, total)
+    return out
+
+
+def aggregate(files: dict[str, tuple[int, int]], prefix: str) -> ModuleCoverage:
+    """Roll up coverage for all files under ``prefix``.
+
+    Args:
+        files: Per-file coverage as returned by :func:`parse_coverage`.
+        prefix: Path prefix (e.g. ``kernel/``) to match against file keys.
+
+    Returns:
+        A :class:`ModuleCoverage` summarising lines covered within the
+        prefix. An empty group reports 100% to avoid false positives
+        when a module has no source files (e.g. during refactors).
+    """
+    covered = 0
+    total = 0
+    for path, (cv, tv) in files.items():
+        if path.startswith(prefix):
+            covered += cv
+            total += tv
+    return ModuleCoverage(prefix=prefix, covered=covered, total=total)
+
+
+def evaluate_gates(
+    files: dict[str, tuple[int, int]],
+    gates: Iterable[tuple[str, float]],
+) -> list[GateResult]:
+    """Compute :class:`GateResult` objects for each ``(prefix, threshold)``.
+
+    Args:
+        files: Per-file coverage as returned by :func:`parse_coverage`.
+        gates: Iterable of ``(prefix, threshold)`` gate definitions.
+
+    Returns:
+        One :class:`GateResult` per gate, in the input order.
+    """
+    return [GateResult(coverage=aggregate(files, prefix), threshold=threshold) for prefix, threshold in gates]
+
+
+def global_coverage(files: dict[str, tuple[int, int]]) -> ModuleCoverage:
+    """Return the global line-coverage roll-up across every tracked file.
+
+    Args:
+        files: Per-file coverage as returned by :func:`parse_coverage`.
+
+    Returns:
+        A :class:`ModuleCoverage` whose ``prefix`` is ``"<global>"``.
+    """
+    covered = sum(cv for cv, _ in files.values())
+    total = sum(tv for _, tv in files.values())
+    return ModuleCoverage(prefix="<global>", covered=covered, total=total)
+
+
+def format_summary(
+    global_result: GateResult,
+    module_results: list[GateResult],
+    plugin_results: list[GateResult],
+) -> str:
+    """Format a ratchet-friendly summary table.
+
+    Args:
+        global_result: The global gate outcome.
+        module_results: Per-area gate outcomes.
+        plugin_results: Per-bundled-plugin gate outcomes.
+
+    Returns:
+        A multi-line string suitable for stdout, with one row per gate.
+        The ``ratchet→`` column names the gate value a future PR could
+        raise the threshold to, so maintainers can see regressions and
+        ratchet opportunities at a glance.
+    """
+    lines = ["Coverage gates:", ""]
+    header = f"  {'prefix':<30} {'covered/total':>14} {'actual':>8} {'gate':>7} {'status':>8} {'ratchet→':>10}"
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+
+    def row(result: GateResult) -> str:
+        cov = result.coverage
+        status = "ok" if result.passed else "FAIL"
+        # Suggested ratchet: actual - 0.5, floored to 0.5 grid. Only
+        # emit a ratchet suggestion when it would raise the gate.
+        grid = (int(cov.percent * 2) - 1) / 2  # floor(actual) - 0.5
+        suggestion = f"{grid:.1f}" if grid > result.threshold else "—"
+        return (
+            f"  {result.coverage.prefix:<30} "
+            f"{cov.covered:>6}/{cov.total:<7} "
+            f"{cov.percent:>7.2f}% "
+            f"{result.threshold:>6.1f}% "
+            f"{status:>8} "
+            f"{suggestion:>10}"
+        )
+
+    lines.append(row(global_result))
+    lines.append("")
+    for result in module_results:
+        lines.append(row(result))
+    lines.append("")
+    for result in plugin_results:
+        lines.append(row(result))
+    return "\n".join(lines)
+
+
+def format_failures(failures: list[GateResult]) -> str:
+    """Return a human-readable error listing every failing gate.
+
+    Args:
+        failures: Gate results whose ``.passed`` is False.
+
+    Returns:
+        A multi-line error message naming each failing prefix, its
+        measured coverage, and the required threshold.
+    """
+    lines = ["Coverage gate failures:"]
+    for f in failures:
+        cov = f.coverage
+        lines.append(
+            f"  {cov.prefix}: {cov.percent:.2f}% < {f.threshold:.1f}% ({cov.covered}/{cov.total} lines covered)"
+        )
+    lines.append("")
+    lines.append("See docs/dev/testing.md for the ratchet policy.")
+    return "\n".join(lines)
+
+
+def run(xml_path: Path) -> int:
+    """Evaluate all gates against ``xml_path`` and return a shell exit code.
+
+    Args:
+        xml_path: Path to the ``coverage.xml`` file to parse.
+
+    Returns:
+        Exit code: 0 on success, 1 on any gate failure, 2 on usage error.
+    """
+    if not xml_path.exists():
+        print(f"error: coverage file not found: {xml_path}", file=sys.stderr)
+        print("Hint: run `uv run pytest --cov --cov-report=xml` first.", file=sys.stderr)
+        return 2
+
+    files = parse_coverage(xml_path)
+    global_res = GateResult(coverage=global_coverage(files), threshold=GLOBAL_GATE)
+    module_res = evaluate_gates(files, MODULE_GATES)
+    plugin_res = evaluate_gates(files, PLUGIN_GATES)
+
+    print(format_summary(global_res, module_res, plugin_res))
+
+    failures = [r for r in [global_res, *module_res, *plugin_res] if not r.passed]
+    if failures:
+        print("", file=sys.stderr)
+        print(format_failures(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argument vector for testing; defaults to ``sys.argv``.
+
+    Returns:
+        Shell exit code from :func:`run`.
+    """
+    parser = argparse.ArgumentParser(description="Enforce per-module coverage gates on coverage.xml.")
+    parser.add_argument(
+        "--xml",
+        type=Path,
+        default=Path("coverage.xml"),
+        help="Path to coverage.xml (default: ./coverage.xml).",
+    )
+    args = parser.parse_args(argv)
+    return run(args.xml)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/AGENT.md
+++ b/tests/AGENT.md
@@ -6,7 +6,7 @@
 Pytest suite. Mirrors `src/yaya/` one-to-one. Tests are the specification.
 
 ## External Reality
-- `just test` (pytest + coverage) is ground truth. Coverage floor: 88% (`fail_under`).
+- `just test` (pytest + coverage) is ground truth. Global coverage floor: 90% (`fail_under`), plus per-module gates enforced by `scripts/check_coverage.py` (kernel / core / cli / each bundled plugin). Ratchet policy: [../docs/dev/testing.md](../docs/dev/testing.md#ratchet-policy).
 - `addopts` enforces `--strict-markers` + `--strict-config` + 30s timeout.
 - `pytest-randomly` shuffles test order — order-dependence fails CI immediately.
 - Tests run hermetically: autouse fixtures redirect `STATE_DIR` and disable the update toast.

--- a/tests/scripts/test_check_coverage.py
+++ b/tests/scripts/test_check_coverage.py
@@ -1,0 +1,181 @@
+"""Tests for ``scripts/check_coverage.py``.
+
+These tests synthesise tiny ``coverage.xml`` fixtures rather than
+running pytest-cov itself — we're testing the gate evaluator, not the
+coverage tooling.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_coverage.py"
+
+
+def _load_script() -> Any:
+    """Import ``check_coverage.py`` as a module without installing it."""
+    spec = importlib.util.spec_from_file_location("check_coverage", SCRIPT_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load coverage checker from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_coverage"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def checker() -> Any:
+    """Return the loaded ``check_coverage`` module."""
+    return _load_script()
+
+
+def _build_xml(classes: list[tuple[str, int, int]]) -> str:
+    """Build a coverage.xml string with ``(filename, total, covered)`` rows.
+
+    Each ``<class>`` gets ``total`` ``<line>`` nodes where the first
+    ``covered`` have ``hits="1"`` and the rest have ``hits="0"``.
+    """
+    parts = [
+        '<?xml version="1.0" ?>',
+        "<coverage>",
+        "  <sources><source>/repo/src/yaya</source></sources>",
+        "  <packages><package><classes>",
+    ]
+    for filename, total, covered in classes:
+        parts.append(f'    <class filename="{filename}"><lines>')
+        for i in range(total):
+            hits = 1 if i < covered else 0
+            parts.append(f'      <line number="{i + 1}" hits="{hits}"/>')
+        parts.append("    </lines></class>")
+    parts.extend(["  </classes></package></packages>", "</coverage>"])
+    return "\n".join(parts)
+
+
+def _write_passing_xml(path: Path) -> None:
+    """Write a coverage.xml that clears every gate."""
+    rows = [
+        ("kernel/bus.py", 100, 99),  # 99%
+        ("kernel/loop.py", 100, 98),  # 99% combined kernel
+        ("core/updater.py", 100, 95),  # 95%
+        ("cli/commands/hello.py", 100, 90),  # 90%
+        ("plugins/agent_tool/plugin.py", 100, 99),
+        ("plugins/llm_echo/plugin.py", 100, 100),
+        ("plugins/llm_openai/plugin.py", 100, 85),
+        ("plugins/mcp_bridge/client.py", 100, 95),
+        ("plugins/memory_sqlite/plugin.py", 100, 95),
+        ("plugins/strategy_react/plugin.py", 100, 99),
+        ("plugins/tool_bash/plugin.py", 100, 99),
+        ("plugins/web/plugin.py", 100, 90),
+    ]
+    path.write_text(_build_xml(rows), encoding="utf-8")
+
+
+def test_passing_xml_exits_zero(checker: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_passing_xml(xml)
+    code = checker.run(xml)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Coverage gates:" in out
+    assert "kernel/" in out
+
+
+def test_kernel_regression_exits_one_and_names_kernel(
+    checker: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Kernel at 94% (below the 93.5 gate? no, 94 clears) — pick 92% to fail.
+    rows = [
+        ("kernel/bus.py", 100, 92),  # 92% kernel — below 93.5 gate
+        ("core/updater.py", 100, 95),
+        ("cli/commands/hello.py", 100, 90),
+        ("plugins/agent_tool/plugin.py", 100, 99),
+        ("plugins/llm_echo/plugin.py", 100, 100),
+        ("plugins/llm_openai/plugin.py", 100, 85),
+        ("plugins/mcp_bridge/client.py", 100, 95),
+        ("plugins/memory_sqlite/plugin.py", 100, 95),
+        ("plugins/strategy_react/plugin.py", 100, 99),
+        ("plugins/tool_bash/plugin.py", 100, 99),
+        ("plugins/web/plugin.py", 100, 90),
+    ]
+    xml = tmp_path / "coverage.xml"
+    xml.write_text(_build_xml(rows), encoding="utf-8")
+    code = checker.run(xml)
+    captured = capsys.readouterr()
+    assert code == 1
+    # Failure message goes to stderr and names the kernel prefix + threshold.
+    assert "kernel/" in captured.err
+    assert "93.5" in captured.err
+
+
+def test_plugin_regression_names_plugin(checker: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Drop web plugin to 80% (below its 84 gate); keep everything else passing.
+    rows = [
+        ("kernel/bus.py", 100, 99),
+        ("core/updater.py", 100, 95),
+        ("cli/commands/hello.py", 100, 90),
+        ("plugins/agent_tool/plugin.py", 100, 99),
+        ("plugins/llm_echo/plugin.py", 100, 100),
+        ("plugins/llm_openai/plugin.py", 100, 85),
+        ("plugins/mcp_bridge/client.py", 100, 95),
+        ("plugins/memory_sqlite/plugin.py", 100, 95),
+        ("plugins/strategy_react/plugin.py", 100, 99),
+        ("plugins/tool_bash/plugin.py", 100, 99),
+        ("plugins/web/plugin.py", 100, 80),  # below 84 gate
+    ]
+    xml = tmp_path / "coverage.xml"
+    xml.write_text(_build_xml(rows), encoding="utf-8")
+    code = checker.run(xml)
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "plugins/web/" in err
+
+
+def test_missing_xml_returns_two(checker: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    missing = tmp_path / "nope.xml"
+    code = checker.run(missing)
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "not found" in err
+
+
+def test_aggregate_empty_prefix_reports_100(checker: Any) -> None:
+    # Empty groups (no matching files) must not cause a false failure.
+    result = checker.aggregate({}, "ghost/")
+    assert result.total == 0
+    assert result.percent == 100.0
+
+
+def test_main_parses_xml_argument(checker: Any, tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_passing_xml(xml)
+    code = checker.main(["--xml", str(xml)])
+    assert code == 0
+
+
+def test_summary_suggests_ratchet_for_improved_modules(checker: Any, tmp_path: Path) -> None:
+    xml = tmp_path / "coverage.xml"
+    _write_passing_xml(xml)
+    files = checker.parse_coverage(xml)
+    global_res = checker.GateResult(coverage=checker.global_coverage(files), threshold=checker.GLOBAL_GATE)
+    module_res = checker.evaluate_gates(files, checker.MODULE_GATES)
+    plugin_res = checker.evaluate_gates(files, checker.PLUGIN_GATES)
+    text = checker.format_summary(global_res, module_res, plugin_res)
+    # Modules with plenty of headroom must surface a ratchet suggestion.
+    assert "ratchet→" in text
+    assert "94.5" in text  # global at 95.33% → ratchet suggestion 94.5
+
+    # A gate exactly at reality should get the em-dash placeholder.
+    tight = checker.GateResult(
+        coverage=checker.ModuleCoverage(prefix="tight/", covered=90, total=100),
+        threshold=90.0,
+    )
+    text2 = checker.format_summary(global_res, [tight], [])
+    assert "—" in text2

--- a/tests/scripts/test_check_coverage.py
+++ b/tests/scripts/test_check_coverage.py
@@ -169,13 +169,13 @@ def test_summary_suggests_ratchet_for_improved_modules(checker: Any, tmp_path: P
     plugin_res = checker.evaluate_gates(files, checker.PLUGIN_GATES)
     text = checker.format_summary(global_res, module_res, plugin_res)
     # Modules with plenty of headroom must surface a ratchet suggestion.
-    assert "ratchet→" in text
-    assert "94.5" in text  # global at 95.33% → ratchet suggestion 94.5
+    assert "ratchet->" in text
+    assert "94.5" in text  # global at 95.33% -> ratchet suggestion 94.5
 
-    # A gate exactly at reality should get the em-dash placeholder.
+    # A gate exactly at reality should get the ASCII placeholder.
     tight = checker.GateResult(
         coverage=checker.ModuleCoverage(prefix="tight/", covered=90, total=100),
         threshold=90.0,
     )
     text2 = checker.format_summary(global_res, [tight], [])
-    assert "—" in text2
+    assert " -- " in text2 or text2.rstrip().endswith("--")


### PR DESCRIPTION
## Summary

- Raise global `fail_under` from 88 -> 90 (main sits at ~90.95%).
- Add `scripts/check_coverage.py` (stdlib only) enforcing per-module
  line-coverage gates on `coverage.xml`. Kernel regressions can no
  longer hide behind high overall coverage in plugin code.
- Wire the gate into `just test` and the CI `tests` job on every OS
  in the matrix — platform-specific dips surface at PR time.
- Document the ratchet policy in `docs/dev/testing.md`; mirror the
  new floors into `AGENT.md`, `tests/AGENT.md`, `scripts/AGENT.md`.

## Gates

| Prefix | Gate | Aspirational | Current |
| --- | --- | --- | --- |
| `<global>` (line+branch) | 90.0% | rise with reality | 90.95% |
| `src/yaya/kernel/` | 93.5% | 95% | 94.46% |
| `src/yaya/core/` | 90.0% | 90% | 92.26% |
| `src/yaya/cli/` | 85.0% | 85% | 93.98% |
| `src/yaya/plugins/agent_tool/` | 95.0% | 85% | 99.28% |
| `src/yaya/plugins/llm_echo/` | 95.0% | 85% | 100% |
| `src/yaya/plugins/llm_openai/` | 79.5% | 85% | 80.16% |
| `src/yaya/plugins/mcp_bridge/` | 90.0% | 85% | 92.78% |
| `src/yaya/plugins/memory_sqlite/` | 89.5% | 85% | 90.08% |
| `src/yaya/plugins/strategy_react/` | 95.0% | 85% | 97.30% |
| `src/yaya/plugins/tool_bash/` | 95.0% | 85% | 98.11% |
| `src/yaya/plugins/web/` | 84.0% | 85% | 84.86% |

Kernel, `llm_openai`, and `web` are below their aspirational targets,
so their gates sit at `floor(reality - 0.5)` per the ratchet policy.
Follow-up issues raise coverage first, then the gate. Every other
prefix meets or exceeds the issue's proposal.

## Ratchet policy (docs/dev/testing.md)

1. After any merge that raises a prefix's coverage above `gate + 0.5`,
   bump its gate (and `fail_under` for the global) to
   `floor(actual - 0.5)` rounded to the nearest 0.5.
2. Gates never retreat. Lowering requires a `governance` issue.
3. Never set a gate you cannot meet today — lift coverage first.
4. `check_coverage.py` prints a `ratchet ->` column naming the next
   available bump; watch for it in PR logs.

## Test plan

- [x] `just check` green locally.
- [x] `just test` green locally; coverage gate script prints summary + exits 0.
- [x] `tests/scripts/test_check_coverage.py` covers pass / kernel regression
      / plugin regression / missing file / empty prefix / CLI entry / summary
      output (7 tests).
- [ ] CI (ubuntu + macos + windows) green.

Closes #43

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)