### PR TITLE
feat(plugins/web): http api for live config, plugins, and llm providers (#107)

### DIFF
--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -805,6 +805,74 @@ with a conversation FIFO):
   outside it. At 0.2 this is observational only; hard kernel-side
   enforcement is future work.
 
+## Web HTTP API
+
+The bundled `web` adapter plugin exposes an HTTP admin surface on
+top of the kernel's `ConfigStore` and `PluginRegistry`. The API is
+the browser UI's control plane. It is **unauthenticated** — `yaya
+serve` binds `127.0.0.1` only through 1.0, so local-only is the
+sole authorization. Operators fronting yaya with a reverse proxy
+accept the risk.
+
+All routes live under `/api/`. JSON in, JSON out. `text/plain` error
+responses carry a `detail` field per FastAPI's default shape.
+
+### Config endpoints
+
+| Method | Path | Body | Response |
+|---|---|---|---|
+| `GET` | `/api/config` | — | `{<key>: <value-or-mask>, ...}` |
+| `GET` | `/api/config/{key}` | — | `{"key": str, "value": any}` (masked unless `?show=1`) |
+| `PATCH` | `/api/config/{key}` | `{"value": any}` | `{"key": str, "ok": true}` |
+| `DELETE` | `/api/config/{key}` | — | `{"key": str, "removed": bool}` |
+
+Masking rule (mirrors `yaya config list`): keys whose last dotted
+segment is one of `api_key`, `token`, `secret`, `password` collapse
+to `****<last4>` (strings) or `****` (non-strings / ≤4-char values).
+`?show=1` on `GET /api/config/{key}` bypasses the mask for a
+deliberate single-key read.
+
+### Plugin endpoints
+
+| Method | Path | Body | Response |
+|---|---|---|---|
+| `GET` | `/api/plugins` | — | `{"plugins": [{name, category, status, version, enabled, config_schema, current_config}, ...]}` |
+| `PATCH` | `/api/plugins/{name}` | `{"enabled": bool}` | `{"name": str, "enabled": bool, "reload_required": true}` |
+| `POST` | `/api/plugins/install` | `{"source": str, "editable": bool}` | `{"source": str, "ok": true}` |
+| `DELETE` | `/api/plugins/{name}` | — | `{"name": str, "removed": true}` |
+
+`config_schema` is the plugin's pydantic `ConfigModel` JSON Schema
+(or `null` when the plugin does not declare one). `current_config`
+is a nested dict of the plugin's `plugin.<ns>.*` keys from
+ConfigStore. `enabled` reads `plugin.<ns>.enabled` (default `true`)
+and takes effect on the next kernel reload — the admin API does NOT
+mutate a running plugin's subscription set.
+
+Install forwards the `source` string through
+`yaya.kernel.registry.validate_install_source` before calling
+`registry.install`. Disallowed characters / schemes → 400; pip
+failures → 500. Removing a bundled plugin → 400 (registry raises
+`ValueError`).
+
+### LLM-provider endpoints
+
+| Method | Path | Body | Response |
+|---|---|---|---|
+| `GET` | `/api/llm-providers` | — | `{"providers": [{name, version, active, config_schema, current_config}, ...]}` |
+| `PATCH` | `/api/llm-providers/active` | `{"name": str}` | `{"active": str, "ok": true}` |
+| `POST` | `/api/llm-providers/{name}/test` | — | `{"ok": bool, "latency_ms": int, "error"?: str}` |
+
+`active` is derived from config key `provider`; the PATCH endpoint
+writes that key and the running strategy picks it up on the next
+turn. The target must be a loaded `llm-provider` plugin; category
+mismatch → 400, unknown plugin → 404.
+
+`POST /api/llm-providers/{name}/test` fires one `llm.call.request`
+with a trivial prompt and a fresh session id, subscribes to both
+`llm.call.response` and `llm.call.error`, and waits up to 5 s. The
+response carries `ok`, `latency_ms`, and (on failure) the provider's
+error string — `"timeout"` when no reply arrived.
+
 ## Security posture (1.0)
 
 - Plugins run in-process as trusted code. There is no sandbox in 1.0.

--- a/docs/dev/web-ui.md
+++ b/docs/dev/web-ui.md
@@ -165,6 +165,15 @@ shape of the build. PR authors should still rebuild locally and
 commit the result; reviewers can eyeball bundle sizes for
 regressions from the build step's `stdout`.
 
+## HTTP admin API
+
+The adapter mounts an HTTP admin API under `/api/` for the browser
+UI's control plane (config, plugin, and LLM-provider management).
+Full endpoint reference + request / response schemas live in
+[`plugin-protocol.md § Web HTTP API`](plugin-protocol.md#web-http-api).
+The API is **unauthenticated** — 127.0.0.1-only binding is the
+sole authorization through 1.0.
+
 ## WebSocket schema
 
 The WS schema is a thin serialization of the public event set. The

--- a/specs/plugin-web-config-api.spec
+++ b/specs/plugin-web-config-api.spec
@@ -1,0 +1,175 @@
+spec: task
+name: "plugin-web-config-api"
+tags: [plugin, adapter, web, api, config]
+---
+
+## Intent
+
+The bundled `web` adapter gains an HTTP admin API on top of the
+kernel's live `ConfigStore` and `PluginRegistry` so the browser UI
+can drive config edits, plugin enable / install / remove, and LLM-
+provider selection without a kernel restart. The API is the browser
+UI's control plane; the UI (PR C in the current stack) binds form
+widgets to these endpoints. The API is unauthenticated — `yaya
+serve` binds `127.0.0.1` only through 1.0, so local-only is the sole
+authorization.
+
+## Decisions
+
+- **Router factored into `api.py`.** `build_admin_router(registry,
+  config_store, bus)` returns a `fastapi.APIRouter` the adapter
+  mounts inside `_build_app`. Tests exercise the router directly
+  without standing up uvicorn.
+- **Kernel-side escape hatch.** `KernelContext` grows `.registry`
+  and `.config_store` properties (same pattern as `.bus` and
+  `.session`). The admin router reads these from `self._ctx` at
+  `_build_app` time. When either is `None` — tests wiring the ASGI
+  app without a live registry — the affected endpoints return 503,
+  and the pre-API cached `/api/plugins` fallback is registered
+  first so legacy tests keep passing.
+- **Secret masking by suffix.** Keys whose last dotted segment is
+  one of `api_key`, `token`, `secret`, `password` mask to
+  `****<last4>` (strings) or `****` (non-strings / short strings).
+  `GET /api/config` masks; `GET /api/config/{key}` masks; `?show=1`
+  reveals. The mask set mirrors `yaya config list` (the CLI and the
+  API must redact the same things).
+- **Plugin `enabled` is reload-gated.** `PATCH /api/plugins/<name>`
+  writes `plugin.<ns>.enabled` through ConfigStore and returns
+  `{reload_required: true}`. No kernel-level runtime enable/disable
+  primitive — that is a larger refactor. The UI surfaces the flag.
+- **Install validation.** `POST /api/plugins/install` forwards the
+  source string through the registry's existing
+  `validate_install_source` before calling `registry.install`.
+  Disallowed characters / schemes surface as 400 so the API does
+  not leak pip errors.
+- **LLM-provider switch.** `PATCH /api/llm-providers/active` writes
+  config key `provider`. `strategy_react` reads `provider` at each
+  turn, so the switch takes effect on the next `llm.call.request`
+  without a reload. The target must be a loaded `llm-provider`
+  plugin; mismatch → 400, unknown plugin → 404.
+- **`/test` round-trip.** `POST /api/llm-providers/<name>/test`
+  publishes one `llm.call.request` with a fresh session id and a
+  trivial prompt (`say OK`), subscribes to both
+  `llm.call.response` and `llm.call.error`, and waits up to 5 s.
+  Returns `{ok, latency_ms, error?}`. The endpoint is reused by
+  the UI's "test connection" button.
+- **127.0.0.1-only binding unchanged.** The adapter still hard-codes
+  `_BIND_HOST = "127.0.0.1"`; adding admin endpoints does not change
+  the bind posture. The unauthenticated surface is documented in
+  `src/yaya/plugins/web/AGENT.md`.
+- **PR #105 follow-up polish (same PR).** Drops `await
+  existing.close()` in `llm_openai` rebuild (F1: preserves
+  in-flight `chat.completions.create`); extracts `_scoped_keys`
+  helper on `ConfigView` (S1); upgrades the silent
+  `TypeError` skip during TOML migration to a `WARN` log (S2).
+
+## Boundaries
+
+### Allowed Changes
+- src/yaya/plugins/web/api.py
+- src/yaya/plugins/web/plugin.py
+- src/yaya/plugins/web/AGENT.md
+- src/yaya/kernel/plugin.py
+- src/yaya/kernel/registry.py
+- src/yaya/kernel/config_store.py
+- src/yaya/plugins/llm_openai/plugin.py
+- tests/plugins/web/test_web_config_api.py
+- tests/plugins/llm_openai/test_llm_openai.py
+- specs/plugin-web-config-api.spec
+- tests/bdd/features/plugin-web-config-api.feature
+- docs/dev/plugin-protocol.md
+- docs/dev/web-ui.md
+
+### Forbidden
+- src/yaya/cli/
+- src/yaya/core/
+- src/yaya/plugins/strategy_react/
+- src/yaya/plugins/memory_sqlite/
+- src/yaya/plugins/tool_bash/
+- GOAL.md
+
+## Completion Criteria
+
+Scenario: Config CRUD round-trips through the API
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_config_crud_cycle
+  Level: integration
+  Given an admin router wired to a live config store
+  When a client issues a PATCH then GET then DELETE for a config key
+  Then each response reflects the new state and the final GET returns 404
+
+Scenario: Secret-suffix keys mask unless show flag is set
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_config_secret_masking_honours_show_flag
+  Level: integration
+  Given an admin router wired to a live config store containing a secret key
+  When a client reads the key with and without the show flag
+  Then the default response is masked and the show flag reveals the value
+
+Scenario: Plugin list exposes enabled flag and current config
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_plugins_list_exposes_metadata
+  Level: integration
+  Given an admin router wired to a stub registry and a live store
+  When a client issues GET api plugins
+  Then the response includes enabled status schema and current_config per plugin
+
+Scenario: Patching enabled writes the plugin enabled config key
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_plugin_patch_writes_enabled_flag
+  Level: integration
+  Given an admin router wired to a stub registry and a live store
+  When a client PATCHes api plugins with enabled false
+  Then the store records plugin ns enabled false and the response signals reload_required
+
+Scenario: Plugin install delegates to the registry
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_plugin_install_delegates_to_registry
+  Level: integration
+  Given an admin router wired to a stub registry
+  When a client POSTs api plugins install with a valid source
+  Then the stub registry records the install call and the response is ok
+
+Scenario: Switching the active LLM provider writes the provider config key
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_llm_provider_active_switch
+  Level: integration
+  Given an admin router wired to a stub registry with two LLM provider plugins
+  When a client PATCHes api llm providers active with one provider name
+  Then the store records provider equal to that name and the response is ok
+
+Scenario: LLM provider test endpoint round-trips through the bus
+  Test:
+    Package: yaya
+    Filter: tests/plugins/web/test_web_config_api.py::test_llm_provider_test_roundtrip
+  Level: integration
+  Given an admin router wired to a bus where a stub provider echoes llm call response
+  When a client POSTs api llm providers name test
+  Then the response carries ok true and a non negative latency_ms
+
+Scenario: llm_openai hot reload preserves in flight calls
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_openai/test_llm_openai.py::test_llm_openai_hot_reload_preserves_in_flight_call
+  Level: integration
+  Given a running llm openai plugin with a live client
+  When a config updated event triggers a client rebuild
+  Then the previous client is never closed and a fresh client is built
+
+## Out of Scope
+
+- Authentication, authorization, and public-bind support — GOAL.md
+  non-goals through 1.0.
+- Rate limiting — future PR; the local-only bind bounds the blast
+  radius today.
+- Runtime plugin enable / disable without reload — larger refactor
+  of the bus's subscription gating layer.
+- Plugin config editing at arbitrary dotted paths beyond the flat
+  `plugin.<ns>.*` namespace — the UI reads the JSON Schema and
+  writes keys as-is; nested sub-tree editing is left to the UI.

--- a/src/yaya/kernel/config_store.py
+++ b/src/yaya/kernel/config_store.py
@@ -34,6 +34,7 @@ import asyncio
 import concurrent.futures
 import functools
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -77,6 +78,8 @@ _KERNEL_SESSION = "kernel"
 """Routing key for ``config.updated`` events (lesson #2)."""
 
 _CONFIG_SOURCE = "kernel-config-store"
+
+_logger = logging.getLogger(__name__)
 
 
 def default_config_db_path() -> Path:
@@ -170,23 +173,30 @@ class ConfigView(Mapping[str, Any]):
     def _full_key(self, key: str) -> str:
         return f"{self._prefix}{key}" if self._prefix else key
 
+    def _scoped_keys(self) -> list[str]:
+        """Snapshot cache keys, stripping ``self._prefix`` for scoped views.
+
+        Centralises the prefix filter + strip so ``__iter__`` /
+        ``__len__`` stay in lock-step; a fix in one is a fix in both.
+        Snapshots the key list so iteration does not observe a
+        concurrent :meth:`ConfigStore.set` mid-traversal.
+        """
+        if not self._prefix:
+            return list(self._cache.keys())
+        plen = len(self._prefix)
+        return [k[plen:] for k in list(self._cache.keys()) if k.startswith(self._prefix)]
+
     @override
     def __getitem__(self, key: str) -> Any:
         return self._cache[self._full_key(key)]
 
     @override
     def __iter__(self) -> Iterator[str]:
-        # Snapshot keys so iteration does not observe concurrent set()
-        # mid-iteration (the store's writes mutate the dict in place).
-        if not self._prefix:
-            return iter(list(self._cache.keys()))
-        return iter([k[len(self._prefix) :] for k in list(self._cache.keys()) if k.startswith(self._prefix)])
+        return iter(self._scoped_keys())
 
     @override
     def __len__(self) -> int:
-        if not self._prefix:
-            return len(self._cache)
-        return sum(1 for k in self._cache if k.startswith(self._prefix))
+        return len(self._scoped_keys())
 
     @override
     def __contains__(self, key: object) -> bool:
@@ -398,10 +408,18 @@ class ConfigStore:
                 continue
             try:
                 _validate_json_value(value)
-            except TypeError:
-                # Skip non-JSON entries silently; they were unreachable
-                # via the old config anyway (KernelConfig fields are
-                # already JSON-safe).
+            except TypeError as exc:
+                # Skip non-JSON entries but make the skip observable:
+                # silent drops hide bugs in the flattener (#106, S2).
+                # ``KernelConfig`` fields are already JSON-safe, so a
+                # skip here points at a future migration source that
+                # widened the type set.
+                _logger.warning(
+                    "config migration: skipping non-JSON key %r (%s): %s",
+                    key,
+                    type(value).__name__,
+                    exc,
+                )
                 continue
             encoded = json.dumps(value, ensure_ascii=False, sort_keys=True)
             now = int(time.time())

--- a/src/yaya/kernel/plugin.py
+++ b/src/yaya/kernel/plugin.py
@@ -17,6 +17,8 @@ from yaya.kernel.events import Event, new_event
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import, breaks an import cycle.
     from yaya.kernel.bus import EventBus
+    from yaya.kernel.config_store import ConfigStore
+    from yaya.kernel.registry import PluginRegistry
     from yaya.kernel.session import Session
 
 
@@ -100,6 +102,8 @@ class KernelContext:
         state_dir: Path,
         plugin_name: str,
         session: Session | None = None,
+        registry: PluginRegistry | None = None,
+        config_store: ConfigStore | None = None,
     ) -> None:
         """Bind the context to a specific plugin.
 
@@ -121,6 +125,8 @@ class KernelContext:
         self._state_dir = state_dir
         self._plugin_name = plugin_name
         self._session = session
+        self._registry = registry
+        self._config_store = config_store
 
     @property
     def bus(self) -> EventBus:
@@ -175,6 +181,37 @@ class KernelContext:
         handle that gracefully.
         """
         return self._session
+
+    @property
+    def registry(self) -> PluginRegistry | None:
+        """The owning :class:`~yaya.kernel.registry.PluginRegistry`, if any.
+
+        Kernel-side escape hatch used by the bundled ``web`` adapter
+        to expose ``install`` / ``remove`` / ``loaded_plugins`` over
+        the local HTTP API. Third-party plugins SHOULD NOT rely on
+        this surface — cross-plugin orchestration is expected to go
+        through the bus, and a future hardening pass may gate this
+        behind an explicit capability flag.
+
+        Returns ``None`` when the context was built outside a running
+        registry (tests, ``yaya plugin list`` transient stack).
+        """
+        return self._registry
+
+    @property
+    def config_store(self) -> ConfigStore | None:
+        """The live :class:`~yaya.kernel.config_store.ConfigStore`, if any.
+
+        Same escape-hatch caveat as :attr:`registry`: the bundled
+        ``web`` adapter consults this surface to implement
+        ``GET/PATCH/DELETE /api/config``. Normal plugin config reads
+        still go through :attr:`config`, which already reflects live
+        cache updates.
+
+        Returns ``None`` when the registry was started without a
+        store (tests injecting a ``KernelConfig`` directly).
+        """
+        return self._config_store
 
     async def emit(
         self,

--- a/src/yaya/kernel/registry.py
+++ b/src/yaya/kernel/registry.py
@@ -663,6 +663,8 @@ class PluginRegistry:
             state_dir=plugin_state,
             plugin_name=plugin.name,
             session=self._session,
+            registry=self,
+            config_store=self._config_store,
         )
 
     # -- failure accounting -----------------------------------------------------

--- a/src/yaya/plugins/llm_openai/plugin.py
+++ b/src/yaya/plugins/llm_openai/plugin.py
@@ -141,15 +141,15 @@ class OpenAIProvider:
             cfg_base_url if isinstance(cfg_base_url, str) and cfg_base_url else os.environ.get("OPENAI_BASE_URL")
         )
 
-        # Tear down any live client before swapping so an old pool does
-        # not outlive the config it was built from.
-        existing, self._client = self._client, None
+        # Swap the client without closing the old pool: a previous
+        # client may still be servicing an in-flight ``_dispatch`` call
+        # when a ``config.updated`` event preempts it via ``await``.
+        # Closing the pool here would surface a spurious
+        # ``llm.call.error`` on that in-flight turn (PR #105 follow-up
+        # #106, F1). ``AsyncOpenAI`` reclaims its ``httpx`` pool on GC
+        # and the leak is bounded by rotations-per-process.
+        self._client = None
         self._configured = False
-        if existing is not None:
-            try:
-                await existing.close()
-            except Exception as exc:
-                ctx.logger.warning("llm-openai: stale client close failed: %s", exc)
 
         if not api_key:
             ctx.logger.warning("llm-openai: OPENAI_API_KEY not set; calls will error")

--- a/src/yaya/plugins/web/AGENT.md
+++ b/src/yaya/plugins/web/AGENT.md
@@ -14,6 +14,13 @@ Bundled `web` adapter plugin. Loads through `yaya.plugins.v1` like any third-par
 - Subscribes to: `assistant.message.delta`, `assistant.message.done`, `tool.call.start`, `tool.call.result`, `plugin.loaded`, `plugin.removed`, `plugin.error`, `kernel.ready`, `kernel.shutdown`, `kernel.error`.
 - Emits: `user.message.received`, `user.interrupt`.
 - Session model: each WS connection gets `session_id = ws-<uuid4[:8]>` at `accept()`. The same id flows into every `user.message.received` the adapter publishes; `loop.py` propagates it through every downstream event; `_deliver()` routes by `ev.session_id` lookup in `_clients: dict[str, set[WebSocket]]`. Unmatched session ids broadcast (kernel-origin events use `session_id="kernel"`).
+- HTTP admin API (factored into `api.py`, mounted inside `_build_app`):
+  - `GET /api/health` — liveness probe.
+  - `GET /api/config`, `GET/PATCH/DELETE /api/config/{key}` — live `ConfigStore` CRUD. Secret-suffix keys (`api_key`, `token`, `secret`, `password`) mask by default; `?show=1` reveals on a single-key read.
+  - `GET /api/plugins` — name, category, status, version, `enabled`, `config_schema`, `current_config`. `PATCH /api/plugins/{name}` toggles `enabled` (reload-gated). `POST /api/plugins/install` + `DELETE /api/plugins/{name}` wrap `registry.install` / `registry.remove`.
+  - `GET /api/llm-providers` — loaded llm-provider plugins with an `active` flag derived from config key `provider`. `PATCH /api/llm-providers/active` writes that key. `POST /api/llm-providers/{name}/test` fires a one-shot `llm.call.request` for UI "test connection".
+  - **Unauthenticated, local-only.** `127.0.0.1` bind is the only authorization through 1.0 (GOAL.md non-goal). Operators fronting yaya with a reverse proxy accept the risk.
+  - Kernel-side escape hatches: `ctx.registry` + `ctx.config_store` (mirrors `ctx.bus` / `ctx.session`). Third-party plugins SHOULD NOT rely on these — they exist for the bundled admin UI.
 - Self-clean on disconnect (lesson #6): `discard(ws)` then `del self._clients[sid]` if empty.
 - Static assets ship in the wheel via `importlib.resources.files("yaya.plugins.web") / "static"` — never `__file__` relative paths.
 - `uvicorn.Server.should_exit = True` + `await asyncio.wait_for(task, 3.0)` on `on_unload`; cancel on timeout.

--- a/src/yaya/plugins/web/api.py
+++ b/src/yaya/plugins/web/api.py
@@ -80,17 +80,32 @@ def is_secret_key(key: str) -> bool:
     return last in SECRET_SUFFIXES
 
 
-def mask_value(value: Any) -> str:
-    """Render a secret value as ``****<last4>`` or ``****``.
+def mask_value(value: Any) -> Any:
+    """Render a secret value, preserving container structure.
 
-    Only strings get the last-4-chars reveal; non-strings always
-    collapse to ``****`` so no structure leaks through.
+    Leaf strings collapse to ``****<last4>`` (or ``****`` when shorter
+    than five chars). Dicts and lists are walked recursively so the
+    UI can render a nested config value (e.g. ``{primary: ...,
+    fallback: ...}``) with each leaf masked independently. Non-string,
+    non-container scalars collapse to ``****`` so their type does not
+    leak.
     """
-    if not isinstance(value, str):
-        return "****"
-    if len(value) <= 4:
-        return "****"
-    return f"****{value[-4:]}"
+    if isinstance(value, str):
+        if len(value) <= 4:
+            return "****"
+        return f"****{value[-4:]}"
+    if isinstance(value, dict):
+        walked = cast("dict[str, Any]", value)
+        return {k: mask_value(v) for k, v in walked.items()}
+    if isinstance(value, list):
+        # mypy infers ``list[Any]`` after the isinstance narrow, so the
+        # cast would be redundant; pyright needs the explicit annotation
+        # to drop the partially-unknown-list warning. A bare
+        # ``list[Any]`` local satisfies both — the ignore pins the
+        # single cross-checker skew on this one line.
+        items: list[Any] = value  # pyright: ignore[reportUnknownVariableType]
+        return [mask_value(v) for v in items]
+    return "****"
 
 
 class _ConfigPatchBody(BaseModel):
@@ -255,7 +270,10 @@ def _register_config_routes(
             await store.set(key, body.value)
         except (TypeError, ValueError) as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return JSONResponse({"key": key, "ok": True})
+        # Echo ``{key, value}`` per the TypeScript client contract in
+        # ``src/yaya/plugins/web/src/api.ts``. ``ok`` is kept for
+        # pre-existing clients; the new field is ``value``.
+        return JSONResponse({"key": key, "value": body.value, "ok": True})
 
     @router.delete("/api/config/{key:path}")
     async def _config_delete(key: str) -> JSONResponse:
@@ -265,16 +283,43 @@ def _register_config_routes(
         return JSONResponse({"key": key, "removed": bool(removed)})
 
 
+async def _read_enabled_by_name(name: str, store: ConfigStore | None) -> bool:
+    """Read ``plugin.<ns>.enabled`` by name, defaulting to ``True``.
+
+    Variant of :func:`_plugin_enabled` that does not require a live
+    Plugin object — used on the unloaded branch of
+    :func:`_build_plugin_row` so failed-load plugins do not show as
+    ``enabled=True`` when the config says otherwise.
+    """
+    if store is None:
+        return True
+    ns = name.replace("-", "_")
+    raw = await store.get(f"plugin.{ns}.enabled", True)
+    return bool(raw)
+
+
 async def _build_plugin_row(
     row: dict[str, str],
     by_name: dict[str, Plugin],
     config_store: ConfigStore | None,
 ) -> dict[str, Any]:
-    """Assemble one ``/api/plugins`` row with live metadata."""
+    """Assemble one ``/api/plugins`` row with live metadata.
+
+    ``reload_required`` defaults to ``False`` — it is the row's
+    pristine state. :func:`_mark_reload_required` flips it to ``True``
+    on the row returned by ``PATCH /api/plugins/<name>`` so the UI can
+    surface a "reload to apply" hint without a separate round trip.
+    """
     name = row["name"]
     plugin = by_name.get(name)
     if plugin is None:
-        return {**row, "enabled": True, "config_schema": None, "current_config": {}}
+        return {
+            **row,
+            "enabled": await _read_enabled_by_name(name, config_store),
+            "config_schema": None,
+            "current_config": {},
+            "reload_required": False,
+        }
     return {
         "name": name,
         "category": row["category"],
@@ -283,7 +328,42 @@ async def _build_plugin_row(
         "enabled": await _plugin_enabled(plugin, config_store),
         "config_schema": _plugin_config_schema(plugin),
         "current_config": _plugin_current_config(plugin, config_store),
+        "reload_required": False,
     }
+
+
+async def _apply_plugin_patch(
+    reg: PluginRegistry,
+    store: ConfigStore,
+    name: str,
+    enabled: bool,
+) -> JSONResponse:
+    """Persist the enabled flip and return the refreshed row.
+
+    Extracted from the ``PATCH /api/plugins/{name}`` handler to keep
+    the route body under the cyclomatic-complexity budget.
+    """
+    by_name: dict[str, Plugin] = {p.name: p for p in reg.loaded_plugins()}
+    snap_row = next((r for r in reg.snapshot() if r["name"] == name), None)
+    if name not in by_name and snap_row is None:
+        raise HTTPException(status_code=404, detail=f"plugin not found: {name}")
+    ns = name.replace("-", "_")
+    await store.set(f"plugin.{ns}.enabled", enabled)
+    if snap_row is None:
+        # Defensive — snap_row is None only when the plugin is loaded
+        # but not in the snapshot, which the registry invariants
+        # prevent. Synthesize the minimal row so the response shape
+        # stays consistent.
+        loaded = by_name[name]
+        snap_row = {
+            "name": loaded.name,
+            "version": loaded.version,
+            "category": loaded.category.value,
+            "status": "loaded",
+        }
+    refreshed = await _build_plugin_row(snap_row, by_name, store)
+    refreshed["reload_required"] = True
+    return JSONResponse(refreshed)
 
 
 def _register_plugin_routes(
@@ -303,23 +383,28 @@ def _register_plugin_routes(
 
     @router.patch("/api/plugins/{name}")
     async def _plugins_patch(name: str, body: _PluginPatchBody) -> JSONResponse:
-        """Toggle a plugin's ``enabled`` flag; reload required to take effect."""
+        """Toggle a plugin's ``enabled`` flag and return the refreshed row.
+
+        ``reload_required=True`` on the returned row is a UI hint —
+        ephemeral per-process state, NOT persisted to the config
+        store. The kernel must be reloaded for the enabled flip to
+        take effect.
+        """
         reg = cast("PluginRegistry", _require(registry, "plugin registry"))
         store = cast("ConfigStore", _require(config_store, "config store"))
-        loaded_names = {p.name for p in reg.loaded_plugins()}
-        if name not in loaded_names and not any(r["name"] == name for r in reg.snapshot()):
-            raise HTTPException(status_code=404, detail=f"plugin not found: {name}")
-        ns = name.replace("-", "_")
-        await store.set(f"plugin.{ns}.enabled", body.enabled)
-        return JSONResponse({
-            "name": name,
-            "enabled": body.enabled,
-            "reload_required": True,
-        })
+        return await _apply_plugin_patch(reg, store, name, body.enabled)
 
     @router.post("/api/plugins/install")
     async def _plugins_install(body: _PluginInstallBody) -> JSONResponse:
-        """Install a plugin package via the registry's install path."""
+        """Install a plugin package via the registry's install path.
+
+        The install is **synchronous** today — the handler blocks until
+        ``registry.install`` returns. The ``job_id`` in the response is
+        a correlation id the UI can pin to a progress row; when a
+        future PR moves installs to a background queue the same field
+        will carry a pollable job handle and the response will become
+        ``202 Accepted`` instead of ``200``.
+        """
         reg = cast("PluginRegistry", _require(registry, "plugin registry"))
         _validate_install_source_guard(body.source)
         try:
@@ -328,7 +413,11 @@ def _register_plugin_routes(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
-        return JSONResponse({"source": body.source, "ok": True})
+        return JSONResponse({
+            "job_id": str(uuid.uuid4()),
+            "source": body.source,
+            "ok": True,
+        })
 
     @router.delete("/api/plugins/{name}")
     async def _plugins_delete(name: str) -> JSONResponse:
@@ -343,6 +432,35 @@ def _register_plugin_routes(
         return JSONResponse({"name": name, "removed": True})
 
 
+async def _collect_provider_rows(
+    registry: PluginRegistry,
+    config_store: ConfigStore | None,
+) -> list[dict[str, Any]]:
+    """Build the list of LLM-provider rows served by the API.
+
+    Extracted from the ``GET /api/llm-providers`` handler so the
+    ``PATCH /api/llm-providers/active`` handler can return the
+    refreshed list in the same round trip — the UI atomically
+    re-renders from one response body.
+    """
+    providers = registry.loaded_plugins(Category.LLM_PROVIDER)
+    active_name: str | None = None
+    if config_store is not None:
+        raw = await config_store.get(_PROVIDER_CONFIG_KEY)
+        if isinstance(raw, str) and raw:
+            active_name = raw
+    return [
+        {
+            "name": plugin.name,
+            "version": plugin.version,
+            "active": plugin.name == active_name,
+            "config_schema": _plugin_config_schema(plugin),
+            "current_config": _plugin_current_config(plugin, config_store),
+        }
+        for plugin in providers
+    ]
+
+
 def _register_provider_routes(
     router: APIRouter,
     registry: PluginRegistry | None,
@@ -353,41 +471,42 @@ def _register_provider_routes(
 
     @router.get("/api/llm-providers")
     async def _providers_list() -> JSONResponse:
-        """List every loaded LLM-provider plugin with the active flag."""
+        """List every loaded LLM-provider plugin with the active flag.
+
+        Returns a bare JSON array (``LlmProviderRow[]``) to match the
+        TypeScript client contract in
+        ``src/yaya/plugins/web/src/api.ts``.
+        """
         reg = cast("PluginRegistry", _require(registry, "plugin registry"))
-        providers = reg.loaded_plugins(Category.LLM_PROVIDER)
-        active_name: str | None = None
-        if config_store is not None:
-            raw = await config_store.get(_PROVIDER_CONFIG_KEY)
-            if isinstance(raw, str) and raw:
-                active_name = raw
-        rows = [
-            {
-                "name": plugin.name,
-                "version": plugin.version,
-                "active": plugin.name == active_name,
-                "config_schema": _plugin_config_schema(plugin),
-                "current_config": _plugin_current_config(plugin, config_store),
-            }
-            for plugin in providers
-        ]
-        return JSONResponse({"providers": rows})
+        rows = await _collect_provider_rows(reg, config_store)
+        return JSONResponse(rows)
 
     @router.patch("/api/llm-providers/active")
     async def _providers_set_active(body: _ProviderActiveBody) -> JSONResponse:
-        """Switch the active provider by writing the ``provider`` config key."""
+        """Switch the active provider and return the refreshed list.
+
+        Validation uses :meth:`loaded_plugins` (not ``snapshot``) so
+        only currently-loaded providers are selectable — a plugin that
+        is installed but failed to load cannot be made active.
+        """
         reg = cast("PluginRegistry", _require(registry, "plugin registry"))
         store = cast("ConfigStore", _require(config_store, "config store"))
-        match = next((r for r in reg.snapshot() if r["name"] == body.name), None)
-        if match is None:
-            raise HTTPException(status_code=404, detail=f"plugin not found: {body.name}")
-        if match["category"] != Category.LLM_PROVIDER.value:
+        loaded_providers = reg.loaded_plugins(Category.LLM_PROVIDER)
+        loaded_provider_names = {p.name for p in loaded_providers}
+        if body.name not in loaded_provider_names:
+            # Distinguish "not a provider (present elsewhere in the
+            # snapshot)" from "unknown plugin" so the UI can render a
+            # useful error.
+            snap_match = next((r for r in reg.snapshot() if r["name"] == body.name), None)
+            if snap_match is None:
+                raise HTTPException(status_code=404, detail=f"plugin not found: {body.name}")
             raise HTTPException(
                 status_code=400,
-                detail=f"{body.name!r} is not an llm-provider plugin",
+                detail=f"{body.name!r} is not a loaded llm-provider plugin",
             )
         await store.set(_PROVIDER_CONFIG_KEY, body.name)
-        return JSONResponse({"active": body.name, "ok": True})
+        rows = await _collect_provider_rows(reg, store)
+        return JSONResponse(rows)
 
     @router.post("/api/llm-providers/{name}/test")
     async def _providers_test(name: str) -> JSONResponse:

--- a/src/yaya/plugins/web/api.py
+++ b/src/yaya/plugins/web/api.py
@@ -1,0 +1,474 @@
+"""HTTP admin API for the bundled web adapter.
+
+Adds REST endpoints on top of the kernel's live
+:class:`~yaya.kernel.config_store.ConfigStore` and
+:class:`~yaya.kernel.registry.PluginRegistry` so the browser UI can
+drive config edits, plugin enable / install / remove, and LLM-provider
+selection without a restart.
+
+Security posture: the routes are **unauthenticated**. The kernel
+binds ``127.0.0.1`` only through 1.0 (``GOAL.md`` non-goals), so the
+local-only assumption is the only authorization. Operators running
+``yaya`` behind a reverse proxy accept the risk of exposing these
+routes; a future PR layers a capability token when public bind lands.
+
+Layering: imports only :mod:`yaya.kernel` plus stdlib + ``fastapi`` /
+``pydantic``. No reaching into ``yaya.cli`` or ``yaya.core``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, cast
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, ValidationError
+
+from yaya.kernel.events import Event, new_event
+from yaya.kernel.plugin import Category
+
+if TYPE_CHECKING:  # pragma: no cover - type-only imports, avoid cycles.
+    from yaya.kernel.bus import EventBus
+    from yaya.kernel.config_store import ConfigStore
+    from yaya.kernel.plugin import Plugin
+    from yaya.kernel.registry import PluginRegistry
+
+__all__ = [
+    "SECRET_SUFFIXES",
+    "build_admin_router",
+    "is_secret_key",
+    "mask_value",
+]
+
+SECRET_SUFFIXES: tuple[str, ...] = ("api_key", "token", "secret", "password")
+"""Dotted-suffix tokens that mark a config key as secret-bearing.
+
+Mirrors :mod:`yaya.cli.commands.config` so the CLI ``config list``
+output and the HTTP ``/api/config`` response redact the same set of
+keys. A single source would be nicer; the duplication is kept here
+to preserve the kernel-vs-plugin layering boundary (``cli/`` cannot
+import from plugin code, and plugin code cannot import from
+``cli/``).
+"""
+
+_PROVIDER_CONFIG_KEY = "provider"
+"""Config key the strategy plugin reads to pick the active LLM provider."""
+
+_TEST_PROMPT_MODEL_DEFAULT = "gpt-4o-mini"
+"""Model name used by ``POST /api/llm-providers/<name>/test``.
+
+Provider plugins that ignore ``model`` simply echo; the important
+signal is the request/response round-trip latency.
+"""
+
+_TEST_PROMPT_TIMEOUT_S: float = 5.0
+"""Upper bound the ``/test`` endpoint waits for ``llm.call.response``."""
+
+
+def is_secret_key(key: str) -> bool:
+    """Return True when ``key`` ends with a secret suffix.
+
+    Matches the last dotted segment so ``plugin.llm_openai.api_key``
+    and the bare ``api_key`` both redact; does NOT over-match keys
+    that merely contain a suffix as a substring (``apikeys_allowed``
+    stays visible).
+    """
+    last = key.rsplit(".", 1)[-1].lower()
+    return last in SECRET_SUFFIXES
+
+
+def mask_value(value: Any) -> str:
+    """Render a secret value as ``****<last4>`` or ``****``.
+
+    Only strings get the last-4-chars reveal; non-strings always
+    collapse to ``****`` so no structure leaks through.
+    """
+    if not isinstance(value, str):
+        return "****"
+    if len(value) <= 4:
+        return "****"
+    return f"****{value[-4:]}"
+
+
+class _ConfigPatchBody(BaseModel):
+    """Body shape for ``PATCH /api/config/{key}``."""
+
+    value: Any = Field(..., description="New value; JSON-encodable.")
+
+
+class _PluginPatchBody(BaseModel):
+    """Body shape for ``PATCH /api/plugins/{name}``."""
+
+    enabled: bool = Field(..., description="Target enabled state.")
+
+
+class _PluginInstallBody(BaseModel):
+    """Body shape for ``POST /api/plugins/install``."""
+
+    source: str = Field(..., min_length=1)
+    editable: bool = Field(default=False)
+
+
+class _ProviderActiveBody(BaseModel):
+    """Body shape for ``PATCH /api/llm-providers/active``."""
+
+    name: str = Field(..., min_length=1)
+
+
+def _plugin_config_schema(plugin: Plugin) -> dict[str, Any] | None:
+    """Return ``plugin.ConfigModel``'s JSON schema when declared.
+
+    Plugins opt in by exposing a class attribute ``ConfigModel`` that
+    subclasses :class:`pydantic.BaseModel`. Anything else (missing
+    attribute, non-pydantic class, malformed schema call) resolves to
+    ``None`` so a broken plugin does not taint the ``GET`` response.
+    """
+    model_cls = getattr(plugin, "ConfigModel", None)
+    if model_cls is None:
+        return None
+    schema_fn = getattr(model_cls, "model_json_schema", None)
+    if not callable(schema_fn):
+        return None
+    try:
+        schema = schema_fn()
+    except Exception:
+        return None
+    if isinstance(schema, dict):
+        return cast("dict[str, Any]", schema)
+    return None
+
+
+def _plugin_current_config(
+    plugin: Plugin,
+    store: ConfigStore | None,
+) -> dict[str, Any]:
+    """Collect the ``plugin.<ns>.*`` keys into a nested dict.
+
+    The ConfigStore stores flat dotted keys; the API returns the keys
+    with their plugin prefix stripped so the UI can render the plugin's
+    config namespace without re-parsing.
+    """
+    if store is None:
+        return {}
+    ns = plugin.name.replace("-", "_")
+    prefix = f"plugin.{ns}."
+    view = store.view(prefix)
+    return {key: view[key] for key in view}
+
+
+async def _plugin_enabled(plugin: Plugin, store: ConfigStore | None) -> bool:
+    """Read ``plugin.<ns>.enabled`` with a sensible default.
+
+    Missing keys default to ``True`` — a freshly installed plugin is
+    enabled on next reload unless the operator explicitly toggles it
+    off.
+    """
+    if store is None:
+        return True
+    ns = plugin.name.replace("-", "_")
+    raw = await store.get(f"plugin.{ns}.enabled", True)
+    return bool(raw)
+
+
+def _validate_install_source_guard(source: str) -> None:
+    """Delegate to the registry's validator but raise ``HTTPException``.
+
+    The registry raises :class:`ValueError` with a shell-safe message;
+    we surface that as ``400`` without leaking argv-level details.
+    """
+    from yaya.kernel.registry import validate_install_source
+
+    try:
+        validate_install_source(source)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def build_admin_router(
+    *,
+    registry: PluginRegistry | None,
+    config_store: ConfigStore | None,
+    bus: EventBus | None,
+) -> APIRouter:
+    """Assemble the HTTP admin router.
+
+    Factored out of the adapter's :meth:`_build_app` so tests can
+    mount the routes against a stub registry / in-memory
+    :class:`ConfigStore` without booting uvicorn.
+
+    Args:
+        registry: Live plugin registry; endpoints that need it return
+            ``503`` when ``None`` so tests and the ``yaya plugin list``
+            transient path still expose ``/api/health``.
+        config_store: Live config store; same ``503`` treatment when
+            absent.
+        bus: Event bus used by ``POST /api/llm-providers/{name}/test``
+            to fire ``llm.call.request``.
+    """
+    router = APIRouter()
+    _register_config_routes(router, config_store)
+    _register_plugin_routes(router, registry, config_store)
+    _register_provider_routes(router, registry, config_store, bus)
+    return router
+
+
+def _require(obj: Any, label: str) -> Any:
+    """Raise 503 when a dependency is missing, else return it."""
+    if obj is None:
+        raise HTTPException(status_code=503, detail=f"{label} unavailable")
+    return obj
+
+
+def _register_config_routes(
+    router: APIRouter,
+    config_store: ConfigStore | None,
+) -> None:
+    """Attach the four ``/api/config*`` endpoints to ``router``."""
+
+    @router.get("/api/config")
+    async def _config_list() -> JSONResponse:
+        """Return every config key with secret values masked."""
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        rows = await store.list_prefix("")
+        out: dict[str, Any] = {key: (mask_value(value) if is_secret_key(key) else value) for key, value in rows.items()}
+        return JSONResponse(out)
+
+    @router.get("/api/config/{key:path}")
+    async def _config_get(key: str, show: int = 0) -> JSONResponse:
+        """Return one key. ``?show=1`` bypasses masking for secrets."""
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        value = await store.get(key, default=_SENTINEL)
+        if value is _SENTINEL:
+            raise HTTPException(status_code=404, detail=f"key not found: {key}")
+        if is_secret_key(key) and not show:
+            return JSONResponse({"key": key, "value": mask_value(value)})
+        return JSONResponse({"key": key, "value": value})
+
+    @router.patch("/api/config/{key:path}")
+    async def _config_patch(key: str, body: _ConfigPatchBody) -> JSONResponse:
+        """Upsert a config key. Body: ``{value: ...}``."""
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        try:
+            await store.set(key, body.value)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return JSONResponse({"key": key, "ok": True})
+
+    @router.delete("/api/config/{key:path}")
+    async def _config_delete(key: str) -> JSONResponse:
+        """Remove a config key; idempotent."""
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        removed = await store.unset(key)
+        return JSONResponse({"key": key, "removed": bool(removed)})
+
+
+async def _build_plugin_row(
+    row: dict[str, str],
+    by_name: dict[str, Plugin],
+    config_store: ConfigStore | None,
+) -> dict[str, Any]:
+    """Assemble one ``/api/plugins`` row with live metadata."""
+    name = row["name"]
+    plugin = by_name.get(name)
+    if plugin is None:
+        return {**row, "enabled": True, "config_schema": None, "current_config": {}}
+    return {
+        "name": name,
+        "category": row["category"],
+        "status": row["status"],
+        "version": row["version"],
+        "enabled": await _plugin_enabled(plugin, config_store),
+        "config_schema": _plugin_config_schema(plugin),
+        "current_config": _plugin_current_config(plugin, config_store),
+    }
+
+
+def _register_plugin_routes(
+    router: APIRouter,
+    registry: PluginRegistry | None,
+    config_store: ConfigStore | None,
+) -> None:
+    """Attach the four ``/api/plugins*`` endpoints to ``router``."""
+
+    @router.get("/api/plugins")
+    async def _plugins_list() -> JSONResponse:
+        """List every registered plugin with live metadata."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        by_name: dict[str, Plugin] = {p.name: p for p in reg.loaded_plugins()}
+        rows = [await _build_plugin_row(row, by_name, config_store) for row in reg.snapshot()]
+        return JSONResponse({"plugins": rows})
+
+    @router.patch("/api/plugins/{name}")
+    async def _plugins_patch(name: str, body: _PluginPatchBody) -> JSONResponse:
+        """Toggle a plugin's ``enabled`` flag; reload required to take effect."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        loaded_names = {p.name for p in reg.loaded_plugins()}
+        if name not in loaded_names and not any(r["name"] == name for r in reg.snapshot()):
+            raise HTTPException(status_code=404, detail=f"plugin not found: {name}")
+        ns = name.replace("-", "_")
+        await store.set(f"plugin.{ns}.enabled", body.enabled)
+        return JSONResponse({
+            "name": name,
+            "enabled": body.enabled,
+            "reload_required": True,
+        })
+
+    @router.post("/api/plugins/install")
+    async def _plugins_install(body: _PluginInstallBody) -> JSONResponse:
+        """Install a plugin package via the registry's install path."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        _validate_install_source_guard(body.source)
+        try:
+            await reg.install(body.source, editable=body.editable)
+        except ValueError as exc:  # pragma: no cover - guard above screens these.
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return JSONResponse({"source": body.source, "ok": True})
+
+    @router.delete("/api/plugins/{name}")
+    async def _plugins_delete(name: str) -> JSONResponse:
+        """Uninstall a plugin package via the registry's remove path."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        try:
+            await reg.remove(name)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return JSONResponse({"name": name, "removed": True})
+
+
+def _register_provider_routes(
+    router: APIRouter,
+    registry: PluginRegistry | None,
+    config_store: ConfigStore | None,
+    bus: EventBus | None,
+) -> None:
+    """Attach the three ``/api/llm-providers*`` endpoints to ``router``."""
+
+    @router.get("/api/llm-providers")
+    async def _providers_list() -> JSONResponse:
+        """List every loaded LLM-provider plugin with the active flag."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        providers = reg.loaded_plugins(Category.LLM_PROVIDER)
+        active_name: str | None = None
+        if config_store is not None:
+            raw = await config_store.get(_PROVIDER_CONFIG_KEY)
+            if isinstance(raw, str) and raw:
+                active_name = raw
+        rows = [
+            {
+                "name": plugin.name,
+                "version": plugin.version,
+                "active": plugin.name == active_name,
+                "config_schema": _plugin_config_schema(plugin),
+                "current_config": _plugin_current_config(plugin, config_store),
+            }
+            for plugin in providers
+        ]
+        return JSONResponse({"providers": rows})
+
+    @router.patch("/api/llm-providers/active")
+    async def _providers_set_active(body: _ProviderActiveBody) -> JSONResponse:
+        """Switch the active provider by writing the ``provider`` config key."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        store = cast("ConfigStore", _require(config_store, "config store"))
+        match = next((r for r in reg.snapshot() if r["name"] == body.name), None)
+        if match is None:
+            raise HTTPException(status_code=404, detail=f"plugin not found: {body.name}")
+        if match["category"] != Category.LLM_PROVIDER.value:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{body.name!r} is not an llm-provider plugin",
+            )
+        await store.set(_PROVIDER_CONFIG_KEY, body.name)
+        return JSONResponse({"active": body.name, "ok": True})
+
+    @router.post("/api/llm-providers/{name}/test")
+    async def _providers_test(name: str) -> JSONResponse:
+        """Fire a one-shot prompt and return latency / error."""
+        reg = cast("PluginRegistry", _require(registry, "plugin registry"))
+        bus_obj = cast("EventBus", _require(bus, "event bus"))
+        providers = reg.loaded_plugins(Category.LLM_PROVIDER)
+        plugin = next((p for p in providers if p.name == name), None)
+        if plugin is None:
+            raise HTTPException(status_code=404, detail=f"llm-provider not found: {name}")
+        return await _run_test_prompt(plugin.name, bus_obj)
+
+
+async def _run_test_prompt(plugin_name: str, bus_obj: EventBus) -> JSONResponse:
+    """Fire one ``llm.call.request`` and wait for a reply.
+
+    The endpoint publishes ``llm.call.request`` with a fresh request
+    id, subscribes to both ``llm.call.response`` and
+    ``llm.call.error``, and waits up to :data:`_TEST_PROMPT_TIMEOUT_S`
+    seconds for a reply tagged with that request id.
+    """
+    provider_id = plugin_name[len("llm-") :] if plugin_name.startswith("llm-") else plugin_name
+    session_id = f"test-{uuid.uuid4().hex[:8]}"
+    request = new_event(
+        "llm.call.request",
+        {
+            "provider": provider_id,
+            "model": _TEST_PROMPT_MODEL_DEFAULT,
+            "messages": [{"role": "user", "content": "say OK"}],
+        },
+        session_id=session_id,
+        source="web-admin-test",
+    )
+
+    future: asyncio.Future[tuple[str, Any]] = asyncio.get_running_loop().create_future()
+
+    async def _on_response(ev: Event) -> None:
+        if future.done() or ev.payload.get("request_id") != request.id:
+            return
+        future.set_result(("ok", ev.payload))
+
+    async def _on_error(ev: Event) -> None:
+        if future.done() or ev.payload.get("request_id") != request.id:
+            return
+        future.set_result(("error", ev.payload))
+
+    sub_ok = bus_obj.subscribe("llm.call.response", _on_response, source="web-admin-test")
+    sub_err = bus_obj.subscribe("llm.call.error", _on_error, source="web-admin-test")
+    started = time.monotonic()
+    try:
+        await bus_obj.publish(request)
+        try:
+            kind, payload = await asyncio.wait_for(future, timeout=_TEST_PROMPT_TIMEOUT_S)
+        except TimeoutError:
+            latency_ms = int((time.monotonic() - started) * 1000)
+            return JSONResponse({"ok": False, "latency_ms": latency_ms, "error": "timeout"})
+    finally:
+        sub_ok.unsubscribe()
+        sub_err.unsubscribe()
+    latency_ms = int((time.monotonic() - started) * 1000)
+    if kind == "ok":
+        return JSONResponse({"ok": True, "latency_ms": latency_ms})
+    return JSONResponse({
+        "ok": False,
+        "latency_ms": latency_ms,
+        "error": str(payload.get("error", "unknown")),
+    })
+
+
+class _Sentinel:
+    """Private marker for "key missing" in ``GET /api/config/{key}``.
+
+    Using a dedicated sentinel lets the handler distinguish a stored
+    ``None`` from a missing key without re-querying the store.
+    """
+
+
+_SENTINEL = _Sentinel()
+
+
+# Explicit re-export so mypy does not complain about the unused import
+# in the TYPE_CHECKING block.
+if TYPE_CHECKING:  # pragma: no cover
+    _: ValidationError | None = None

--- a/src/yaya/plugins/web/plugin.py
+++ b/src/yaya/plugins/web/plugin.py
@@ -65,6 +65,7 @@ from fastapi.staticfiles import StaticFiles
 
 from yaya.kernel.events import Event
 from yaya.kernel.plugin import Category, KernelContext
+from yaya.plugins.web.api import build_admin_router
 
 if TYPE_CHECKING:  # pragma: no cover - type-only imports.
     import uvicorn
@@ -294,16 +295,48 @@ class WebAdapter:
 
         static_root = self._static_root()
 
-        @app.get("/api/plugins")
-        async def _plugins() -> JSONResponse:
-            """Return the adapter's cached plugin snapshot."""
-            rows = list(self._plugin_rows.values())
-            return JSONResponse({"plugins": rows})
-
         @app.get("/api/health")
         async def _health() -> JSONResponse:
             """Tiny ok-probe for test harnesses."""
             return JSONResponse({"ok": True, "adapter": _ADAPTER_ID})
+
+        # Resolve admin-side references from the kernel context.
+        # When the adapter boots without a registry (tests, transient
+        # ``yaya plugin list`` stack), admin endpoints degrade to 503
+        # and the legacy cached ``_plugin_rows`` snapshot wins at
+        # ``GET /api/plugins``.
+        ctx = self._ctx
+        registry_ref = ctx.registry if ctx is not None else None
+        store_ref = ctx.config_store if ctx is not None else None
+        bus_ref = ctx.bus if ctx is not None else None
+
+        # FastAPI matches in registration order. Register the legacy
+        # ``/api/plugins`` fallback FIRST when no registry is wired so
+        # tests that mount the ASGI app without a live registry still
+        # see the pre-API-layer behaviour. The admin router registers
+        # its own ``/api/plugins`` handler too; with a live registry
+        # it is registered first and takes precedence.
+        if registry_ref is None:
+
+            @app.get("/api/plugins")
+            async def _plugins_fallback() -> JSONResponse:
+                """Legacy cached snapshot used when no registry is wired."""
+                rows = list(self._plugin_rows.values())
+                return JSONResponse({"plugins": rows})
+
+        app.include_router(
+            build_admin_router(
+                registry=registry_ref,
+                config_store=store_ref,
+                bus=bus_ref,
+            )
+        )
+
+        @app.get("/api/plugins/snapshot")
+        async def _plugins_snapshot() -> JSONResponse:
+            """Return the adapter's cached plugin snapshot (legacy diag)."""
+            rows = list(self._plugin_rows.values())
+            return JSONResponse({"plugins": rows})
 
         @app.websocket("/ws")
         async def _ws(ws: WebSocket) -> None:

--- a/tests/bdd/features/plugin-web-config-api.feature
+++ b/tests/bdd/features/plugin-web-config-api.feature
@@ -1,0 +1,48 @@
+Feature: Web adapter HTTP admin API
+
+  The bundled web adapter exposes HTTP endpoints over the kernel's
+  live ConfigStore and PluginRegistry so the browser UI can drive
+  config, plugin, and LLM provider management without a restart.
+
+  Scenarios mirror specs/plugin-web-config-api.spec Completion
+  Criteria and are kept in sync by scripts/check_feature_sync.py.
+
+  Scenario: Config CRUD round-trips through the API
+    Given an admin router wired to a live config store
+    When a client issues a PATCH then GET then DELETE for a config key
+    Then each response reflects the new state and the final GET returns 404
+
+  Scenario: Secret-suffix keys mask unless show flag is set
+    Given an admin router wired to a live config store containing a secret key
+    When a client reads the key with and without the show flag
+    Then the default response is masked and the show flag reveals the value
+
+  Scenario: Plugin list exposes enabled flag and current config
+    Given an admin router wired to a stub registry and a live store
+    When a client issues GET api plugins
+    Then the response includes enabled status schema and current_config per plugin
+
+  Scenario: Patching enabled writes the plugin enabled config key
+    Given an admin router wired to a stub registry and a live store
+    When a client PATCHes api plugins with enabled false
+    Then the store records plugin ns enabled false and the response signals reload_required
+
+  Scenario: Plugin install delegates to the registry
+    Given an admin router wired to a stub registry
+    When a client POSTs api plugins install with a valid source
+    Then the stub registry records the install call and the response is ok
+
+  Scenario: Switching the active LLM provider writes the provider config key
+    Given an admin router wired to a stub registry with two LLM provider plugins
+    When a client PATCHes api llm providers active with one provider name
+    Then the store records provider equal to that name and the response is ok
+
+  Scenario: LLM provider test endpoint round-trips through the bus
+    Given an admin router wired to a bus where a stub provider echoes llm call response
+    When a client POSTs api llm providers name test
+    Then the response carries ok true and a non negative latency_ms
+
+  Scenario: llm_openai hot reload preserves in flight calls
+    Given a running llm openai plugin with a live client
+    When a config updated event triggers a client rebuild
+    Then the previous client is never closed and a fresh client is built

--- a/tests/plugins/llm_openai/test_llm_openai.py
+++ b/tests/plugins/llm_openai/test_llm_openai.py
@@ -354,8 +354,16 @@ async def test_base_url_env_lands_on_client(tmp_path: Path, monkeypatch: pytest.
     await plugin.on_unload(ctx)
 
 
-async def test_rebuild_swallows_stale_client_close_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A stale client's ``close()`` raising is logged, not re-raised."""
+async def test_llm_openai_hot_reload_preserves_in_flight_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rebuild must NOT close the previous client's pool.
+
+    Regression guard for PR #105 follow-up #106 (F1): closing the
+    existing :class:`AsyncOpenAI` instance inside ``_rebuild_client``
+    tears down the ``httpx`` pool out from under any ``_dispatch``
+    currently awaiting ``chat.completions.create``. Dropping the
+    ``await existing.close()`` keeps the in-flight call healthy; the
+    pool is reclaimed on GC.
+    """
     monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
@@ -373,11 +381,12 @@ async def test_rebuild_swallows_stale_client_close_error(tmp_path: Path, monkeyp
     ctx = _make_ctx(bus, tmp_path, plugin)
     await plugin.on_load(ctx)
 
-    # Swap the live client for one whose close() raises so the
-    # stale-close ``except Exception`` branch in ``_rebuild_client`` runs.
-    bad_client = MagicMock()
-    bad_client.close = AsyncMock(side_effect=RuntimeError("close failed"))
-    plugin._client = bad_client
+    # Swap the live client for a mock whose ``close()`` must never be
+    # awaited — if it were, the in-flight ``_dispatch`` would observe
+    # a dead pool.
+    never_close = MagicMock()
+    never_close.close = AsyncMock()
+    plugin._client = never_close
 
     ev = new_event(
         "config.updated",
@@ -385,9 +394,11 @@ async def test_rebuild_swallows_stale_client_close_error(tmp_path: Path, monkeyp
         session_id="kernel",
         source="kernel-config-store",
     )
-    # Should not raise — the failure is swallowed + logged.
     await plugin.on_event(ev, ctx)
-    bad_client.close.assert_awaited_once()
+    never_close.close.assert_not_awaited()
+    # A rebuild still produces a working new client.
+    assert plugin._client is not None
+    assert plugin._client is not never_close
     await plugin.on_unload(ctx)
 
 

--- a/tests/plugins/web/test_web_config_api.py
+++ b/tests/plugins/web/test_web_config_api.py
@@ -1,0 +1,533 @@
+"""Tests for the bundled ``web`` adapter's HTTP admin API.
+
+AC-bindings from ``specs/plugin-web-config-api.spec``:
+
+* config CRUD                 → ``test_config_crud_cycle``
+* secret masking + ?show=1    → ``test_config_secret_masking_honours_show_flag``
+* plugins listing             → ``test_plugins_list_exposes_metadata``
+* plugin enable toggle        → ``test_plugin_patch_writes_enabled_flag``
+* plugin install mocked       → ``test_plugin_install_delegates_to_registry``
+* llm-provider active switch  → ``test_llm_provider_active_switch``
+
+Tests mount :mod:`yaya.plugins.web.api`'s router against a real
+:class:`EventBus` + :class:`ConfigStore` and a minimal stub registry.
+No uvicorn: ASGI + pydantic round-trip is the contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from yaya.kernel.bus import EventBus
+from yaya.kernel.config_store import ConfigStore
+from yaya.kernel.events import Event
+from yaya.kernel.plugin import Category
+from yaya.plugins.web.api import SECRET_SUFFIXES, build_admin_router, is_secret_key, mask_value
+
+
+class _StubPlugin:
+    """Minimal Plugin-shaped stub for registry snapshot tests."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        category: Category,
+        version: str = "0.1.0",
+        config_model: type[Any] | None = None,
+    ) -> None:
+        self.name = name
+        self.category = category
+        self.version = version
+        self.requires: list[str] = []
+        if config_model is not None:
+            self.ConfigModel = config_model
+
+    def subscriptions(self) -> list[str]:
+        return []
+
+    async def on_load(self, ctx: Any) -> None:
+        return None
+
+    async def on_event(self, ev: Any, ctx: Any) -> None:
+        return None
+
+    async def on_unload(self, ctx: Any) -> None:
+        return None
+
+
+class _StubRegistry:
+    """Minimal :class:`PluginRegistry` look-alike for API tests.
+
+    Exposes the three surfaces the admin router calls:
+    :meth:`snapshot`, :meth:`loaded_plugins`, and async ``install`` /
+    ``remove`` that record their arguments instead of shelling to pip.
+    """
+
+    def __init__(self, plugins: list[_StubPlugin]) -> None:
+        self._plugins = plugins
+        self.installed: list[tuple[str, bool]] = []
+        self.removed: list[str] = []
+        self.remove_error: Exception | None = None
+        self.install_error: Exception | None = None
+
+    def snapshot(self) -> list[dict[str, str]]:
+        return [
+            {
+                "name": p.name,
+                "version": p.version,
+                "category": p.category.value,
+                "status": "loaded",
+            }
+            for p in self._plugins
+        ]
+
+    def loaded_plugins(self, category: Category | None = None) -> list[Any]:
+        if category is None:
+            return list(self._plugins)
+        return [p for p in self._plugins if p.category is category]
+
+    async def install(self, source: str, *, editable: bool = False) -> str:
+        if self.install_error is not None:
+            raise self.install_error
+        self.installed.append((source, editable))
+        return source
+
+    async def remove(self, name: str) -> None:
+        if self.remove_error is not None:
+            raise self.remove_error
+        self.removed.append(name)
+
+
+@pytest.fixture
+async def store(tmp_path: Path) -> AsyncIterator[ConfigStore]:
+    """Fresh ConfigStore against a tmp SQLite file."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "cfg.db")
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest.fixture
+def registry() -> _StubRegistry:
+    """Stub registry pre-populated with two providers + one misc plugin."""
+    plugins = [
+        _StubPlugin(name="llm-openai", category=Category.LLM_PROVIDER, version="0.1.0"),
+        _StubPlugin(name="llm-echo", category=Category.LLM_PROVIDER, version="0.0.1"),
+        _StubPlugin(name="tool-bash", category=Category.TOOL, version="0.1.0"),
+    ]
+    return _StubRegistry(plugins)
+
+
+def _build_app(
+    *,
+    store: ConfigStore | None,
+    registry: _StubRegistry | None,
+    bus: EventBus | None = None,
+) -> FastAPI:
+    """Return a FastAPI app that mounts only the admin router.
+
+    Using a bare app (no WebSocket / static mounts) keeps the test
+    surface focused on the admin routes.
+    """
+    app = FastAPI()
+    app.include_router(
+        build_admin_router(
+            registry=registry,  # type: ignore[arg-type]
+            config_store=store,
+            bus=bus,
+        )
+    )
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver")
+
+
+async def test_config_crud_cycle(store: ConfigStore, registry: _StubRegistry) -> None:
+    """PATCH / GET / DELETE / GET round-trip a key end-to-end."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        # PATCH writes.
+        resp = await client.patch("/api/config/provider", json={"value": "openai"})
+        assert resp.status_code == 200
+        assert resp.json() == {"key": "provider", "ok": True}
+
+        # GET reads back.
+        resp = await client.get("/api/config/provider")
+        assert resp.status_code == 200
+        assert resp.json() == {"key": "provider", "value": "openai"}
+
+        # List returns the full map.
+        resp = await client.get("/api/config")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("provider") == "openai"
+
+        # DELETE removes.
+        resp = await client.delete("/api/config/provider")
+        assert resp.status_code == 200
+        assert resp.json() == {"key": "provider", "removed": True}
+
+        # GET on missing key → 404.
+        resp = await client.get("/api/config/provider")
+        assert resp.status_code == 404
+
+
+async def test_config_secret_masking_honours_show_flag(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Secret-suffix keys mask in list + get, until ``?show=1``."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        await client.patch(
+            "/api/config/plugin.llm_openai.api_key",
+            json={"value": "sk-supersecretvalue"},
+        )
+        await client.patch("/api/config/model", json={"value": "gpt-4o-mini"})
+
+        # List: secret is masked, non-secret is verbatim.
+        resp = await client.get("/api/config")
+        body = resp.json()
+        assert body["plugin.llm_openai.api_key"] == "****alue"
+        assert body["model"] == "gpt-4o-mini"
+
+        # GET (default): masked.
+        resp = await client.get("/api/config/plugin.llm_openai.api_key")
+        assert resp.json()["value"] == "****alue"
+
+        # GET with ?show=1: unmasked.
+        resp = await client.get("/api/config/plugin.llm_openai.api_key?show=1")
+        assert resp.json()["value"] == "sk-supersecretvalue"
+
+
+async def test_config_patch_rejects_non_json(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Non-JSON-encodable values surface as 400."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        # A set payload cannot round-trip through json.dumps; FastAPI will
+        # fail to parse the body → 422. Use a dict with a non-JSON value
+        # by posting a valid body then overriding the stored type below.
+        # Plain content: we trigger the TypeError path by posting missing
+        # body key, which pydantic rejects as 422.
+        resp = await client.patch("/api/config/x", json={"wrong": 1})
+        assert resp.status_code == 422
+
+
+async def test_config_patch_rejects_empty_key(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Empty keys hit ConfigStore's validation and return 400."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch("/api/config/", json={"value": "x"})
+        # Starlette normalises the trailing slash → 404 for route match
+        # before reaching pydantic; that is also acceptable.
+        assert resp.status_code in {404, 400, 307}
+
+
+async def test_plugins_list_exposes_metadata(store: ConfigStore, registry: _StubRegistry) -> None:
+    """GET /api/plugins surfaces enabled / schema / current_config."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        # Seed a config key so ``current_config`` is non-empty.
+        await client.patch("/api/config/plugin.llm_openai.model", json={"value": "gpt-4o-mini"})
+
+        resp = await client.get("/api/plugins")
+        assert resp.status_code == 200
+        names = {row["name"] for row in resp.json()["plugins"]}
+        assert names == {"llm-openai", "llm-echo", "tool-bash"}
+
+        openai_row = next(r for r in resp.json()["plugins"] if r["name"] == "llm-openai")
+        assert openai_row["category"] == "llm-provider"
+        assert openai_row["status"] == "loaded"
+        assert openai_row["enabled"] is True  # default when unset
+        assert openai_row["config_schema"] is None
+        assert openai_row["current_config"] == {"model": "gpt-4o-mini"}
+
+
+async def test_plugin_patch_writes_enabled_flag(store: ConfigStore, registry: _StubRegistry) -> None:
+    """PATCH /api/plugins/<name> writes ``plugin.<ns>.enabled`` in store."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch("/api/plugins/llm-openai", json={"enabled": False})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is False
+        assert body["reload_required"] is True
+
+        # Read via the config endpoint to prove the store was touched.
+        resp = await client.get("/api/config/plugin.llm_openai.enabled")
+        assert resp.status_code == 200
+        assert resp.json()["value"] is False
+
+
+async def test_plugin_patch_unknown_plugin_404(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Unknown plugin name → 404."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch("/api/plugins/does-not-exist", json={"enabled": True})
+        assert resp.status_code == 404
+
+
+async def test_plugin_install_delegates_to_registry(store: ConfigStore, registry: _StubRegistry) -> None:
+    """POST /api/plugins/install calls registry.install with validated source."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/plugins/install",
+            json={"source": "some-dist", "editable": False},
+        )
+        assert resp.status_code == 200
+        assert registry.installed == [("some-dist", False)]
+
+
+async def test_plugin_install_rejects_bad_source(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Sources with disallowed characters → 400 before reaching install."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/plugins/install",
+            json={"source": "bad\nname", "editable": False},
+        )
+        assert resp.status_code == 400
+        assert registry.installed == []
+
+
+async def test_plugin_install_surfaces_runtime_errors(store: ConfigStore, registry: _StubRegistry) -> None:
+    """A ``RuntimeError`` from the registry becomes 500 with its message."""
+    registry.install_error = RuntimeError("pip exploded")
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/plugins/install",
+            json={"source": "some-dist"},
+        )
+        assert resp.status_code == 500
+        assert "pip exploded" in resp.json()["detail"]
+
+
+async def test_plugin_delete_calls_registry_remove(store: ConfigStore, registry: _StubRegistry) -> None:
+    """DELETE /api/plugins/<name> calls registry.remove."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.delete("/api/plugins/tool-bash")
+        assert resp.status_code == 200
+        assert registry.removed == ["tool-bash"]
+
+
+async def test_plugin_delete_rejects_bundled(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Registry ValueError (bundled) → 400."""
+    registry.remove_error = ValueError("cannot remove bundled plugin 'tool-bash'")
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.delete("/api/plugins/tool-bash")
+        assert resp.status_code == 400
+
+
+async def test_llm_provider_list_flags_active(store: ConfigStore, registry: _StubRegistry) -> None:
+    """The provider whose name matches config key ``provider`` is active."""
+    await store.set("provider", "llm-echo")
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.get("/api/llm-providers")
+        body = resp.json()
+        actives = {row["name"]: row["active"] for row in body["providers"]}
+        assert actives == {"llm-openai": False, "llm-echo": True}
+
+
+async def test_llm_provider_active_switch(store: ConfigStore, registry: _StubRegistry) -> None:
+    """PATCH /api/llm-providers/active writes the ``provider`` config key."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch(
+            "/api/llm-providers/active",
+            json={"name": "llm-openai"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"active": "llm-openai", "ok": True}
+        assert await store.get("provider") == "llm-openai"
+
+
+async def test_llm_provider_active_rejects_non_provider(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Switching to a non-llm-provider plugin → 400."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch(
+            "/api/llm-providers/active",
+            json={"name": "tool-bash"},
+        )
+        assert resp.status_code == 400
+
+
+async def test_llm_provider_active_rejects_unknown_plugin(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Switching to a non-existent plugin → 404."""
+    app = _build_app(store=store, registry=registry)
+    async with _client(app) as client:
+        resp = await client.patch(
+            "/api/llm-providers/active",
+            json={"name": "ghost"},
+        )
+        assert resp.status_code == 404
+
+
+async def test_llm_provider_test_roundtrip(store: ConfigStore, registry: _StubRegistry) -> None:
+    """POST /api/llm-providers/<name>/test round-trips through the bus.
+
+    The fake provider subscribes to ``llm.call.request`` and echoes
+    back ``llm.call.response`` with the same ``request_id``. The
+    endpoint returns ``{ok: True, latency_ms}``.
+    """
+    bus = EventBus()
+
+    async def _echo(ev: Event) -> None:
+        if ev.payload.get("provider") != "openai":
+            return
+        reply_id = ev.id
+        from yaya.kernel.events import new_event as _mk
+
+        await bus.publish(
+            _mk(
+                "llm.call.response",
+                {"text": "OK", "tool_calls": [], "usage": {}, "request_id": reply_id},
+                session_id=ev.session_id,
+                source="stub-openai",
+            )
+        )
+
+    bus.subscribe("llm.call.request", _echo, source="stub-openai")
+
+    app = _build_app(store=store, registry=registry, bus=bus)
+    async with _client(app) as client:
+        resp = await client.post("/api/llm-providers/llm-openai/test")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["latency_ms"] >= 0
+
+
+async def test_llm_provider_test_error_path(store: ConfigStore, registry: _StubRegistry) -> None:
+    """A provider that emits ``llm.call.error`` → ``{ok: False, error}``."""
+    bus = EventBus()
+
+    async def _fail(ev: Event) -> None:
+        if ev.payload.get("provider") != "openai":
+            return
+        from yaya.kernel.events import new_event as _mk
+
+        await bus.publish(
+            _mk(
+                "llm.call.error",
+                {"error": "not_configured", "request_id": ev.id},
+                session_id=ev.session_id,
+                source="stub-openai",
+            )
+        )
+
+    bus.subscribe("llm.call.request", _fail, source="stub-openai")
+
+    app = _build_app(store=store, registry=registry, bus=bus)
+    async with _client(app) as client:
+        resp = await client.post("/api/llm-providers/llm-openai/test")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["error"] == "not_configured"
+
+
+async def test_llm_provider_test_timeout(
+    store: ConfigStore, registry: _StubRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No reply within the budget → ``{ok: False, error: 'timeout'}``."""
+    import yaya.plugins.web.api as api_mod
+
+    monkeypatch.setattr(api_mod, "_TEST_PROMPT_TIMEOUT_S", 0.05)
+
+    bus = EventBus()  # no subscriber to ``llm.call.request``
+    app = _build_app(store=store, registry=registry, bus=bus)
+    async with _client(app) as client:
+        resp = await client.post("/api/llm-providers/llm-openai/test")
+        body = resp.json()
+        assert body["ok"] is False
+        assert body["error"] == "timeout"
+
+
+async def test_llm_provider_test_unknown_plugin(store: ConfigStore, registry: _StubRegistry) -> None:
+    """Unknown provider → 404."""
+    bus = EventBus()
+    app = _build_app(store=store, registry=registry, bus=bus)
+    async with _client(app) as client:
+        resp = await client.post("/api/llm-providers/ghost/test")
+        assert resp.status_code == 404
+
+
+async def test_plugin_list_returns_schema_when_declared(
+    store: ConfigStore,
+) -> None:
+    """A plugin exposing ``ConfigModel`` surfaces its JSON schema."""
+    from pydantic import BaseModel
+
+    class _Model(BaseModel):
+        api_key: str = ""
+
+    plugins = [
+        _StubPlugin(
+            name="llm-foo",
+            category=Category.LLM_PROVIDER,
+            version="1.0.0",
+            config_model=_Model,
+        ),
+    ]
+    reg = _StubRegistry(plugins)
+    app = _build_app(store=store, registry=reg)
+    async with _client(app) as client:
+        resp = await client.get("/api/plugins")
+        body = resp.json()
+        row = body["plugins"][0]
+        assert row["config_schema"] is not None
+        assert row["config_schema"]["properties"]["api_key"]["type"] == "string"
+
+
+async def test_store_unavailable_returns_503(registry: _StubRegistry) -> None:
+    """When the admin router is built without a store, reads → 503."""
+    app = _build_app(store=None, registry=registry)
+    async with _client(app) as client:
+        resp = await client.get("/api/config")
+        assert resp.status_code == 503
+
+
+async def test_registry_unavailable_returns_503(store: ConfigStore) -> None:
+    """When the admin router is built without a registry, plugin list → 503."""
+    app = _build_app(store=store, registry=None)
+    async with _client(app) as client:
+        resp = await client.get("/api/plugins")
+        assert resp.status_code == 503
+
+
+# -- helper function tests --------------------------------------------------
+
+
+def test_is_secret_key_matches_last_segment() -> None:
+    """Only the last dotted segment is tested against the suffix set."""
+    for suffix in SECRET_SUFFIXES:
+        assert is_secret_key(f"plugin.x.{suffix}")
+        assert is_secret_key(suffix)
+    assert not is_secret_key("apikeys_allowed")
+    assert not is_secret_key("plugin.x.model")
+
+
+def test_mask_value_shapes() -> None:
+    """Short / non-string values collapse to ``****``."""
+    assert mask_value("abc") == "****"
+    assert mask_value("supersecret") == "****cret"
+    assert mask_value(12345) == "****"
+    assert mask_value(None) == "****"
+
+
+# Unused helper surface kept for future parametric cases.
+_: Callable[..., Awaitable[Any]] | None = None

--- a/tests/plugins/web/test_web_config_api.py
+++ b/tests/plugins/web/test_web_config_api.py
@@ -157,10 +157,10 @@ async def test_config_crud_cycle(store: ConfigStore, registry: _StubRegistry) ->
     """PATCH / GET / DELETE / GET round-trip a key end-to-end."""
     app = _build_app(store=store, registry=registry)
     async with _client(app) as client:
-        # PATCH writes.
+        # PATCH writes and echoes {key, value}.
         resp = await client.patch("/api/config/provider", json={"value": "openai"})
         assert resp.status_code == 200
-        assert resp.json() == {"key": "provider", "ok": True}
+        assert resp.json() == {"key": "provider", "value": "openai", "ok": True}
 
         # GET reads back.
         resp = await client.get("/api/config/provider")
@@ -208,15 +208,10 @@ async def test_config_secret_masking_honours_show_flag(store: ConfigStore, regis
         assert resp.json()["value"] == "sk-supersecretvalue"
 
 
-async def test_config_patch_rejects_non_json(store: ConfigStore, registry: _StubRegistry) -> None:
-    """Non-JSON-encodable values surface as 400."""
+async def test_config_patch_rejects_missing_value(store: ConfigStore, registry: _StubRegistry) -> None:
+    """A body without the required ``value`` field is rejected with 422."""
     app = _build_app(store=store, registry=registry)
     async with _client(app) as client:
-        # A set payload cannot round-trip through json.dumps; FastAPI will
-        # fail to parse the body → 422. Use a dict with a non-JSON value
-        # by posting a valid body then overriding the stored type below.
-        # Plain content: we trigger the TypeError path by posting missing
-        # body key, which pydantic rejects as 422.
         resp = await client.patch("/api/config/x", json={"wrong": 1})
         assert resp.status_code == 422
 
@@ -249,15 +244,20 @@ async def test_plugins_list_exposes_metadata(store: ConfigStore, registry: _Stub
         assert openai_row["enabled"] is True  # default when unset
         assert openai_row["config_schema"] is None
         assert openai_row["current_config"] == {"model": "gpt-4o-mini"}
+        assert openai_row["reload_required"] is False
 
 
 async def test_plugin_patch_writes_enabled_flag(store: ConfigStore, registry: _StubRegistry) -> None:
-    """PATCH /api/plugins/<name> writes ``plugin.<ns>.enabled`` in store."""
+    """PATCH /api/plugins/<name> writes ``plugin.<ns>.enabled`` and returns the row."""
     app = _build_app(store=store, registry=registry)
     async with _client(app) as client:
         resp = await client.patch("/api/plugins/llm-openai", json={"enabled": False})
         assert resp.status_code == 200
         body = resp.json()
+        # Response is the refreshed PluginRow with the reload hint flipped.
+        assert body["name"] == "llm-openai"
+        assert body["category"] == "llm-provider"
+        assert body["status"] == "loaded"
         assert body["enabled"] is False
         assert body["reload_required"] is True
 
@@ -284,6 +284,12 @@ async def test_plugin_install_delegates_to_registry(store: ConfigStore, registry
             json={"source": "some-dist", "editable": False},
         )
         assert resp.status_code == 200
+        body = resp.json()
+        assert body["source"] == "some-dist"
+        assert body["ok"] is True
+        # ``job_id`` is a fresh UUID4 per install — assert shape, not value.
+        assert isinstance(body["job_id"], str)
+        assert len(body["job_id"]) >= 32
         assert registry.installed == [("some-dist", False)]
 
 
@@ -337,12 +343,14 @@ async def test_llm_provider_list_flags_active(store: ConfigStore, registry: _Stu
     async with _client(app) as client:
         resp = await client.get("/api/llm-providers")
         body = resp.json()
-        actives = {row["name"]: row["active"] for row in body["providers"]}
+        # Bare array per the TS client contract.
+        assert isinstance(body, list)
+        actives = {row["name"]: row["active"] for row in body}
         assert actives == {"llm-openai": False, "llm-echo": True}
 
 
 async def test_llm_provider_active_switch(store: ConfigStore, registry: _StubRegistry) -> None:
-    """PATCH /api/llm-providers/active writes the ``provider`` config key."""
+    """PATCH /api/llm-providers/active writes ``provider`` and returns the refreshed list."""
     app = _build_app(store=store, registry=registry)
     async with _client(app) as client:
         resp = await client.patch(
@@ -350,7 +358,10 @@ async def test_llm_provider_active_switch(store: ConfigStore, registry: _StubReg
             json={"name": "llm-openai"},
         )
         assert resp.status_code == 200
-        assert resp.json() == {"active": "llm-openai", "ok": True}
+        body = resp.json()
+        assert isinstance(body, list)
+        actives = {row["name"]: row["active"] for row in body}
+        assert actives == {"llm-openai": True, "llm-echo": False}
         assert await store.get("provider") == "llm-openai"
 
 
@@ -522,11 +533,30 @@ def test_is_secret_key_matches_last_segment() -> None:
 
 
 def test_mask_value_shapes() -> None:
-    """Short / non-string values collapse to ``****``."""
+    """Short / non-string scalars collapse to ``****``; long strings keep the tail."""
     assert mask_value("abc") == "****"
     assert mask_value("supersecret") == "****cret"
     assert mask_value(12345) == "****"
     assert mask_value(None) == "****"
+
+
+def test_mask_value_walks_nested_dict_and_list() -> None:
+    """Containers are walked; only leaf strings mask, structure is preserved."""
+    nested = {
+        "primary": "sk-abc123",
+        "fallback": "sk-xyz789",
+        "meta": {"label": "prod-key", "count": 42},
+        "history": ["sk-first-one", "sk-second-one", 7],
+    }
+    masked = mask_value(nested)
+    assert masked == {
+        "primary": "****c123",
+        "fallback": "****z789",
+        "meta": {"label": "****-key", "count": "****"},
+        "history": ["****-one", "****-one", "****"],
+    }
+    # Top-level list also walks.
+    assert mask_value(["supersecret", "x"]) == ["****cret", "****"]
 
 
 # Unused helper surface kept for future parametric cases.


### PR DESCRIPTION
Adds REST endpoints over the #105 ConfigStore so the browser UI (PR C, #108) can drive config edits, plugin enable/install/remove, and LLM-provider selection without a kernel restart.

## Summary
- **Config:** `GET /api/config`, `GET/PATCH/DELETE /api/config/{key}` with suffix-based secret masking; `?show=1` reveals on demand. Mask set mirrors `yaya config list`.
- **Plugins:** `GET /api/plugins` surfaces `enabled` / `config_schema` / `current_config`; `PATCH /api/plugins/{name}` toggles `enabled` (reload-gated); `POST /api/plugins/install` + `DELETE /api/plugins/{name}` wrap `PluginRegistry.install` / `.remove` with source validation.
- **LLM providers:** `GET /api/llm-providers` lists with `active` flag from config key `provider`; `PATCH /api/llm-providers/active` switches via that key (so `strategy_react` picks it up next turn); `POST /api/llm-providers/{name}/test` fires one `llm.call.request` and waits 5 s for response/error.
- **Layering:** router factored into `yaya.plugins.web.api.build_admin_router` so tests mount it against a stub registry + in-memory `ConfigStore` without booting uvicorn. `KernelContext` grows `.registry` and `.config_store` (escape-hatch parity with `.bus` / `.session`).
- **Security:** unauthenticated, 127.0.0.1-only — `GOAL.md` non-goal through 1.0.

## Endpoint checklist
| Method | Path | Status |
|---|---|---|
| `GET` | `/api/config` | ✅ |
| `GET` | `/api/config/{key}` (`?show=1`) | ✅ |
| `PATCH` | `/api/config/{key}` | ✅ |
| `DELETE` | `/api/config/{key}` | ✅ |
| `GET` | `/api/plugins` | ✅ |
| `PATCH` | `/api/plugins/{name}` | ✅ |
| `POST` | `/api/plugins/install` | ✅ |
| `DELETE` | `/api/plugins/{name}` | ✅ |
| `GET` | `/api/llm-providers` | ✅ |
| `PATCH` | `/api/llm-providers/active` | ✅ |
| `POST` | `/api/llm-providers/{name}/test` | ✅ |

## #106 review follow-ups (rolled in)
- **F1** `llm_openai` rebuild no longer awaits `existing.close()` — closing the `AsyncOpenAI` httpx pool out from under an in-flight `_dispatch` surfaced spurious `llm.call.error` on the preempted turn. New regression test asserts `close()` is never awaited and a fresh client is built.
- **S1** `ConfigView` extracts `_scoped_keys` so `__iter__` and `__len__` share one prefix-strip path.
- **S2** TOML migration `TypeError` now logs at WARN instead of silent skip.

## Test plan
- [x] `just check` (ruff + mypy + pyright + agent-spec lifecycle + feature-sync) — green.
- [x] `just test` — 676 passed; global coverage 91.19% (gate ≥90%); `plugins/web` 89.50% (gate ≥84%); `kernel/` 94.65% (gate ≥93.5%).
- [x] All 25 dedicated `tests/plugins/web/test_web_config_api.py` cases pass: CRUD, masking + `?show=1`, error paths (404 unknown plugin, 400 bad source, 422 invalid body, 503 missing dep, timeout, error-event), schema surfacing.
- [x] Spec ↔ feature mirror enforced (8 scenarios) by `scripts/check_feature_sync.py`.
- [ ] CI green on the PR.

Closes #107
Closes #106
Spec: specs/plugin-web-config-api.spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round 2 — contract alignment with PR #109

All findings addressed in b4608692a044ab0d68777e744326b58516bb1683:

- **C1/C2/C3** contract shapes now match `src/yaya/plugins/web/src/api.ts`: `GET /api/llm-providers` bare array, `PATCH .../active` returns refreshed array, `POST /api/plugins/install` returns `{job_id, source, ok}`.
- **I1** `PATCH /api/plugins/<name>` returns a full refreshed `PluginRow` with an extra `reload_required: boolean` UI hint. PR #109 should add `reload_required?: boolean` to its `PluginRow` TS type in a follow-up push — the client spread merge already preserves the field at runtime, so UI behavior is correct before that typing fix lands.
- **I2** `PATCH /api/config/<key>` echoes `{key, value, ok}`.
- **S1** `mask_value` walks dicts and lists; leaf strings only, structure preserved.
- **S2** test renamed to `test_config_patch_rejects_missing_value`.
- **S3** active-provider switch validates against `loaded_plugins(LLM_PROVIDER)`, not just snapshot.
- **S4** plugin rows read `plugin.<ns>.enabled` from the store even on the unloaded branch; failed-load plugins no longer mis-render as `enabled=true`.

Tests updated to match the new shapes (new row, new bare arrays, new echoed value) rather than pinned to old snapshots. `just check && just test` green locally; per-module coverage gates all pass (plugins/web at 88.55%, global 91.07%).
