### PR TITLE
feat(plugins): instance-scoped dispatch for llm-openai / llm-echo / strategy-react

### DIFF
--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -215,16 +215,46 @@ keep working; a follow-up garbage-collects them once every bundled
 `llm-provider` reads instance-scoped config. The marker is stamped
 last so a crash mid-bootstrap re-runs cleanly on next boot.
 
-**Plugin iteration pattern** (for the coming D4b migration):
+**Dispatch pattern** (the D4b shape used by bundled `llm-openai` /
+`llm-echo` after #123). One plugin process owns many instances; the
+`provider` id inside `llm.call.request` is an *instance id*, not a
+plugin name, and the plugin filters its own owned set:
 
 ```python
 async def on_load(self, ctx: KernelContext) -> None:
     view = ctx.providers
+    self._clients: dict[str, _Client] = {}
     if view is None:
-        return  # test/transient context — fall back to ctx.config
+        return  # test/transient context
     for instance in view.instances_for_plugin(self.name):
-        self._instances[instance.id] = _Client.from_config(instance.config)
+        self._clients[instance.id] = _Client.from_config(instance.config)
+
+async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+    if ev.kind == "config.updated":
+        await self._maybe_hot_reload(ev, ctx)
+        return
+    if ev.kind != "llm.call.request":
+        return
+    provider_id = ev.payload.get("provider")
+    if provider_id not in self._clients:
+        return  # sibling plugins own their own ids on this subscription
+    await self._dispatch(ev, ctx, provider_id)
 ```
+
+**Hot-reload.** On `config.updated` with a `providers.<id>.*` key,
+look up the instance via `ctx.providers.get_instance(id)`:
+
+- absent / `plugin` meta no longer matches → drop the per-instance state;
+- owned → rebuild only that instance's state (do not `close()` the old
+  client synchronously — let GC reclaim pools so in-flight dispatches
+  finish cleanly).
+
+Unrelated prefixes (`plugin.other.*`, kernel keys) are ignored.
+
+**Strategy resolution.** `strategy_react` resolves the active
+`(provider, model)` pair via `ctx.providers.active_id` →
+`ctx.providers.get_instance(active_id).config["model"]`. Flipping the
+kernel-level `provider` key hot-switches dispatch on the next decision.
 
 ### Extension namespace
 

--- a/specs/instance-dispatch.spec
+++ b/specs/instance-dispatch.spec
@@ -1,0 +1,147 @@
+spec: task
+name: "instance-dispatch"
+tags: [plugin, llm-provider, strategy, providers]
+---
+
+## Intent
+
+D4a (#116) reserved the ``providers.<id>.*`` namespace and a
+``ProvidersView`` read surface so one ``llm-provider`` plugin can
+back many configured instances. The plugins themselves still read
+from the legacy ``plugin.<ns>.*`` sub-tree and dispatched off a
+single ``provider == "<plugin-name>"`` match, which defeated the
+whole point: an operator could configure two "OpenAI prod" and
+"Azure OpenAI" instances and only one would ever answer.
+
+This spec flips the three affected bundled plugins (``llm_openai``,
+``llm_echo``, ``strategy_react``) to **instance-scoped dispatch**.
+Each ``llm-provider`` plugin maintains per-instance state keyed by
+the id under ``providers.<id>.*`` whose ``plugin`` meta names that
+plugin; ``strategy_react`` resolves the active instance via
+``ctx.providers.active_id`` and reads ``model`` from the instance's
+own config. ``config.updated`` drives per-instance hot-reload — add
+/ drop / rebuild one client without restarting the kernel.
+
+## Decisions
+
+- ``llm_openai`` keeps a ``self._clients: dict[str, AsyncOpenAI]``
+  keyed by instance id, populated from
+  ``ctx.providers.instances_for_plugin(self.name)`` on load. Dispatch
+  matches ``ev.payload["provider"]`` against the dict; non-matching
+  ids return silently so sibling ``llm-provider`` plugins coexist.
+- ``llm_echo`` keeps a ``self._active_instances: set[str]`` with
+  the same ownership semantics. No per-instance state beyond
+  membership — echo is stateless.
+- ``strategy_react._provider_and_model`` reads
+  ``ctx.providers.active_id`` and resolves model via
+  ``ctx.providers.get_instance(active_id).config["model"]``. Fallback
+  order when ``ctx.providers`` is absent: env sniff over
+  ``OPENAI_API_KEY`` → ``llm-openai`` / ``gpt-4o-mini``, else
+  ``llm-echo`` / ``echo``. Fallback instance names mirror the
+  D4a-seeded ids so production and fallback resolve to identical
+  strings.
+- Hot-reload path for both LLM-provider plugins: on
+  ``config.updated`` with a ``providers.<id>.*`` key, look up the
+  instance via ``ctx.providers.get_instance(id)``; if absent or no
+  longer owned, drop the per-instance state; otherwise rebuild it.
+  Unrelated prefixes (e.g. ``plugin.other.thing``) are ignored.
+- ``llm_openai`` never ``await``s the old client's ``close()`` when
+  rebuilding — pool reclamation rides GC so in-flight dispatches
+  finish cleanly (preserves the #106 fix).
+- Legacy ``plugin.<ns>.*`` reads are removed from all three plugins.
+  D4a's bootstrap lift guarantees pre-existing keys survive as
+  ``providers.<plugin-name>.*`` rows on first upgrade.
+
+## Boundaries
+
+### Allowed Changes
+- src/yaya/plugins/llm_echo/plugin.py
+- src/yaya/plugins/llm_echo/__init__.py
+- src/yaya/plugins/llm_echo/AGENT.md
+- src/yaya/plugins/llm_openai/plugin.py
+- src/yaya/plugins/llm_openai/__init__.py
+- src/yaya/plugins/llm_openai/AGENT.md
+- src/yaya/plugins/strategy_react/plugin.py
+- src/yaya/plugins/strategy_react/AGENT.md
+- tests/plugins/llm_echo/test_echo.py
+- tests/plugins/llm_openai/test_llm_openai.py
+- tests/plugins/strategy_react/test_strategy_react.py
+- tests/plugins/strategy_react/test_provider_selection.py
+- tests/plugins/agent_tool/test_agent_tool_integration.py
+- tests/kernel/test_strategy_hot_provider.py
+- tests/bdd/test_plugins.py
+- tests/bdd/features/plugin-llm_openai.feature
+- tests/bdd/features/kernel-config-store.feature
+- tests/bdd/features/instance-dispatch.feature
+- specs/instance-dispatch.spec
+- specs/plugin-llm_openai.spec
+- specs/kernel-config-store.spec
+- docs/dev/plugin-protocol.md
+
+### Forbidden
+- src/yaya/kernel/
+- src/yaya/cli/
+- src/yaya/core/
+- src/yaya/plugins/web/
+- src/yaya/plugins/memory_sqlite/
+- src/yaya/plugins/tool_bash/
+- src/yaya/plugins/agent_tool/
+- src/yaya/plugins/mcp_bridge/
+- GOAL.md
+- pyproject.toml
+
+## Completion Criteria
+
+Scenario: AC-01 llm_openai builds one client per owned instance on load
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_openai/test_llm_openai.py::test_two_instances_route_to_distinct_clients
+  Level: unit
+  Given a ConfigStore with two providers.<id> rows whose plugin meta equals llm-openai
+  When the plugin on_load runs against a KernelContext bound to that store
+  Then self._clients contains one AsyncOpenAI per instance id and unrelated instances are skipped
+
+Scenario: AC-02 llm_openai dispatch filters by instance id against the owned-client dict
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_openai/test_llm_openai.py::test_non_matching_provider_is_ignored
+  Level: unit
+  Given an llm_openai plugin holding a stub client under instance id prod
+  When a llm.call.request payload provider equals an unowned id
+  Then the plugin emits no llm.call.response and no llm.call.error
+
+Scenario: AC-03 llm_echo answers only for owned instance ids
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_echo/test_echo.py::test_non_matching_provider_is_ignored
+  Level: unit
+  Given a llm_echo plugin with active instance set containing llm-echo
+  When a llm.call.request for a non-owned provider id is published
+  Then no llm.call.response event is emitted by the llm-echo plugin
+
+Scenario: AC-04 strategy_react resolves model from the active instance config
+  Test:
+    Package: yaya
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_provider_and_model_reads_instance_config
+  Level: unit
+  Given a ConfigStore with provider set to instance-a whose config model field equals gpt-4.1
+  When strategy_react handles a strategy.decide.request
+  Then the emitted strategy.decide.response carries provider instance-a and model gpt-4.1
+
+Scenario: AC-05 llm_openai rebuilds only the edited instance on providers.<id> config.updated
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_openai/test_llm_openai.py::test_config_updated_rebuilds_only_affected_instance
+  Level: unit
+  Given an llm_openai plugin with two seeded instances prod and azure
+  When providers.prod.base_url is updated and config.updated is delivered
+  Then only the prod client is rebuilt and the azure client instance remains the same object
+
+## Out of Scope
+
+- CRUD HTTP surface for ``providers.<id>.*`` — lands in D4c.
+- UI affordances for switching the active instance — lands in D4d.
+- Garbage-collecting the legacy ``plugin.<ns>.*`` rows — follow-up
+  PR after D4b lands and confirms no plugin still reads them.
+- Per-plugin schema validation beyond the existing ``api_key`` /
+  ``base_url`` / ``model`` reads.

--- a/specs/kernel-config-store.spec
+++ b/specs/kernel-config-store.spec
@@ -206,23 +206,23 @@ Scenario: AC-13 non-JSON values are rejected
   When the caller sets a value that is not JSON-encodable
   Then the call raises TypeError
 
-Scenario: AC-14 strategy_react hot-switches provider between decisions
+Scenario: AC-14 strategy_react hot-switches active provider instance between decisions
   Test:
     Package: yaya
     Filter: tests/kernel/test_strategy_hot_provider.py::test_hot_switch_provider_between_decisions
   Level: unit
-  Given ReActStrategy loaded against a live ConfigStore scoped view
-  When the operator flips plugin.strategy_react.provider between two strategy.decide.request events
-  Then the second strategy.decide.response carries the new provider name
+  Given ReActStrategy loaded against a live ConfigStore with two seeded provider instances
+  When the operator flips the kernel-level provider key between two strategy.decide.request events
+  Then the second strategy.decide.response carries the new instance id and its per-instance model
 
-Scenario: AC-15 llm_openai rebuilds the client on config.updated
+Scenario: AC-15 llm_openai rebuilds the per-instance client on providers.<id>.* config.updated
   Test:
     Package: yaya
     Filter: tests/kernel/test_strategy_hot_provider.py::test_llm_openai_rebuilds_client_on_config_updated
   Level: unit
-  Given an OpenAIProvider loaded with a stubbed AsyncOpenAI and an initial base_url
-  When plugin.llm_openai.base_url is set to a new value and config.updated is delivered
-  Then the plugin rebuilds its client with the new base_url and non-matching keys do not rebuild
+  Given an OpenAIProvider loaded with a stubbed AsyncOpenAI and one seeded providers.<id> instance
+  When providers.<id>.base_url is set to a new value and config.updated is delivered
+  Then the plugin rebuilds only that instance's client with the new base_url and non-matching keys do not rebuild
 
 ## Out of Scope
 

--- a/specs/plugin-llm_openai.spec
+++ b/specs/plugin-llm_openai.spec
@@ -7,23 +7,26 @@ tags: [plugin, llm-provider]
 
 The OpenAI LLM-provider plugin speaks to the official OpenAI Chat
 Completions API through the async SDK and surfaces its result on the
-yaya bus. It subscribes to `llm.call.request`, filters by the
-`openai` provider id so sibling providers can coexist, reads its
-credentials from environment variables, and emits either a
-`llm.call.response` on success or a `llm.call.error` on any SDK
-failure. A missing API key degrades gracefully: the plugin loads but
-every call errors with `not_configured` rather than crashing the
-kernel.
+yaya bus. It subscribes to `llm.call.request`, filters by *instance
+id* (after D4b every provider is instance-scoped — one plugin backs
+many configured records under `providers.<id>.*`) so sibling
+providers coexist, and emits either a `llm.call.response` on
+success or a `llm.call.error` on any SDK failure. An unconfigured
+instance id simply sees no response from this plugin — the bus
+surfaces a "no subscriber" silence rather than a synthetic error.
 
 ## Decisions
 
-- Subscribes only to `llm.call.request`; handler returns silently
-  when `payload["provider"]` is not `"openai"` so other provider
-  plugins own their own traffic on the same subscription.
-- Credentials come from environment: `OPENAI_API_KEY` is required
-  and `OPENAI_BASE_URL` is optional. Missing key on `on_load` logs
-  a WARNING and sets `_configured` to False; subsequent requests
-  emit `llm.call.error` with `{"error": "not_configured"}`.
+- Subscribes to `llm.call.request` and `config.updated`. The handler
+  returns silently when `payload["provider"]` is not an instance id
+  in `self._clients` so other provider plugins own their own traffic
+  on the same subscription.
+- Credentials per instance: `providers.<id>.api_key` wins, falling
+  back to `OPENAI_API_KEY` when unset. `providers.<id>.base_url`
+  overrides `OPENAI_BASE_URL`. Instances with neither key nor env
+  fallback log a WARNING at load and are simply absent from
+  `self._clients` — requests naming them get the bus-level "no
+  subscriber" silence.
 - On success the plugin calls `openai.AsyncOpenAI.chat.completions.create`
   non-streaming and emits a `llm.call.response` event that echoes
   `request_id` plus `text`, `tool_calls`, and `usage` with
@@ -34,8 +37,8 @@ kernel.
   `llm.call.error` with `str(exc)`.
 - `asyncio.CancelledError` propagates out of the handler
   unchanged so `asyncio.wait_for` and task cancellation unwind
-  cleanly; `on_unload` closes the SDK client inside a try/except
-  that logs but never re-raises.
+  cleanly; `on_unload` drops the per-instance client dict without
+  awaiting `close()` so in-flight dispatches finish cleanly.
 
 ## Boundaries
 
@@ -70,15 +73,15 @@ Scenario: Successful completion emits llm.call.response with text tool_calls usa
   Then the stubbed chat completions create method is called with the request model and messages
   And a llm.call.response event is emitted carrying text tool_calls usage and the originating request id
 
-Scenario: Missing API key degrades to llm.call.error without crashing the kernel
+Scenario: Missing API key and no configured instance leaves the request silent
   Test:
     Package: yaya
     Filter: tests/plugins/llm_openai/test_llm_openai.py::test_missing_api_key_emits_not_configured_error
   Level: unit
   Given an llm-openai plugin loaded with no OPENAI_API_KEY environment variable
   When a llm.call.request for provider openai is published
-  Then a llm.call.error event is emitted with error not_configured
-  And the response echoes the originating request id
+  Then no llm.call.response event is emitted by the llm-openai plugin
+  And no llm.call.error event is emitted by the llm-openai plugin
 
 Scenario: Error path — unrelated provider id leaves the event uncommented by llm-openai
   Test:

--- a/src/yaya/plugins/llm_echo/AGENT.md
+++ b/src/yaya/plugins/llm_echo/AGENT.md
@@ -1,23 +1,24 @@
 ## Philosophy
-Echo LLM-provider plugin — deterministic, zero-config, dev-only. Ships so a fresh `yaya serve` round-trips the kernel end-to-end without any API key. Closes the 0.1 onboarding gap (`GOAL.md` §Milestones 0.1).
+Echo LLM-provider plugin — deterministic, zero-config, dev-only. Ships so a fresh `yaya serve` round-trips the kernel end-to-end without any API key. Closes the 0.1 onboarding gap (`GOAL.md` §Milestones 0.1). **Instance-scoped** (D4b / #123): filters by the set of owned instance ids under `providers.<id>.*`, matching the D4a-seeded `llm-echo` instance by default.
 
 ## External Reality
-- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row).
-- Contract: [`specs/plugin-llm_echo.spec`](../../../../specs/plugin-llm_echo.spec).
+- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row + "Provider instances" section).
+- Contracts: [`specs/plugin-llm_echo.spec`](../../../../specs/plugin-llm_echo.spec) + [`specs/instance-dispatch.spec`](../../../../specs/instance-dispatch.spec).
 - Tests: `tests/plugins/llm_echo/`.
 
 ## Constraints
-- `Category.LLM_PROVIDER`. Subscribes only to `llm.call.request`; filters by `payload["provider"] == "echo"`.
+- `Category.LLM_PROVIDER`. Subscribes to `llm.call.request` and `config.updated`; filters `payload["provider"]` against `self._active_instances`.
 - Stdlib only. No third-party AI agent frameworks (`AGENT.md` §4); no LLM SDK.
 - Deterministic: `(echo) <last user message>` for non-empty user input, else the literal `(echo) (no input)`.
 - Every `llm.call.response` echoes `request_id` (lesson #15).
-- `on_unload` is a no-op — the plugin holds no resources.
+- `on_unload` clears the active-instance set — the plugin holds no other resources.
 
 ## Interaction (patterns)
-- Request filter: `ev.payload.get("provider") != "echo"` → return silently (sibling providers coexist).
+- Request filter: `ev.payload.get("provider") not in self._active_instances` → return silently.
+- `config.updated` under `providers.*` → re-snapshot the owned set via `ctx.providers.instances_for_plugin(self.name)`; no fine-grained diff.
 - Iterate `messages` in reverse to grab the most recent `role == "user"` `content` string.
-- Token usage hard-coded to `{"input_tokens": 0, "output_tokens": 0}` — this is a dev provider, not an LLM call.
-- Auto-selection lives in the strategy (see `strategy_react/plugin.py`): when `OPENAI_API_KEY` is unset, the strategy picks `provider == "echo"`. Temporary env sniff; migrates to `ctx.config` in #23.
+- Token usage hard-coded to `{"input_tokens": 0, "output_tokens": 0}` — dev provider, not an LLM call.
+- Active-instance selection lives in `strategy_react`: when no `OPENAI_API_KEY` and `ctx.providers` is absent, the strategy falls back to `provider == "llm-echo"` (matches the D4a-seeded instance id).
 
 ## Budget & Loading
 - Sibling: [`../AGENT.md`](../AGENT.md). Authoritative: [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md#llm-invocation-kernel--llm-provider).

--- a/src/yaya/plugins/llm_echo/__init__.py
+++ b/src/yaya/plugins/llm_echo/__init__.py
@@ -1,10 +1,14 @@
 """Echo LLM-provider plugin (deterministic, zero-config, dev-only).
 
-Bundled plugin satisfying the ``llm-provider`` category for the
-``echo`` provider id. Subscribes to ``llm.call.request``, filters
-payloads where ``provider == "echo"``, and replies with a
-deterministic ``(echo) <last user message>`` body so users can
-verify the kernel end-to-end without any API key.
+Bundled plugin satisfying the ``llm-provider`` category. After D4b
+(#123) the plugin is **instance-scoped**: it subscribes to
+``llm.call.request`` and ``config.updated``, tracks the set of
+instance ids under ``providers.<id>.*`` whose ``plugin`` meta
+equals ``llm-echo``, and replies with a deterministic
+``(echo) <last user message>`` body so users can verify the kernel
+end-to-end without any API key. The D4a bootstrap seeds a default
+``llm-echo`` instance so a fresh ``yaya serve`` round-trips without
+any configuration.
 """
 
 from yaya.plugins.llm_echo.plugin import EchoLLM

--- a/src/yaya/plugins/llm_echo/plugin.py
+++ b/src/yaya/plugins/llm_echo/plugin.py
@@ -1,21 +1,27 @@
 """Echo LLM provider — deterministic, zero-config, dev-only.
 
-Every ``llm.call.request`` with ``provider == "echo"`` gets a
-response body prefixed with ``(echo) `` followed by the last user
-message in ``messages``. Token usage is reported as zero. The
-plugin is bundled so a fresh ``yaya serve`` round-trips the kernel
-without any API key — closes the 0.1 onboarding gap (see
-``GOAL.md`` §Milestones 0.1).
+The plugin is **instance-scoped**: after #123 (D4b) it maintains a
+set of *instance ids* whose ``providers.<id>.plugin`` meta equals
+``llm-echo`` and responds to ``llm.call.request`` only when
+``ev.payload["provider"]`` names one of those ids. For historical
+callers that still ship ``provider == "echo"`` (the literal plugin
+name) the legacy id is accepted as long as a matching instance is
+configured — the D4a bootstrap seeds exactly that row, so a fresh
+``yaya serve`` round-trips without any API key.
+
+Token usage is reported as zero. The plugin is bundled so a fresh
+``yaya serve`` round-trips the kernel without any API key — closes
+the 0.1 onboarding gap (see ``GOAL.md`` §Milestones 0.1).
 
 Layering: imports only from ``yaya.kernel``. No third-party
 dependencies — stdlib only, per ``AGENT.md`` §4.
 
 Routing parity with the bundled ``llm_openai`` plugin: subscribes
-only to ``llm.call.request``; non-matching providers return
-silently so sibling LLM plugins coexist on the same subscription.
-Every emitted ``llm.call.response`` echoes ``request_id`` for the
-agent loop's ``_RequestTracker`` correlation (lesson #15 in
-``docs/wiki/lessons-learned.md``).
+to ``llm.call.request`` and ``config.updated``; non-matching
+providers return silently so sibling LLM plugins coexist on the
+same subscription. Every emitted ``llm.call.response`` echoes
+``request_id`` for the agent loop's ``_RequestTracker`` correlation
+(lesson #15 in ``docs/wiki/lessons-learned.md``).
 """
 
 from __future__ import annotations
@@ -27,7 +33,7 @@ from yaya.kernel.plugin import Category, KernelContext
 
 _NAME = "llm-echo"
 _VERSION = "0.1.0"
-_PROVIDER_ID = "echo"
+_PROVIDERS_PREFIX = "providers."
 _NO_INPUT = "(echo) (no input)"
 
 
@@ -38,33 +44,57 @@ class EchoLLM:
         name: Plugin name (kebab-case).
         version: Semver.
         category: :class:`Category.LLM_PROVIDER`.
-        provider_id: The literal ``"echo"`` filter value matched on
-            ``ev.payload["provider"]``.
     """
 
     name: str = _NAME
     version: str = _VERSION
     category: Category = Category.LLM_PROVIDER
-    provider_id: str = _PROVIDER_ID
     requires: ClassVar[list[str]] = []
 
+    def __init__(self) -> None:
+        # Set of instance ids owned by this plugin. Refreshed from
+        # :attr:`ctx.providers` in :meth:`on_load` and on every
+        # ``config.updated`` event that touches the ``providers.*``
+        # namespace.
+        self._active_instances: set[str] = set()
+
     def subscriptions(self) -> list[str]:
-        """Only ``llm.call.request`` — the single request kind for this category."""
-        return ["llm.call.request"]
+        """Subscribe to llm requests and live-config updates.
+
+        ``config.updated`` drives the hot-reload path: adding,
+        removing, or re-pointing a ``providers.<id>.*`` row whose
+        plugin meta equals :data:`_NAME` shows up in
+        :attr:`_active_instances` on the next turn — no restart.
+        """
+        return ["llm.call.request", "config.updated"]
 
     async def on_load(self, ctx: KernelContext) -> None:
-        """Log readiness. The echo provider needs no configuration."""
+        """Seed :attr:`_active_instances` from every owned row.
+
+        Reads :meth:`ctx.providers.instances_for_plugin` and snapshots
+        the current set. ``ctx.providers == None`` (config store
+        absent — test / transient stacks) leaves the set empty; tests
+        that drive this plugin directly can populate
+        :attr:`_active_instances` manually.
+        """
         ctx.logger.info("llm-echo ready (no API key required)")
+        self._refresh(ctx)
 
     async def on_event(self, ev: Event, ctx: KernelContext) -> None:
-        """Route ``llm.call.request`` for ``provider == "echo"``.
+        """Route ``llm.call.request`` for any owned instance id.
 
-        Non-matching providers are ignored so sibling LLM plugins
-        own their own traffic on the shared subscription.
+        Non-matching providers are ignored so sibling LLM plugins own
+        their own traffic on the shared subscription.
+        ``config.updated`` under ``providers.*`` refreshes the owned
+        set; other prefixes are silently skipped.
         """
+        if ev.kind == "config.updated":
+            self._maybe_hot_reload(ev, ctx)
+            return
         if ev.kind != "llm.call.request":
             return
-        if ev.payload.get("provider") != _PROVIDER_ID:
+        provider_id = ev.payload.get("provider")
+        if not isinstance(provider_id, str) or provider_id not in self._active_instances:
             return
 
         text = _build_echo(ev.payload)
@@ -80,7 +110,33 @@ class EchoLLM:
         )
 
     async def on_unload(self, ctx: KernelContext) -> None:
-        """No-op — the echo provider holds no resources."""
+        """Clear the owned-instance set; the plugin holds no other resources."""
+        self._active_instances.clear()
+        del ctx  # unused — kept for Plugin protocol conformance.
+
+    # -- internals ------------------------------------------------------------
+
+    def _refresh(self, ctx: KernelContext) -> None:
+        """Re-snapshot the owned-instance set from :attr:`ctx.providers`."""
+        providers = ctx.providers
+        if providers is None:
+            self._active_instances = set()
+            return
+        self._active_instances = {inst.id for inst in providers.instances_for_plugin(_NAME)}
+
+    def _maybe_hot_reload(self, ev: Event, ctx: KernelContext) -> None:
+        """Refresh on any ``config.updated`` under the ``providers.*`` tree.
+
+        The set is cheap to rebuild (a single
+        :meth:`ProvidersView.instances_for_plugin` call, which in turn
+        is an in-memory dict scan) so we skip fine-grained diffing —
+        simpler, and correct across every mutation shape (add, remove,
+        re-point ``plugin`` meta).
+        """
+        key_raw = ev.payload.get("key")
+        if not isinstance(key_raw, str) or not key_raw.startswith(_PROVIDERS_PREFIX):
+            return
+        self._refresh(ctx)
 
 
 def _build_echo(payload: dict[str, Any]) -> str:

--- a/src/yaya/plugins/llm_openai/AGENT.md
+++ b/src/yaya/plugins/llm_openai/AGENT.md
@@ -1,22 +1,22 @@
 ## Philosophy
-OpenAI LLM-provider plugin built on the official `openai.AsyncOpenAI` SDK (the only LLM SDK allowed by `AGENT.md` §4). Non-streaming chat completions at 0.1; streaming follows adapter work.
+OpenAI LLM-provider plugin built on the official `openai.AsyncOpenAI` SDK (the only LLM SDK allowed by `AGENT.md` §4). **Instance-scoped** (D4b / #123): one plugin process backs many operator-configured records under `providers.<id>.*` — "OpenAI prod", "Azure OpenAI", "local-LM-Studio" each with its own `api_key`, `base_url`, `model`. Non-streaming chat completions at 0.1; streaming follows adapter work.
 
 ## External Reality
-- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row).
-- Contract: [`specs/plugin-llm_openai.spec`](../../../../specs/plugin-llm_openai.spec).
-- Tests: `tests/plugins/llm_openai/`.
+- [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row + "Provider instances" section).
+- Contracts: [`specs/plugin-llm_openai.spec`](../../../../specs/plugin-llm_openai.spec) + [`specs/instance-dispatch.spec`](../../../../specs/instance-dispatch.spec).
+- Tests: `tests/plugins/llm_openai/` + `tests/kernel/test_strategy_hot_provider.py::test_llm_openai_rebuilds_client_on_config_updated`.
 
 ## Constraints
-- `Category.LLM_PROVIDER`. Subscribes only to `llm.call.request`; filters by `payload["provider"] == "openai"`.
-- Env-driven config: `OPENAI_API_KEY` (required) + `OPENAI_BASE_URL` (optional). Missing key → `on_load` logs WARNING and sets `_configured = False`. No hard crash.
+- `Category.LLM_PROVIDER`. Subscribes to `llm.call.request` and `config.updated`; filters `payload["provider"]` against `self._clients` keyed by instance id.
+- Per-instance config: `providers.<id>.api_key` wins over `OPENAI_API_KEY`; `providers.<id>.base_url` overrides `OPENAI_BASE_URL`. Instances with neither key nor env fallback log a WARNING at load and are absent from `self._clients` — the bus surfaces "no subscriber" silence for them.
 - Every response event echoes `request_id` (lesson #15). Applies to both `llm.call.response` and `llm.call.error`.
 - `asyncio.CancelledError` propagates — never swallow it (lesson #3).
-- `on_unload` calls `await self._client.close()` inside a try/except; cleanup errors log WARNING and never re-raise.
+- `on_unload` drops `self._clients` without awaiting the old clients' `close()` — pool reclamation rides GC so in-flight dispatches finish cleanly (preserves the #106 fix).
 - No third-party AI agent frameworks (AGENT.md §4). `openai` SDK only.
 
 ## Interaction (patterns)
-- Request filter: `ev.payload.get("provider") != "openai"` → return silently (sibling providers coexist on the same subscription).
-- Not configured → emit `llm.call.error` with `{"error": "not_configured", "request_id": ev.id}`.
+- Request filter: `ev.payload.get("provider") not in self._clients` → return silently.
+- `config.updated` key under `providers.<id>.*`: look up the instance; absent or no longer owned → drop client; otherwise rebuild just that instance's client. Unrelated prefixes ignored.
 - `openai.RateLimitError` → `llm.call.error` with `retry_after_s` when the SDK exposes one.
 - Any other `openai.APIError` / generic `Exception` → `llm.call.error` with `{"error": str(e), "request_id": ev.id}`.
 - Do NOT emit `plugin.error` from this handler; the kernel synthesizes those when `on_event` raises.

--- a/src/yaya/plugins/llm_openai/__init__.py
+++ b/src/yaya/plugins/llm_openai/__init__.py
@@ -1,12 +1,15 @@
 """OpenAI LLM-provider plugin (AsyncOpenAI SDK).
 
-Bundled plugin satisfying the ``llm-provider`` category for the
-``openai`` provider id. Subscribes to ``llm.call.request``, filters
-payloads where ``provider == "openai"``, and responds with either
-``llm.call.response`` on success or ``llm.call.error`` on failure.
-
-Configuration is env-driven (``OPENAI_API_KEY`` required,
-``OPENAI_BASE_URL`` optional) per ``docs/dev/plugin-protocol.md``.
+Bundled plugin satisfying the ``llm-provider`` category. After D4b
+(#123) the plugin is **instance-scoped**: it subscribes to
+``llm.call.request`` and ``config.updated``, maintains one
+``AsyncOpenAI`` client per configured ``providers.<id>.*`` row whose
+``plugin`` meta equals ``llm-openai``, and dispatches by matching
+``ev.payload["provider"]`` (an *instance id*) against the owned
+client dict. Per-instance ``api_key`` / ``base_url`` / ``model``
+fields win over the legacy ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL``
+env vars. See ``docs/dev/plugin-protocol.md`` for the dispatch and
+hot-reload patterns.
 """
 
 from yaya.plugins.llm_openai.plugin import OpenAIProvider

--- a/src/yaya/plugins/llm_openai/plugin.py
+++ b/src/yaya/plugins/llm_openai/plugin.py
@@ -1,15 +1,24 @@
 """OpenAI LLM-provider plugin implementation.
 
-The plugin is env-driven: ``OPENAI_API_KEY`` is required (a missing
-key flips the plugin to an unconfigured state that surfaces
-``llm.call.error`` per request rather than crashing the kernel) and
-``OPENAI_BASE_URL`` is optional (passed straight through to the SDK
-for self-hosted / proxy deployments).
+The plugin is **instance-scoped**: after #123 (D4b) it maintains one
+:class:`openai.AsyncOpenAI` client per configured ``providers.<id>.*``
+row whose ``plugin`` meta equals ``llm-openai``. Dispatch happens by
+matching ``ev.payload["provider"]`` (an *instance id*, not the plugin
+name) against the plugin's owned-client dict. One plugin process
+therefore backs many operator-configured instances — e.g. "OpenAI
+prod", "Azure OpenAI", "local-LM-Studio" — each with its own
+``api_key``, ``base_url``, and ``model`` fields.
 
 Non-streaming chat completions only at 0.1; streaming is tracked in
 the adapter-plugin spec. Every response event echoes ``request_id``
 so the agent loop's ``_RequestTracker`` correlates concurrent calls
 (lesson #15 in ``docs/wiki/lessons-learned.md``).
+
+Hot-reload is per-instance: a ``config.updated`` event whose key sits
+under ``providers.<id>.`` rebuilds *only* that instance's client.
+Adding a new instance (``providers.<id>.plugin = llm-openai``)
+materialises a new client; removing / re-pointing drops the old one.
+Zero plugin restart in any of these paths.
 
 Per-line ``# pyright: ignore[...]`` pragmas on the SDK-accessor lines
 narrow the suppression to exactly where the OpenAI SDK surface widens
@@ -29,9 +38,12 @@ from yaya.kernel.plugin import Category, KernelContext
 if TYPE_CHECKING:  # pragma: no cover - type-only import.
     from openai import AsyncOpenAI
 
+    from yaya.kernel.providers import InstanceRow
+
 _NAME = "llm-openai"
 _VERSION = "0.1.0"
-_PROVIDER_ID = "openai"
+_PROVIDERS_PREFIX = "providers."
+_DEFAULT_MODEL = "gpt-4o-mini"
 
 
 class OpenAIProvider:
@@ -49,62 +61,77 @@ class OpenAIProvider:
     requires: ClassVar[list[str]] = []
 
     def __init__(self) -> None:
-        self._client: AsyncOpenAI | None = None
-        self._configured: bool = False
+        # Instance-id → live ``AsyncOpenAI`` client. Populated in
+        # :meth:`on_load` from every ``providers.<id>.*`` row whose
+        # ``plugin`` meta equals this plugin's name, and mutated
+        # incrementally by :meth:`_maybe_hot_reload` as operators
+        # edit config.
+        self._clients: dict[str, AsyncOpenAI] = {}
 
     def subscriptions(self) -> list[str]:
         """Subscribe to llm requests and live-config updates.
 
         ``config.updated`` drives the hot-reload path: when a
-        ``plugin.llm_openai.*`` key changes (api_key, base_url) the
-        plugin rebuilds its :class:`AsyncOpenAI` client without a
+        ``providers.<id>.*`` key changes the plugin rebuilds the
+        affected instance's :class:`AsyncOpenAI` client without a
         kernel restart. Non-matching prefixes are filtered in
         :meth:`on_event` so the bus's exact-kind routing stays cheap.
         """
         return ["llm.call.request", "config.updated"]
 
     async def on_load(self, ctx: KernelContext) -> None:
-        """Build an ``AsyncOpenAI`` client from live config + env.
+        """Build one :class:`AsyncOpenAI` client per owned instance.
 
-        A missing ``OPENAI_API_KEY`` is NOT a hard failure — the
-        kernel keeps loading so users with other providers installed
-        still get a working bus. Every incoming ``llm.call.request``
-        for ``provider == "openai"`` then emits ``llm.call.error``.
+        Reads every ``providers.<id>.*`` row whose ``plugin`` meta
+        equals :data:`_NAME` via :attr:`ctx.providers` and seeds
+        :attr:`_clients`. Instances with no ``api_key`` (and no
+        ``OPENAI_API_KEY`` env fallback) are skipped with a WARNING
+        rather than hard-failing, so a partially-configured install
+        still boots and surfaces "no subscriber" on requests naming
+        them.
 
-        Live config (``ctx.config["api_key"]`` / ``["base_url"]``)
-        wins over the ``OPENAI_API_KEY`` / ``OPENAI_BASE_URL`` env
-        vars. The env fallback keeps zero-config `yaya serve` working
-        for developers before they wire a ConfigStore value.
+        If ``ctx.providers`` is ``None`` (kernel booted without a
+        config store — tests, transient stacks) the plugin loads in
+        an empty state; tests that manually set ``self._clients``
+        then run through the dispatch path unchanged.
+
+        One-shot legacy-config warning: if a ``plugin.llm_openai.*``
+        key is still present AND no owned instance exists yet, log
+        a hint pointing operators at the new namespace. Does NOT
+        auto-lift — that is D4a's job (registry bootstrap) and
+        re-doing it here would mask bootstrap regressions.
         """
-        await self._rebuild_client(ctx)
+        providers = ctx.providers
+        self._clients = {}
+        if providers is None:
+            return
+        for inst in providers.instances_for_plugin(_NAME):
+            client = self._build_client(inst, ctx)
+            if client is not None:
+                self._clients[inst.id] = client
+        if not self._clients:
+            self._warn_legacy_keys(ctx)
 
     async def on_event(self, ev: Event, ctx: KernelContext) -> None:
-        """Route ``llm.call.request`` for ``provider == "openai"``.
+        """Route ``llm.call.request`` to the matching instance client.
 
-        ``config.updated`` triggers a client rebuild when the touched
-        key lives under this plugin's namespace; other prefixes are
-        ignored. Non-matching providers on ``llm.call.request`` are
-        ignored so sibling LLM plugins can coexist under the same
-        bus subscription.
+        ``ev.payload["provider"]`` is an *instance id* (D4b); the
+        plugin answers only when that id names one of its owned
+        clients. ``config.updated`` triggers per-instance rebuilds.
+        Non-matching providers on ``llm.call.request`` are ignored so
+        sibling LLM plugins coexist under the same bus subscription.
         """
         if ev.kind == "config.updated":
             await self._maybe_hot_reload(ev, ctx)
             return
         if ev.kind != "llm.call.request":
             return
-        if ev.payload.get("provider") != _PROVIDER_ID:
-            return
-
-        if not self._configured or self._client is None:
-            await ctx.emit(
-                "llm.call.error",
-                {"error": "not_configured", "request_id": ev.id},
-                session_id=ev.session_id,
-            )
+        provider_id = ev.payload.get("provider")
+        if not isinstance(provider_id, str) or provider_id not in self._clients:
             return
 
         try:
-            await self._dispatch(ev, ctx)
+            await self._dispatch(ev, ctx, provider_id)
         except asyncio.CancelledError:
             # Propagate cancellation — lesson #3.
             raise
@@ -112,86 +139,144 @@ class OpenAIProvider:
             await self._emit_error(ctx, ev, exc)
 
     async def on_unload(self, ctx: KernelContext) -> None:
-        """Best-effort ``AsyncOpenAI.close()``; never re-raise cleanup errors."""
-        client, self._client = self._client, None
-        self._configured = False
-        if client is None:
-            return
-        try:
-            await client.close()
-        except Exception as exc:
-            ctx.logger.warning("llm-openai: client close failed: %s", exc)
+        """Drop every owned client; never re-raise cleanup errors.
+
+        Mirrors the rebuild path's leak policy: ``AsyncOpenAI``
+        reclaims its ``httpx`` pool on GC, so we do *not* await
+        ``close()`` (which would tear pools out from under any
+        in-flight ``_dispatch``). See :meth:`_rebuild_instance` for
+        the matching rationale.
+        """
+        self._clients.clear()
+        del ctx  # unused — kept for Plugin protocol conformance.
 
     # -- internals ------------------------------------------------------------
 
-    async def _rebuild_client(self, ctx: KernelContext) -> None:
-        """(Re)build the ``AsyncOpenAI`` client from live config + env.
+    @staticmethod
+    def _build_client(inst: InstanceRow, ctx: KernelContext) -> AsyncOpenAI | None:
+        """Construct one :class:`AsyncOpenAI` client from an instance row.
 
-        Closes a previous client (if any) before opening a new one so
-        a hot-reload swap does not leak a connection pool. Live
-        ``ConfigStore`` values win over the legacy env vars; the env
-        fallback keeps zero-config boots working.
+        Instance ``config["api_key"]`` wins over the ``OPENAI_API_KEY``
+        env var; missing both is not a hard failure — the instance is
+        simply absent from :attr:`_clients` and requests naming it
+        fall through to the bus's "no subscriber" path (silent). The
+        operator sees the WARNING in the plugin log.
         """
-        cfg = ctx.config
-        cfg_api_key = cfg.get("api_key") if cfg else None
-        cfg_base_url = cfg.get("base_url") if cfg else None
-
-        api_key = cfg_api_key if isinstance(cfg_api_key, str) and cfg_api_key else os.environ.get("OPENAI_API_KEY")
-        base_url_val = (
-            cfg_base_url if isinstance(cfg_base_url, str) and cfg_base_url else os.environ.get("OPENAI_BASE_URL")
-        )
-
-        # Swap the client without closing the old pool: a previous
-        # client may still be servicing an in-flight ``_dispatch`` call
-        # when a ``config.updated`` event preempts it via ``await``.
-        # Closing the pool here would surface a spurious
-        # ``llm.call.error`` on that in-flight turn (PR #105 follow-up
-        # #106, F1). ``AsyncOpenAI`` reclaims its ``httpx`` pool on GC
-        # and the leak is bounded by rotations-per-process.
-        self._client = None
-        self._configured = False
-
+        api_key_raw = inst.config.get("api_key")
+        base_url_raw = inst.config.get("base_url")
+        api_key = api_key_raw if isinstance(api_key_raw, str) and api_key_raw else os.environ.get("OPENAI_API_KEY")
+        base_url = base_url_raw if isinstance(base_url_raw, str) and base_url_raw else os.environ.get("OPENAI_BASE_URL")
         if not api_key:
-            ctx.logger.warning("llm-openai: OPENAI_API_KEY not set; calls will error")
-            return
-        # Import lazily so a missing openai install surfaces here, not at
-        # kernel boot for users who do not use this plugin.
+            ctx.logger.warning(
+                "llm-openai: instance %r has no api_key (and OPENAI_API_KEY unset); skipping",
+                inst.id,
+            )
+            return None
+        # Import lazily so a missing openai install surfaces here, not
+        # at kernel boot for users who do not use this plugin.
         from openai import AsyncOpenAI
 
         kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url_val:
-            kwargs["base_url"] = base_url_val
-        self._client = AsyncOpenAI(**kwargs)
-        self._configured = True
-        ctx.logger.debug("llm-openai client built (base_url=%s)", base_url_val or "<default>")
+        if base_url:
+            kwargs["base_url"] = base_url
+        ctx.logger.debug(
+            "llm-openai: built client for instance %r (base_url=%s)",
+            inst.id,
+            base_url or "<default>",
+        )
+        return AsyncOpenAI(**kwargs)
+
+    @staticmethod
+    def _warn_legacy_keys(ctx: KernelContext) -> None:
+        """Hint when config still uses ``plugin.llm_openai.*`` with no instance.
+
+        The D4a registry bootstrap already lifts those rows into
+        ``providers.llm-openai.*`` on first boot; a non-empty
+        ``plugin.llm_openai.*`` subtree *without* a matching provider
+        instance means either the bootstrap did not run (pre-D4a
+        database) or an operator is still setting keys via the legacy
+        namespace. Log once at WARNING so it is visible without
+        crashing the kernel.
+        """
+        store = ctx.config_store
+        if store is None:
+            return
+        cache = store._cache  # pyright: ignore[reportPrivateUsage]
+        legacy_prefix = "plugin.llm_openai."
+        if any(k.startswith(legacy_prefix) for k in cache):
+            ctx.logger.warning(
+                "llm-openai: legacy plugin.llm_openai.* keys present but no providers.<id>.plugin=llm-openai "
+                "instance is configured; use `yaya config set providers.llm-openai.api_key ...` "
+                "(D4c CRUD lands next)"
+            )
 
     async def _maybe_hot_reload(self, ev: Event, ctx: KernelContext) -> None:
-        """Rebuild the client when a ``plugin.llm_openai.*`` key changed.
+        """React to a ``config.updated`` event scoped to ``providers.<id>.*``.
 
-        The scoped :class:`~yaya.kernel.config_store.ConfigView` handed
-        to this plugin already reflects the new value by the time this
-        handler runs (the store updates its cache before emitting);
-        this method just forces a client re-spin for keys that affect
-        connection identity (``api_key``, ``base_url``).
+        The kernel's :class:`~yaya.kernel.config_store.ConfigStore`
+        already updated its cache before publishing, so the
+        :attr:`ctx.providers` view re-reads the fresh value. This
+        method only decides *which* instance to rebuild — the
+        per-client dict is the authoritative routing key, so changes
+        to ``plugin`` meta (adding / removing this plugin's ownership)
+        must insert or drop entries accordingly.
         """
+        providers = ctx.providers
+        if providers is None:
+            return
         key_raw = ev.payload.get("key")
-        if not isinstance(key_raw, str):
+        if not isinstance(key_raw, str) or not key_raw.startswith(_PROVIDERS_PREFIX):
             return
-        # The registry scopes each plugin's config view to
-        # ``plugin.llm_openai.`` — hot-reload when the touched key
-        # lives inside that namespace.
-        if not key_raw.startswith("plugin.llm_openai."):
+        rest = key_raw[len(_PROVIDERS_PREFIX) :]
+        if "." not in rest:
             return
-        suffix = key_raw[len("plugin.llm_openai.") :]
-        if suffix not in {"api_key", "base_url"}:
+        instance_id, _ = rest.split(".", 1)
+        if not instance_id:
             return
-        await self._rebuild_client(ctx)
+        inst = providers.get_instance(instance_id)
+        if inst is None:
+            # Row removed entirely — drop any client we may have held.
+            self._clients.pop(instance_id, None)
+            return
+        if inst.plugin != _NAME:
+            # Instance either never belonged to us, or was just
+            # re-pointed at a different plugin. Drop the client so
+            # dispatch no longer answers for this id.
+            self._clients.pop(instance_id, None)
+            return
+        # Owned by us → (re)build the client. ``model`` is read live
+        # at dispatch time, so a ``model`` change needs no rebuild;
+        # only fields that affect connection identity do. Rebuilding
+        # unconditionally is the simpler correct path — the stale
+        # client is dropped, not closed, to preserve in-flight calls.
+        self._rebuild_instance(inst, ctx)
 
-    async def _dispatch(self, ev: Event, ctx: KernelContext) -> None:
-        """Invoke chat completions and emit ``llm.call.response``."""
-        assert self._client is not None  # noqa: S101 - guarded by on_event.
+    def _rebuild_instance(self, inst: InstanceRow, ctx: KernelContext) -> None:
+        """Swap the per-instance client without closing the old pool.
+
+        Closing would tear down ``httpx`` out from under any
+        ``_dispatch`` currently awaiting ``chat.completions.create``
+        on the previous client (PR #105 follow-up #106, F1). The old
+        client is released to GC instead; its pool is reclaimed
+        asynchronously, bounded by rotations-per-process.
+        """
+        # Drop the reference first so a failing rebuild does not
+        # leave stale state routing under the instance id.
+        self._clients.pop(inst.id, None)
+        client = self._build_client(inst, ctx)
+        if client is not None:
+            self._clients[inst.id] = client
+
+    async def _dispatch(self, ev: Event, ctx: KernelContext, instance_id: str) -> None:
+        """Invoke chat completions and emit ``llm.call.response``.
+
+        Model selection is a live read against
+        :attr:`ctx.providers` so ``yaya config set providers.<id>.model
+        gpt-4.1`` takes effect on the next turn without a rebuild.
+        """
+        client = self._clients[instance_id]
+        model = self._resolve_model(ctx, instance_id, ev.payload)
         payload = ev.payload
-        model = str(payload.get("model", ""))
         messages = cast("list[dict[str, Any]]", payload.get("messages") or [])
         tools = payload.get("tools")
 
@@ -205,7 +290,7 @@ class OpenAIProvider:
         # The SDK typing union (ChatCompletion | AsyncStream[...]) widens
         # everything past this point to Any — that matches the tests'
         # stub-client pattern and the runtime shape we actually emit.
-        completion: Any = await self._client.chat.completions.create(**create_kwargs)  # pyright: ignore[reportUnknownVariableType]
+        completion: Any = await client.chat.completions.create(**create_kwargs)  # pyright: ignore[reportUnknownVariableType]
 
         choices_raw: Any = completion.choices or []  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         choices: list[Any] = list(choices_raw) if choices_raw else []  # pyright: ignore[reportUnknownArgumentType]
@@ -237,6 +322,27 @@ class OpenAIProvider:
             session_id=ev.session_id,
         )
 
+    @staticmethod
+    def _resolve_model(ctx: KernelContext, instance_id: str, payload: dict[str, Any]) -> str:
+        """Resolve the model to request against this instance.
+
+        Priority: instance config ``model`` → payload ``model`` →
+        hard-coded :data:`_DEFAULT_MODEL`. The payload read keeps
+        backwards-compat with agent loops that still thread the
+        strategy's ``model`` decision through ``llm.call.request``.
+        """
+        providers = ctx.providers
+        if providers is not None:
+            inst = providers.get_instance(instance_id)
+            if inst is not None:
+                raw = inst.config.get("model")
+                if isinstance(raw, str) and raw:
+                    return raw
+        payload_model = payload.get("model")
+        if isinstance(payload_model, str) and payload_model:
+            return payload_model
+        return _DEFAULT_MODEL
+
     async def _emit_error(
         self,
         ctx: KernelContext,
@@ -244,8 +350,8 @@ class OpenAIProvider:
         exc: BaseException,
     ) -> None:
         """Translate SDK errors into ``llm.call.error`` payloads."""
-        # Import lazily inside the error path so we only depend on the SDK
-        # types when an error actually happens.
+        # Import lazily inside the error path so we only depend on the
+        # SDK types when an error actually happens.
         payload: dict[str, Any] = {"error": str(exc), "request_id": ev.id}
         try:
             from openai import RateLimitError

--- a/src/yaya/plugins/strategy_react/AGENT.md
+++ b/src/yaya/plugins/strategy_react/AGENT.md
@@ -9,7 +9,7 @@ ReAct strategy plugin — observe → think → act. Drives `strategy.decide.req
 ## Constraints
 - `Category.STRATEGY`. Subscribes only to `strategy.decide.request`.
 - **Echo `request_id`** on every response (lesson #15). The loop's `_RequestTracker` drops uncorrelated events with a WARNING.
-- Hard-coded provider + model defaults (`openai` / `gpt-4o-mini`) — TODO to read `ctx.config` once registry P3 lands (the registry currently hands plugins an empty Mapping).
+- Provider + model resolution (D4b / #123): the `(provider, model)` pair comes from `ctx.providers.active_id` → `ctx.providers.get_instance(active_id).config["model"]`. Fallback (no providers view): env sniff over `OPENAI_API_KEY` → `llm-openai`/`gpt-4o-mini`, else `llm-echo`/`echo`. Fallback instance names mirror the D4a-seeded ids verbatim.
 - Pure-function core (`_decide`): no bus, no state — trivially unit-testable.
 - No third-party AI agent frameworks (AGENT.md §4). Stdlib + `yaya.kernel.*` only.
 

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -5,28 +5,39 @@ snapshot the loop hands it and picks the next step. It carries no
 per-session state of its own — the loop's ``state.messages`` +
 ``state.last_tool_result`` is the authoritative context, so repeated
 turns remain deterministic.
+
+After #123 (D4b) the ``(provider, model)`` pair is resolved per
+decision from :attr:`ctx.providers`: the active instance id comes
+from ``ctx.providers.active_id`` (the ``provider`` kernel-level
+config key), and the model is read live from that instance's
+``config["model"]`` field. Switching ``provider`` to a different
+instance id at runtime takes effect on the next
+``strategy.decide.request`` without a kernel restart. When
+``ctx.providers`` is absent (tests that skip the config store) the
+plugin falls back to an env sniff over ``OPENAI_API_KEY``.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from yaya.kernel.events import Event
 from yaya.kernel.plugin import Category, KernelContext
 
-# ``ctx.config`` is a live :class:`~yaya.kernel.config_store.ConfigView`
-# scoped to this plugin's namespace (``plugin.strategy_react.``), so
-# ``ctx.config["provider"]`` reflects the current ``ConfigStore``
-# value per decision — switching providers at runtime via
-# ``yaya config set plugin.strategy_react.provider anthropic`` takes
-# effect on the next ``strategy.decide.request`` without a restart.
-_DEFAULT_PROVIDER = "openai"
-_FALLBACK_PROVIDER = "echo"
+if TYPE_CHECKING:  # pragma: no cover - type-only import.
+    from yaya.kernel.providers import ProvidersView
+
+# Fallback provider ids used only when ``ctx.providers`` is absent.
+# They mirror the seeded instance ids the D4a bootstrap writes
+# (``providers.llm-openai.plugin = llm-openai`` etc.) so the fallback
+# name matches what a real kernel would resolve to.
+_FALLBACK_OPENAI_PROVIDER = "llm-openai"
+_FALLBACK_ECHO_PROVIDER = "llm-echo"
 _DEFAULT_MODEL = "gpt-4o-mini"
 # The bundled echo provider needs no model id — pick a stable
 # placeholder so the ``llm.call.request`` payload type-checks.
-_FALLBACK_MODEL = "echo"
+_FALLBACK_ECHO_MODEL = "echo"
 
 _NAME = "strategy-react"
 _VERSION = "0.1.0"
@@ -54,11 +65,7 @@ class ReActStrategy:
         return ["strategy.decide.request"]
 
     async def on_load(self, ctx: KernelContext) -> None:
-        """Log the effective configuration on boot.
-
-        Defaults are hard-coded here (see TODO above); swap to
-        ``ctx.config`` once registry P3 lands.
-        """
+        """Log the effective configuration on boot."""
         provider, model = self._provider_and_model(ctx)
         ctx.logger.debug(
             "strategy-react loaded (provider=%s model=%s)",
@@ -99,36 +106,52 @@ class ReActStrategy:
     def _provider_and_model(ctx: KernelContext) -> tuple[str, str]:
         """Return the effective ``(provider, model)`` pair.
 
-        Reads ``ctx.config`` first (for when registry P3 plumbs config),
-        then falls back to an env sniff so a fresh ``yaya serve`` with
-        no API key still round-trips through the bundled ``llm_echo``
-        dev provider. Resolution order:
+        Resolution order:
 
-        1. ``ctx.config["provider"]`` / ``["model"]`` if non-empty strings.
-        2. ``OPENAI_API_KEY`` set → ``("openai", "gpt-4o-mini")``.
-        3. Otherwise → ``("echo", "echo")`` so the bundled echo
-           provider answers the request.
-
-        TODO(#23): replace the env sniff with ``ctx.config`` once the
-        config-loading PR lands. Strategy plugins must not own
-        provider-selection policy long-term.
+        1. ``ctx.providers.active_id`` (the kernel-level ``provider``
+           key) → use that instance id and its ``config["model"]``.
+        2. When no active instance but at least one instance is
+           configured → first instance id, its ``config["model"]``.
+        3. No providers view at all (tests without a config store):
+           env sniff — ``OPENAI_API_KEY`` set → ``(llm-openai,
+           gpt-4o-mini)``, else ``(llm-echo, echo)``.
         """
-        cfg = ctx.config
-        provider_raw = cfg.get("provider") if cfg else None
-        model_raw = cfg.get("model") if cfg else None
-        if isinstance(provider_raw, str) and provider_raw:
-            provider = provider_raw
-        elif os.environ.get("OPENAI_API_KEY"):
-            provider = _DEFAULT_PROVIDER
-        else:
-            provider = _FALLBACK_PROVIDER
+        providers = ctx.providers
+        if providers is not None:
+            resolved = ReActStrategy._resolve_from_providers(providers)
+            if resolved is not None:
+                return resolved
+        # Fallback: no config store or no configured instance. Pick a
+        # seeded name matching what D4a bootstrap would stamp.
+        if os.environ.get("OPENAI_API_KEY"):
+            return _FALLBACK_OPENAI_PROVIDER, _DEFAULT_MODEL
+        return _FALLBACK_ECHO_PROVIDER, _FALLBACK_ECHO_MODEL
+
+    @staticmethod
+    def _resolve_from_providers(providers: ProvidersView) -> tuple[str, str] | None:
+        """Resolve ``(provider, model)`` from a live :class:`ProvidersView`.
+
+        Returns ``None`` when the view is empty — callers then fall
+        through to the env-driven fallback so a test stack without a
+        config store still lands on a deterministic pair.
+        """
+        active_id = providers.active_id
+        instance = None
+        if active_id is not None:
+            instance = providers.get_instance(active_id)
+        if instance is None:
+            all_instances = providers.list_instances()
+            if not all_instances:
+                return None
+            instance = all_instances[0]
+        model_raw = instance.config.get("model")
         if isinstance(model_raw, str) and model_raw:
             model = model_raw
-        elif provider == _FALLBACK_PROVIDER:
-            model = _FALLBACK_MODEL
+        elif instance.plugin == _FALLBACK_ECHO_PROVIDER:
+            model = _FALLBACK_ECHO_MODEL
         else:
             model = _DEFAULT_MODEL
-        return provider, model
+        return instance.id, model
 
 
 def _decide(state: dict[str, Any], *, provider: str, model: str) -> dict[str, Any]:

--- a/tests/bdd/features/instance-dispatch.feature
+++ b/tests/bdd/features/instance-dispatch.feature
@@ -1,0 +1,28 @@
+Feature: Instance-scoped LLM provider dispatch
+
+  The executable Gherkin mirror of specs/instance-dispatch.spec.
+
+  Scenario: AC-01 llm_openai builds one client per owned instance on load
+    Given a ConfigStore with two providers.<id> rows whose plugin meta equals llm-openai
+    When the plugin on_load runs against a KernelContext bound to that store
+    Then self._clients contains one AsyncOpenAI per instance id and unrelated instances are skipped
+
+  Scenario: AC-02 llm_openai dispatch filters by instance id against the owned-client dict
+    Given an llm_openai plugin holding a stub client under instance id prod
+    When a llm.call.request payload provider equals an unowned id
+    Then the plugin emits no llm.call.response and no llm.call.error
+
+  Scenario: AC-03 llm_echo answers only for owned instance ids
+    Given a llm_echo plugin with active instance set containing llm-echo
+    When a llm.call.request for a non-owned provider id is published
+    Then no llm.call.response event is emitted by the llm-echo plugin
+
+  Scenario: AC-04 strategy_react resolves model from the active instance config
+    Given a ConfigStore with provider set to instance-a whose config model field equals gpt-4.1
+    When strategy_react handles a strategy.decide.request
+    Then the emitted strategy.decide.response carries provider instance-a and model gpt-4.1
+
+  Scenario: AC-05 llm_openai rebuilds only the edited instance on providers.<id> config.updated
+    Given an llm_openai plugin with two seeded instances prod and azure
+    When providers.prod.base_url is updated and config.updated is delivered
+    Then only the prod client is rebuilt and the azure client instance remains the same object

--- a/tests/bdd/features/kernel-config-store.feature
+++ b/tests/bdd/features/kernel-config-store.feature
@@ -69,12 +69,12 @@ Feature: Kernel config store (live, hot-reload)
     When the caller sets a value that is not JSON-encodable
     Then the call raises TypeError
 
-  Scenario: AC-14 strategy_react hot-switches provider between decisions
-    Given ReActStrategy loaded against a live ConfigStore scoped view
-    When the operator flips plugin.strategy_react.provider between two strategy.decide.request events
-    Then the second strategy.decide.response carries the new provider name
+  Scenario: AC-14 strategy_react hot-switches active provider instance between decisions
+    Given ReActStrategy loaded against a live ConfigStore with two seeded provider instances
+    When the operator flips the kernel-level provider key between two strategy.decide.request events
+    Then the second strategy.decide.response carries the new instance id and its per-instance model
 
-  Scenario: AC-15 llm_openai rebuilds the client on config.updated
-    Given an OpenAIProvider loaded with a stubbed AsyncOpenAI and an initial base_url
-    When plugin.llm_openai.base_url is set to a new value and config.updated is delivered
-    Then the plugin rebuilds its client with the new base_url and non-matching keys do not rebuild
+  Scenario: AC-15 llm_openai rebuilds the per-instance client on providers.<id>.* config.updated
+    Given an OpenAIProvider loaded with a stubbed AsyncOpenAI and one seeded providers.<id> instance
+    When providers.<id>.base_url is set to a new value and config.updated is delivered
+    Then the plugin rebuilds only that instance's client with the new base_url and non-matching keys do not rebuild

--- a/tests/bdd/features/plugin-llm_openai.feature
+++ b/tests/bdd/features/plugin-llm_openai.feature
@@ -8,11 +8,11 @@ Feature: OpenAI LLM provider plugin
     Then the stubbed chat completions create method is called with the request model and messages
     And a llm.call.response event is emitted carrying text tool_calls usage and the originating request id
 
-  Scenario: Missing API key degrades to llm.call.error without crashing the kernel
+  Scenario: Missing API key and no configured instance leaves the request silent
     Given an llm-openai plugin loaded with no OPENAI_API_KEY environment variable
     When a llm.call.request for provider openai is published
-    Then a llm.call.error event is emitted with error not_configured
-    And the response echoes the originating request id
+    Then no llm.call.response event is emitted by the llm-openai plugin
+    And no llm.call.error event is emitted by the llm-openai plugin
 
   Scenario: Error path — unrelated provider id leaves the event uncommented by llm-openai
     Given a configured llm-openai plugin with a stubbed AsyncOpenAI client

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -88,7 +88,9 @@ def _configured_openai(
     stub_client = MagicMock()
     stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
     stub_client.close = AsyncMock(return_value=None)
-    plugin._client = stub_client
+    # D4b: instance-dispatch keyed by provider id. Register a stub
+    # client under the id the scenario will publish against.
+    plugin._clients["openai"] = stub_client
 
     async def handler(ev: Event) -> None:
         await plugin.on_event(ev, kernel_ctx)
@@ -130,10 +132,17 @@ def _unconfigured_openai(
         await plugin.on_event(ev, kernel_ctx)
 
     captured: list[Event] = []
+    errors: list[Event] = []
     bus.subscribe("llm.call.request", handler, source=plugin.name)
-    bus.subscribe("llm.call.error", lambda ev: _append_async(captured, ev), source="bdd")
+    bus.subscribe("llm.call.response", lambda ev: _append_async(captured, ev), source="bdd")
+    bus.subscribe("llm.call.error", lambda ev: _append_async(errors, ev), source="bdd")
     ctx.bus = bus
-    ctx.extras.update({"plugin": plugin, "kernel_ctx": kernel_ctx, "captured": captured})
+    ctx.extras.update({
+        "plugin": plugin,
+        "kernel_ctx": kernel_ctx,
+        "captured": captured,
+        "errors": errors,
+    })
 
 
 @given("a configured llm-openai plugin whose stubbed client raises a RateLimitError")
@@ -487,7 +496,8 @@ def _strategy_handles(
 def _strategy_next_llm(ctx: BDDContext) -> None:
     payload = _last_payload(ctx)
     assert payload["next"] == "llm"
-    assert payload["provider"] == "openai"
+    # D4b: fallback provider ids mirror the D4a-seeded instance names.
+    assert payload["provider"] == "llm-openai"
     assert payload["model"] == "gpt-4o-mini"
 
 

--- a/tests/kernel/test_strategy_hot_provider.py
+++ b/tests/kernel/test_strategy_hot_provider.py
@@ -1,10 +1,10 @@
-"""Zero-restart provider-switch proof for strategy_react (#104).
+"""Zero-restart provider-switch proof for strategy_react + llm_openai (#123).
 
-AC-14 from ``specs/kernel-config-store.spec``. Loads strategy_react
-against a live :class:`~yaya.kernel.config_store.ConfigStore`, drives
-two ``strategy.decide.request`` events back-to-back, and flips
-``plugin.strategy_react.provider`` between them — the emitted
-``llm.call.request`` events must name the two different providers.
+AC-14 / AC-15 from ``specs/kernel-config-store.spec``, flipped to the
+post-D4b ``providers.<id>.*`` namespace. Both tests load plugins
+against a live :class:`~yaya.kernel.config_store.ConfigStore` and
+drive the ``providers.<id>.*`` hot-reload path: instance-scoped
+config edits take effect on the next event with no kernel restart.
 """
 
 from __future__ import annotations
@@ -27,13 +27,33 @@ def _run(coro: object) -> object:
     return asyncio.run(coro)  # type: ignore[arg-type]
 
 
-def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
-    """AC-14: a ``yaya config set`` between decisions flips the emitted provider.
+def _ctx_with_providers(
+    bus: EventBus,
+    store: ConfigStore,
+    tmp_path: Path,
+    plugin_name: str,
+) -> KernelContext:
+    """Build a :class:`KernelContext` whose ``providers`` resolves through ``store``."""
+    ctx = KernelContext(
+        bus=bus,
+        logger=_NullLogger(),
+        config={},
+        state_dir=tmp_path / "state",
+        plugin_name=plugin_name,
+        config_store=store,
+    )
+    ctx.state_dir.mkdir(parents=True, exist_ok=True)
+    return ctx
 
-    Wires the real strategy plugin against a live config store scoped
-    view. Two decisions are triggered; between them we flip
-    ``plugin.strategy_react.provider``. The second decision's
-    ``strategy.decide.response`` carries the new provider name.
+
+def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
+    """AC-14 (D4b): flipping the active instance id between decisions flips the emitted provider.
+
+    Seeds two ``providers.<id>.*`` instances (``instance-a`` + ``instance-b``),
+    drives two ``strategy.decide.request`` events, and flips the
+    kernel-level ``provider`` key between them. The second
+    ``strategy.decide.response`` carries the second instance's id and
+    its ``config["model"]`` — live, without restarting the plugin.
     """
 
     async def _body() -> None:
@@ -47,22 +67,16 @@ def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
 
         bus.subscribe("strategy.decide.response", _sink, source="test-sink")
 
-        strategy = ReActStrategy()
-        # Scoped view — the registry would hand this to the plugin in
-        # production; we synthesise it here for a no-registry unit.
-        ctx = KernelContext(
-            bus=bus,
-            logger=_NullLogger(),
-            config=store.view(prefix="plugin.strategy_react."),
-            state_dir=tmp_path / "state",
-            plugin_name="strategy-react",
-        )
-        ctx.state_dir.mkdir(parents=True, exist_ok=True)
-        await strategy.on_load(ctx)
+        # Seed two provider instances.
+        await store.set("providers.instance-a.plugin", "llm-openai")
+        await store.set("providers.instance-a.model", "m-a")
+        await store.set("providers.instance-b.plugin", "llm-openai")
+        await store.set("providers.instance-b.model", "m-b")
+        await store.set("provider", "instance-a")
 
-        # Pin the initial provider via the live store.
-        await store.set("plugin.strategy_react.provider", "provider-a")
-        await store.set("plugin.strategy_react.model", "m-a")
+        strategy = ReActStrategy()
+        ctx = _ctx_with_providers(bus, store, tmp_path, "strategy-react")
+        await strategy.on_load(ctx)
 
         req1 = new_event(
             "strategy.decide.request",
@@ -73,9 +87,8 @@ def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
         await strategy.on_event(req1, ctx)
         await asyncio.sleep(0.05)
 
-        # Flip providers live — no restart.
-        await store.set("plugin.strategy_react.provider", "provider-b")
-        await store.set("plugin.strategy_react.model", "m-b")
+        # Hot-switch the active instance.
+        await store.set("provider", "instance-b")
 
         req2 = new_event(
             "strategy.decide.request",
@@ -89,9 +102,9 @@ def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
         responses = [ev for ev in captured if ev.kind == "strategy.decide.response"]
         assert len(responses) >= 2, f"expected 2 responses, got {responses!r}"
         first, second = responses[0], responses[1]
-        assert first.payload.get("provider") == "provider-a"
+        assert first.payload.get("provider") == "instance-a"
         assert first.payload.get("model") == "m-a"
-        assert second.payload.get("provider") == "provider-b"
+        assert second.payload.get("provider") == "instance-b"
         assert second.payload.get("model") == "m-b"
 
         await strategy.on_unload(ctx)
@@ -102,15 +115,14 @@ def test_hot_switch_provider_between_decisions(tmp_path: Path) -> None:
 
 
 def test_llm_openai_rebuilds_client_on_config_updated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC-15: llm_openai rebuilds its ``AsyncOpenAI`` client on hot config change.
+    """AC-15 (D4b): llm_openai rebuilds a per-instance client on ``providers.<id>.*`` edits.
 
-    A stubbed SDK constructor records every call; we set a new
-    ``plugin.llm_openai.base_url`` on the store and assert the plugin
-    re-instantiated with the new URL.
+    A stubbed ``AsyncOpenAI`` constructor records every call. Seeding
+    ``providers.prod.*`` with an initial ``base_url`` builds one
+    client at ``on_load``; overwriting ``providers.prod.base_url``
+    and delivering ``config.updated`` rebuilds only that instance.
+    Unrelated keys (``plugin.other.*``) must NOT rebuild.
     """
-    # The package ``__init__`` reexports ``plugin = OpenAIProvider()``
-    # which shadows the ``plugin`` submodule at the package level, so
-    # we import the class from its declaring module directly.
     from yaya.plugins.llm_openai.plugin import OpenAIProvider
 
     async def _body() -> None:
@@ -128,42 +140,33 @@ def test_llm_openai_rebuilds_client_on_config_updated(tmp_path: Path, monkeypatc
 
         monkeypatch.setattr("openai.AsyncOpenAI", _StubClient)
 
-        await store.set("plugin.llm_openai.api_key", "sk-first")
-        await store.set("plugin.llm_openai.base_url", "https://a.example")
+        # Seed one llm-openai instance.
+        await store.set("providers.prod.plugin", "llm-openai")
+        await store.set("providers.prod.api_key", "sk-first")
+        await store.set("providers.prod.base_url", "https://a.example")
 
         provider = OpenAIProvider()
-        ctx = KernelContext(
-            bus=bus,
-            logger=_NullLogger(),
-            config=store.view(prefix="plugin.llm_openai."),
-            state_dir=tmp_path / "state",
-            plugin_name="llm-openai",
-        )
-        ctx.state_dir.mkdir(parents=True, exist_ok=True)
+        ctx = _ctx_with_providers(bus, store, tmp_path, "llm-openai")
         await provider.on_load(ctx)
-        assert calls, "on_load should build the client once"
+        assert calls, "on_load should build one client per owned instance"
         assert calls[-1].get("base_url") == "https://a.example"
 
-        # Live config change — hot-reload path.
+        # Hot-edit the instance's base_url → expect a per-instance rebuild.
+        await store.set("providers.prod.base_url", "https://b.example")
         hot_event = new_event(
             "config.updated",
-            {"key": "plugin.llm_openai.base_url", "prefix_match_hint": "plugin.llm_openai."},
+            {"key": "providers.prod.base_url"},
             session_id="kernel",
             source="kernel-config-store",
         )
-        # The store's set() already emits config.updated on its own; we
-        # mutate the cache first so the scoped view surfaces the new
-        # value when the plugin's handler runs.
-        await store.set("plugin.llm_openai.base_url", "https://b.example")
         await provider.on_event(hot_event, ctx)
-        # The plugin should have rebuilt with the new URL.
         assert calls[-1].get("base_url") == "https://b.example"
 
-        # Non-matching key must NOT rebuild.
+        # Unrelated key → no rebuild.
         before = len(calls)
         unrelated = new_event(
             "config.updated",
-            {"key": "plugin.other.thing", "prefix_match_hint": "plugin.other."},
+            {"key": "plugin.other.thing"},
             session_id="kernel",
             source="kernel-config-store",
         )

--- a/tests/plugins/agent_tool/test_agent_tool_integration.py
+++ b/tests/plugins/agent_tool/test_agent_tool_integration.py
@@ -86,6 +86,10 @@ async def test_agent_tool_bus_reentry_end_to_end(tmp_path: Path) -> None:
     )
     (tmp_path / "echo").mkdir(parents=True, exist_ok=True)
     await echo.on_load(echo_ctx)
+    # No config store here → echo.on_load found zero owned instances.
+    # Seed the active set manually so the plugin answers for the
+    # `llm-echo` fallback id the strategy resolves to.
+    echo._active_instances.add("llm-echo")
 
     # Subscribe the two bundled plugins directly to the bus with
     # closures that carry the ctx the plugin needs at dispatch time.

--- a/tests/plugins/llm_echo/test_echo.py
+++ b/tests/plugins/llm_echo/test_echo.py
@@ -1,12 +1,14 @@
 """Tests for the echo LLM-provider plugin.
 
-AC-bindings from ``specs/plugin-llm_echo.spec``:
+AC-bindings from ``specs/plugin-llm_echo.spec`` and
+``specs/plugin-instance-dispatch.spec``:
 
 * AC-01 echo round-trip → ``test_echo_response_for_user_message``
 * filter           → ``test_non_matching_provider_is_ignored``
 * empty-messages   → ``test_empty_messages_returns_no_input_marker``
 * multi-turn       → ``test_echoes_only_last_user_message``
 * request_id echo  → ``test_request_id_matches_source_event``
+* instance dispatch → ``test_multi_instance_dispatch``
 """
 
 from __future__ import annotations
@@ -15,19 +17,32 @@ import logging
 from pathlib import Path
 
 from yaya.kernel.bus import EventBus
+from yaya.kernel.config_store import ConfigStore
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.plugin import KernelContext
 from yaya.plugins.llm_echo.plugin import EchoLLM
 
 
-def _make_ctx(bus: EventBus, tmp_path: Path, plugin: EchoLLM) -> KernelContext:
+def _make_ctx(
+    bus: EventBus,
+    tmp_path: Path,
+    plugin: EchoLLM,
+    *,
+    store: ConfigStore | None = None,
+) -> KernelContext:
     return KernelContext(
         bus=bus,
         logger=logging.getLogger("plugin.llm-echo"),
         config={},
         state_dir=tmp_path,
         plugin_name=plugin.name,
+        config_store=store,
     )
+
+
+async def _seed_echo_instance(store: ConfigStore, instance_id: str = "llm-echo") -> None:
+    """Write the minimal ``providers.<id>.plugin=llm-echo`` row."""
+    await store.set(f"providers.{instance_id}.plugin", "llm-echo")
 
 
 async def _drive(
@@ -36,50 +51,56 @@ async def _drive(
     *,
     response_kind: str = "llm.call.response",
     error_kind: str = "llm.call.error",
+    instance_id: str = "llm-echo",
 ) -> tuple[Event, list[Event], list[Event]]:
     """Publish one ``llm.call.request`` and return (request, responses, errors)."""
     plugin = EchoLLM()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await _seed_echo_instance(store, instance_id)
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    async def _handler(ev: Event) -> None:
-        await plugin.on_event(ev, ctx)
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
 
-    responses: list[Event] = []
-    errors: list[Event] = []
+        responses: list[Event] = []
+        errors: list[Event] = []
 
-    async def _r(ev: Event) -> None:
-        responses.append(ev)
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
 
-    async def _e(ev: Event) -> None:
-        errors.append(ev)
+        async def _e(ev: Event) -> None:
+            errors.append(ev)
 
-    bus.subscribe(response_kind, _r, source="observer")
-    bus.subscribe(error_kind, _e, source="observer")
+        bus.subscribe(response_kind, _r, source="observer")
+        bus.subscribe(error_kind, _e, source="observer")
 
-    req = new_event(
-        "llm.call.request",
-        # `new_event` accepts a strict TypedDict; the test feeds a plain
-        # dict literal. Casting per call would obscure each scenario's
-        # shape — narrow ignore is the lesser evil.
-        payload,  # type: ignore[arg-type]
-        session_id="sess-echo",
-        source="kernel",
-    )
-    await bus.publish(req)
-    await plugin.on_unload(ctx)
-    return req, responses, errors
+        req = new_event(
+            "llm.call.request",
+            # ``new_event`` accepts a strict TypedDict; the test feeds a plain
+            # dict literal. Casting per call would obscure each scenario's
+            # shape — narrow ignore is the lesser evil.
+            payload,  # type: ignore[arg-type]
+            session_id="sess-echo",
+            source="kernel",
+        )
+        await bus.publish(req)
+        await plugin.on_unload(ctx)
+        return req, responses, errors
+    finally:
+        await store.close()
 
 
 async def test_echo_response_for_user_message(tmp_path: Path) -> None:
-    """AC-01: provider=echo + user message → ``(echo) <message>`` response."""
+    """AC-01: provider=<echo-instance> + user message → ``(echo) <message>`` response."""
     req, responses, errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [{"role": "user", "content": "hello"}],
             "params": {},
@@ -99,7 +120,7 @@ async def test_non_matching_provider_is_ignored(tmp_path: Path) -> None:
     _req, responses, errors = await _drive(
         tmp_path,
         {
-            "provider": "openai",
+            "provider": "llm-openai",
             "model": "gpt-4o-mini",
             "messages": [{"role": "user", "content": "hi"}],
             "params": {},
@@ -114,7 +135,7 @@ async def test_empty_messages_returns_no_input_marker(tmp_path: Path) -> None:
     _req, responses, errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [],
             "params": {},
@@ -130,7 +151,7 @@ async def test_echoes_only_last_user_message(tmp_path: Path) -> None:
     _req, responses, _errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [
                 {"role": "user", "content": "first"},
@@ -149,7 +170,7 @@ async def test_request_id_matches_source_event(tmp_path: Path) -> None:
     req, responses, _errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [{"role": "user", "content": "ping"}],
             "params": {},
@@ -164,7 +185,7 @@ async def test_user_message_with_empty_content_returns_no_input(tmp_path: Path) 
     _req, responses, _errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [{"role": "user", "content": ""}],
             "params": {},
@@ -174,9 +195,11 @@ async def test_user_message_with_empty_content_returns_no_input(tmp_path: Path) 
     assert responses[0].payload["text"] == "(echo) (no input)"
 
 
-def test_subscriptions_returns_only_llm_call_request() -> None:
-    """The plugin advertises its single subscription kind."""
-    assert EchoLLM().subscriptions() == ["llm.call.request"]
+def test_subscriptions_returns_request_and_config_updated() -> None:
+    """The plugin advertises its subscription kinds including config.updated."""
+    subs = EchoLLM().subscriptions()
+    assert "llm.call.request" in subs
+    assert "config.updated" in subs
 
 
 async def test_non_list_messages_returns_no_input(tmp_path: Path) -> None:
@@ -184,7 +207,7 @@ async def test_non_list_messages_returns_no_input(tmp_path: Path) -> None:
     _req, responses, _errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": "not-a-list",  # malformed payload
             "params": {},
@@ -199,7 +222,7 @@ async def test_skips_non_dict_and_non_user_messages(tmp_path: Path) -> None:
     _req, responses, _errors = await _drive(
         tmp_path,
         {
-            "provider": "echo",
+            "provider": "llm-echo",
             "model": "echo",
             "messages": [
                 {"role": "system", "content": "ignored"},
@@ -218,22 +241,131 @@ async def test_non_request_event_kind_is_ignored(tmp_path: Path) -> None:
     """on_event must early-return on unrelated kinds (defence-in-depth)."""
     plugin = EchoLLM()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await _seed_echo_instance(store)
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    captured: list[Event] = []
+        captured: list[Event] = []
 
-    async def _r(ev: Event) -> None:
-        captured.append(ev)
+        async def _r(ev: Event) -> None:
+            captured.append(ev)
 
-    bus.subscribe("llm.call.response", _r, source="observer")
+        bus.subscribe("llm.call.response", _r, source="observer")
 
-    other = new_event(
-        "llm.call.response",
-        {"text": "x", "tool_calls": [], "usage": {}},
-        session_id="sess-other",
-        source="kernel",
-    )
-    await plugin.on_event(other, ctx)
-    assert captured == []
-    await plugin.on_unload(ctx)
+        other = new_event(
+            "llm.call.response",
+            {"text": "x", "tool_calls": [], "usage": {}},
+            session_id="sess-other",
+            source="kernel",
+        )
+        await plugin.on_event(other, ctx)
+        assert captured == []
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_multi_instance_dispatch(tmp_path: Path) -> None:
+    """Two echo instances → each instance id routes to this plugin independently."""
+    plugin = EchoLLM()
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.echo-a.plugin", "llm-echo")
+        await store.set("providers.echo-b.plugin", "llm-echo")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        assert plugin._active_instances == {"echo-a", "echo-b"}
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        responses: list[Event] = []
+
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
+
+        bus.subscribe("llm.call.response", _r, source="observer")
+        for pid in ("echo-a", "echo-b"):
+            await bus.publish(
+                new_event(
+                    "llm.call.request",
+                    {
+                        "provider": pid,
+                        "model": "echo",
+                        "messages": [{"role": "user", "content": pid}],
+                    },
+                    session_id=f"sess-{pid}",
+                    source="kernel",
+                )
+            )
+        texts = {ev.payload["text"] for ev in responses}
+        assert texts == {"(echo) echo-a", "(echo) echo-b"}
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_hot_reload_refreshes_active_instances(tmp_path: Path) -> None:
+    """Adding / removing a ``providers.<id>.plugin=llm-echo`` row updates the owned set."""
+    plugin = EchoLLM()
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        assert plugin._active_instances == set()
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("config.updated", _handler, source=plugin.name)
+
+        await store.set("providers.echo-new.plugin", "llm-echo")
+        assert "echo-new" in plugin._active_instances
+
+        await store.unset("providers.echo-new.plugin")
+        assert "echo-new" not in plugin._active_instances
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_config_updated_outside_providers_prefix_is_noop(tmp_path: Path) -> None:
+    """A ``config.updated`` whose key is outside ``providers.*`` does not trigger a refresh."""
+    plugin = EchoLLM()
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await _seed_echo_instance(store)
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        before = set(plugin._active_instances)
+
+        ev = new_event(
+            "config.updated",
+            {"key": "plugin.other.api_key", "prefix_match_hint": "plugin.other."},
+            session_id="kernel",
+            source="kernel-config-store",
+        )
+        await plugin.on_event(ev, ctx)
+        assert plugin._active_instances == before
+
+        # Non-string key — ignored silently.
+        empty = new_event(
+            "config.updated",
+            {"key": 12345, "prefix_match_hint": ""},  # type: ignore[dict-item]
+            session_id="kernel",
+            source="kernel-config-store",
+        )
+        await plugin.on_event(empty, ctx)
+        assert plugin._active_instances == before
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()

--- a/tests/plugins/llm_openai/test_llm_openai.py
+++ b/tests/plugins/llm_openai/test_llm_openai.py
@@ -1,15 +1,19 @@
 """Tests for the OpenAI LLM-provider plugin.
 
-AC-bindings from ``specs/plugin-llm_openai.spec``:
+AC-bindings from ``specs/plugin-llm_openai.spec`` and
+``specs/plugin-instance-dispatch.spec``:
 
 * success → ``test_successful_completion_emits_response``
-* missing key → ``test_missing_api_key_emits_not_configured_error``
+* missing key → ``test_missing_api_key_instance_is_not_owned``
 * filter → ``test_non_matching_provider_is_ignored``
 * rate limit → ``test_rate_limit_error_emits_error_event``
+* instance dispatch → ``test_two_instances_route_to_distinct_clients``
+* per-instance rebuild → ``test_config_updated_rebuilds_only_affected_instance``
+* add instance → ``test_adding_new_instance_lands_new_client``
+* remove instance → ``test_removing_instance_drops_client``
 
 Uses ``unittest.mock`` to stub ``openai.AsyncOpenAI`` so tests stay
-offline and deterministic. ``pytest-httpx`` is available but injecting
-a stub client is simpler than intercepting raw HTTP.
+offline and deterministic.
 """
 
 from __future__ import annotations
@@ -23,18 +27,31 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from yaya.kernel.bus import EventBus
+from yaya.kernel.config_store import ConfigStore
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.plugin import KernelContext
 from yaya.plugins.llm_openai.plugin import OpenAIProvider
 
 
-def _make_ctx(bus: EventBus, tmp_path: Path, plugin: OpenAIProvider) -> KernelContext:
+async def _make_store(tmp_path: Path, bus: EventBus) -> ConfigStore:
+    """Open a fresh :class:`ConfigStore` in a per-test directory."""
+    return await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+
+
+def _make_ctx(
+    bus: EventBus,
+    tmp_path: Path,
+    plugin: OpenAIProvider,
+    *,
+    store: ConfigStore | None = None,
+) -> KernelContext:
     return KernelContext(
         bus=bus,
         logger=logging.getLogger("plugin.llm-openai"),
         config={},
         state_dir=tmp_path,
         plugin_name=plugin.name,
+        config_store=store,
     )
 
 
@@ -51,228 +68,343 @@ def _fake_completion(
     return SimpleNamespace(choices=[choice], usage=usage)
 
 
+async def _seed_instance(
+    store: ConfigStore,
+    instance_id: str,
+    *,
+    plugin: str = "llm-openai",
+    api_key: str = "sk-test",
+    base_url: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Write a ``providers.<id>.*`` subtree under ``store``."""
+    await store.set(f"providers.{instance_id}.plugin", plugin)
+    await store.set(f"providers.{instance_id}.api_key", api_key)
+    if base_url is not None:
+        await store.set(f"providers.{instance_id}.base_url", base_url)
+    if model is not None:
+        await store.set(f"providers.{instance_id}.model", model)
+
+
 async def test_successful_completion_emits_response(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A successful chat completion emits llm.call.response with all fields."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test", model="gpt-4o-mini")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        # Swap the live client for a stub so we don't hit the network.
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
+        plugin._clients["llm-openai"] = stub_client
 
-    # Inject a stub client before on_event so we don't hit the network.
-    await plugin.on_load(ctx)
-    stub_client = MagicMock()
-    stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
-    stub_client.close = AsyncMock(return_value=None)
-    plugin._client = stub_client
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    async def _handler(ev: Event) -> None:
-        await plugin.on_event(ev, ctx)
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
 
-    bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        captured: list[Event] = []
 
-    captured: list[Event] = []
+        async def _observer(ev: Event) -> None:
+            captured.append(ev)
 
-    async def _observer(ev: Event) -> None:
-        captured.append(ev)
+        bus.subscribe("llm.call.response", _observer, source="observer")
 
-    bus.subscribe("llm.call.response", _observer, source="observer")
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "params": {},
+            },
+            session_id="sess-openai-ok",
+            source="kernel",
+        )
+        await bus.publish(req)
 
-    req = new_event(
-        "llm.call.request",
-        {
-            "provider": "openai",
-            "model": "gpt-4o-mini",
-            "messages": [{"role": "user", "content": "hi"}],
-            "params": {},
-        },
-        session_id="sess-openai-ok",
-        source="kernel",
-    )
-    await bus.publish(req)
+        stub_client.chat.completions.create.assert_awaited_once()
+        kwargs = stub_client.chat.completions.create.await_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"
+        assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
 
-    stub_client.chat.completions.create.assert_awaited_once()
-    kwargs = stub_client.chat.completions.create.await_args.kwargs
-    assert kwargs["model"] == "gpt-4o-mini"
-    assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+        assert len(captured) == 1
+        payload = captured[0].payload
+        assert payload["text"] == "hi there"
+        assert payload["tool_calls"] == []
+        assert payload["usage"] == {"input_tokens": 7, "output_tokens": 3}
+        assert payload["request_id"] == req.id
 
-    assert len(captured) == 1
-    payload = captured[0].payload
-    assert payload["text"] == "hi there"
-    assert payload["tool_calls"] == []
-    assert payload["usage"] == {"input_tokens": 7, "output_tokens": 3}
-    assert payload["request_id"] == req.id
-
-    await plugin.on_unload(ctx)
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
-async def test_missing_api_key_emits_not_configured_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """With no API key, every request emits not_configured error."""
+async def test_missing_api_key_instance_is_not_owned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Instance with no api_key (and no env) is skipped; requests naming it fall through silently."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await _make_store(tmp_path, bus)
+    try:
+        # Instance declared but no api_key and no env — skipped.
+        await store.set("providers.llm-openai.plugin", "llm-openai")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    async def _handler(ev: Event) -> None:
-        await plugin.on_event(ev, ctx)
+        assert plugin._clients == {}
 
-    bus.subscribe("llm.call.request", _handler, source=plugin.name)
-    captured: list[Event] = []
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    async def _observer(ev: Event) -> None:
-        captured.append(ev)
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        responses: list[Event] = []
+        errors: list[Event] = []
 
-    bus.subscribe("llm.call.error", _observer, source="observer")
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
 
-    req = new_event(
-        "llm.call.request",
-        {
-            "provider": "openai",
-            "model": "gpt-4o-mini",
-            "messages": [],
-            "params": {},
-        },
-        session_id="sess-noauth",
-        source="kernel",
-    )
-    await bus.publish(req)
+        async def _e(ev: Event) -> None:
+            errors.append(ev)
 
-    assert len(captured) == 1
-    payload = captured[0].payload
-    assert payload["error"] == "not_configured"
-    assert payload["request_id"] == req.id
+        bus.subscribe("llm.call.response", _r, source="observer")
+        bus.subscribe("llm.call.error", _e, source="observer")
 
-    await plugin.on_unload(ctx)
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [],
+                "params": {},
+            },
+            session_id="sess-noauth",
+            source="kernel",
+        )
+        await bus.publish(req)
+
+        # Plugin did not answer — unowned instances fall through.
+        assert responses == []
+        assert errors == []
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
 async def test_non_matching_provider_is_ignored(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A request for a sibling provider does not emit any event from llm-openai."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    stub_client = MagicMock()
-    stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
-    stub_client.close = AsyncMock(return_value=None)
-    plugin._client = stub_client
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
+        plugin._clients["llm-openai"] = stub_client
 
-    async def _handler(ev: Event) -> None:
-        await plugin.on_event(ev, ctx)
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    bus.subscribe("llm.call.request", _handler, source=plugin.name)
-    responses: list[Event] = []
-    errors: list[Event] = []
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        responses: list[Event] = []
+        errors: list[Event] = []
 
-    async def _r(ev: Event) -> None:
-        responses.append(ev)
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
 
-    async def _e(ev: Event) -> None:
-        errors.append(ev)
+        async def _e(ev: Event) -> None:
+            errors.append(ev)
 
-    bus.subscribe("llm.call.response", _r, source="observer")
-    bus.subscribe("llm.call.error", _e, source="observer")
+        bus.subscribe("llm.call.response", _r, source="observer")
+        bus.subscribe("llm.call.error", _e, source="observer")
 
-    await bus.publish(
-        new_event(
-            "llm.call.request",
-            {
-                "provider": "anthropic",
-                "model": "claude-3-5",
-                "messages": [],
-                "params": {},
-            },
-            session_id="sess-anthropic",
-            source="kernel",
+        await bus.publish(
+            new_event(
+                "llm.call.request",
+                {
+                    "provider": "anthropic",
+                    "model": "claude-3-5",
+                    "messages": [],
+                    "params": {},
+                },
+                session_id="sess-anthropic",
+                source="kernel",
+            )
         )
-    )
 
-    assert responses == []
-    assert errors == []
-    stub_client.chat.completions.create.assert_not_called()
+        assert responses == []
+        assert errors == []
+        stub_client.chat.completions.create.assert_not_called()
 
-    await plugin.on_unload(ctx)
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
 async def test_rate_limit_error_emits_error_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """An SDK RateLimitError surfaces as llm.call.error with str(exc) + request_id.
-
-    We build the SDK's real ``RateLimitError`` from a 429 response so
-    the ``isinstance(exc, RateLimitError)`` branch in ``_emit_error``
-    runs. If a future SDK minor version tightens the constructor and
-    this construction breaks, fall back to ``side_effect=Exception(
-    "rate limited")`` — the plugin translates any exception to
-    ``llm.call.error`` regardless of subclass.
-    """
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    """An SDK RateLimitError surfaces as llm.call.error with str(exc) + request_id."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
     import httpx
     import openai
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    rate_limit_exc = openai.RateLimitError(
-        message="rate limited",
-        response=httpx.Response(429, request=httpx.Request("POST", "http://x")),
-        body=None,
-    )
+        rate_limit_exc = openai.RateLimitError(
+            message="rate limited",
+            response=httpx.Response(429, request=httpx.Request("POST", "http://x")),
+            body=None,
+        )
 
-    stub_client = MagicMock()
-    stub_client.chat.completions.create = AsyncMock(side_effect=rate_limit_exc)
-    stub_client.close = AsyncMock(return_value=None)
-    plugin._client = stub_client
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = AsyncMock(side_effect=rate_limit_exc)
+        plugin._clients["llm-openai"] = stub_client
 
-    async def _handler(ev: Event) -> None:
-        await plugin.on_event(ev, ctx)
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    bus.subscribe("llm.call.request", _handler, source=plugin.name)
-    captured: list[Event] = []
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        captured: list[Event] = []
 
-    async def _observer(ev: Event) -> None:
-        captured.append(ev)
+        async def _observer(ev: Event) -> None:
+            captured.append(ev)
 
-    bus.subscribe("llm.call.error", _observer, source="observer")
+        bus.subscribe("llm.call.error", _observer, source="observer")
 
-    req = new_event(
-        "llm.call.request",
-        {
-            "provider": "openai",
-            "model": "gpt-4o-mini",
-            "messages": [],
-            "params": {},
-        },
-        session_id="sess-ratelimit",
-        source="kernel",
-    )
-    await bus.publish(req)
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [],
+                "params": {},
+            },
+            session_id="sess-ratelimit",
+            source="kernel",
+        )
+        await bus.publish(req)
 
-    assert len(captured) == 1
-    payload = captured[0].payload
-    assert "rate limited" in payload["error"]
-    assert payload["request_id"] == req.id
+        assert len(captured) == 1
+        payload = captured[0].payload
+        assert "rate limited" in payload["error"]
+        assert payload["request_id"] == req.id
 
-    await plugin.on_unload(ctx)
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
-async def test_config_updated_rebuilds_on_matching_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A ``config.updated`` for ``plugin.llm_openai.base_url`` rebuilds the client."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+async def test_two_instances_route_to_distinct_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC-01: two llm-openai instances with distinct base_url each route their own traffic."""
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
-
-    calls: list[dict[str, Any]] = []
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     class _StubSDK:
         def __init__(self, **kwargs: Any) -> None:
-            calls.append(kwargs)
+            self._kwargs = kwargs
+            self._base = kwargs.get("base_url", "<default>")
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=AsyncMock(return_value=_fake_completion(text=f"from {self._base}")),
+                ),
+            )
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _StubSDK)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a", base_url="https://a.example", model="gpt-a")
+        await _seed_instance(store, "openai-b", api_key="sk-b", base_url="https://b.example", model="gpt-b")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        assert set(plugin._clients) == {"openai-a", "openai-b"}
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+        responses: list[Event] = []
+
+        async def _observer(ev: Event) -> None:
+            responses.append(ev)
+
+        bus.subscribe("llm.call.response", _observer, source="observer")
+
+        await bus.publish(
+            new_event(
+                "llm.call.request",
+                {
+                    "provider": "openai-a",
+                    "model": "ignored",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                session_id="sess-a",
+                source="kernel",
+            )
+        )
+        await bus.publish(
+            new_event(
+                "llm.call.request",
+                {
+                    "provider": "openai-b",
+                    "model": "ignored",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                session_id="sess-b",
+                source="kernel",
+            )
+        )
+
+        assert len(responses) == 2
+        # Each client stub embedded its own base_url in the response text.
+        texts = {ev.payload["text"] for ev in responses}
+        assert texts == {"from https://a.example", "from https://b.example"}
+        # Each client's create() was called with its own instance-configured model.
+        models_called = {call.kwargs["model"] for call in _model_calls(plugin)}
+        assert models_called == {"gpt-a", "gpt-b"}
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+def _model_calls(plugin: OpenAIProvider) -> list[Any]:
+    """Return every ``chat.completions.create`` await-args across all owned clients."""
+    out: list[Any] = []
+    for client in plugin._clients.values():
+        mock = client.chat.completions.create  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        out.extend(mock.await_args_list)
+    return out
+
+
+async def test_config_updated_rebuilds_only_affected_instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC-03: ``config.updated`` on ``providers.B.api_key`` rebuilds only client B."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    class _StubSDK:
+        def __init__(self, **_: Any) -> None:
+            return None
 
         async def close(self) -> None:
             return None
@@ -281,56 +413,143 @@ async def test_config_updated_rebuilds_on_matching_key(tmp_path: Path, monkeypat
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
-    built_once = len(calls)
-    assert built_once == 1
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a")
+        await _seed_instance(store, "openai-b", api_key="sk-b")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    ev = new_event(
-        "config.updated",
-        {"key": "plugin.llm_openai.base_url", "prefix_match_hint": "plugin.llm_openai."},
-        session_id="kernel",
-        source="kernel-config-store",
-    )
-    await plugin.on_event(ev, ctx)
-    assert len(calls) == built_once + 1
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    # Non-matching suffix — e.g. a sibling key like ``plugin.llm_openai.model`` —
-    # does NOT rebuild the client.
-    unrelated = new_event(
-        "config.updated",
-        {"key": "plugin.llm_openai.model", "prefix_match_hint": "plugin.llm_openai."},
-        session_id="kernel",
-        source="kernel-config-store",
-    )
-    await plugin.on_event(unrelated, ctx)
-    assert len(calls) == built_once + 1
+        bus.subscribe("config.updated", _handler, source=plugin.name)
 
-    # Entirely foreign namespace — no rebuild.
-    foreign = new_event(
-        "config.updated",
-        {"key": "plugin.other.base_url", "prefix_match_hint": "plugin.other."},
-        session_id="kernel",
-        source="kernel-config-store",
-    )
-    await plugin.on_event(foreign, ctx)
-    assert len(calls) == built_once + 1
+        client_a_before = plugin._clients["openai-a"]
+        client_b_before = plugin._clients["openai-b"]
 
-    # Payload without a key — ignored silently.
-    empty = new_event(
-        "config.updated",
-        {"key": 12345, "prefix_match_hint": ""},  # type: ignore[dict-item]
-        session_id="kernel",
-        source="kernel-config-store",
-    )
-    await plugin.on_event(empty, ctx)
-    assert len(calls) == built_once + 1
+        await store.set("providers.openai-b.api_key", "sk-b-rotated")
 
-    await plugin.on_unload(ctx)
+        assert plugin._clients["openai-a"] is client_a_before
+        assert plugin._clients["openai-b"] is not client_b_before
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_adding_new_instance_lands_new_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC-04: adding ``providers.C.plugin=llm-openai`` materialises a new client."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    class _StubSDK:
+        def __init__(self, **_: Any) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _StubSDK)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("config.updated", _handler, source=plugin.name)
+        assert set(plugin._clients) == {"openai-a"}
+
+        # Stage a new instance: api_key first, then plugin meta.
+        await store.set("providers.openai-c.api_key", "sk-c")
+        # api_key alone with no plugin meta → not owned.
+        assert "openai-c" not in plugin._clients
+        await store.set("providers.openai-c.plugin", "llm-openai")
+        # Now owned — the hot-reload path added it.
+        assert "openai-c" in plugin._clients
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_removing_instance_drops_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC-05: deleting an instance's plugin meta drops its client."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    class _StubSDK:
+        def __init__(self, **_: Any) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _StubSDK)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("config.updated", _handler, source=plugin.name)
+        assert "openai-a" in plugin._clients
+
+        await store.unset("providers.openai-a.plugin")
+        assert "openai-a" not in plugin._clients
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_repointing_instance_plugin_meta_drops_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-pointing ``providers.<id>.plugin`` away from this plugin drops the client."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    class _StubSDK:
+        def __init__(self, **_: Any) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _StubSDK)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("config.updated", _handler, source=plugin.name)
+        assert "openai-a" in plugin._clients
+
+        await store.set("providers.openai-a.plugin", "llm-other")
+        assert "openai-a" not in plugin._clients
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
 async def test_base_url_env_lands_on_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``OPENAI_BASE_URL`` is threaded into the SDK constructor when ctx.config is empty."""
+    """``OPENAI_BASE_URL`` is threaded into the SDK constructor when the instance omits it."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://env.example")
 
@@ -347,23 +566,99 @@ async def test_base_url_env_lands_on_client(tmp_path: Path, monkeypatch: pytest.
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
-    assert calls
-    assert calls[-1].get("base_url") == "https://env.example"
-    await plugin.on_unload(ctx)
+    store = await _make_store(tmp_path, bus)
+    try:
+        # api_key absent from instance but OPENAI_API_KEY is set; base_url absent
+        # from instance but OPENAI_BASE_URL is set.
+        await store.set("providers.llm-openai.plugin", "llm-openai")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        assert calls
+        assert calls[-1].get("base_url") == "https://env.example"
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
-async def test_llm_openai_hot_reload_preserves_in_flight_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A rebuild must NOT close the previous client's pool.
+async def test_subscribes_to_config_updated() -> None:
+    """The plugin declares a subscription to ``config.updated`` for hot reload."""
+    plugin = OpenAIProvider()
+    assert "config.updated" in plugin.subscriptions()
+    assert "llm.call.request" in plugin.subscriptions()
 
-    Regression guard for PR #105 follow-up #106 (F1): closing the
-    existing :class:`AsyncOpenAI` instance inside ``_rebuild_client``
-    tears down the ``httpx`` pool out from under any ``_dispatch``
-    currently awaiting ``chat.completions.create``. Dropping the
-    ``await existing.close()`` keeps the in-flight call healthy; the
-    pool is reclaimed on GC.
-    """
+
+async def test_legacy_plugin_keys_emit_warning_when_no_instance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A stale ``plugin.llm_openai.*`` row with no owned instance emits a legacy-key hint."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await store.set("plugin.llm_openai.api_key", "sk-legacy")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        caplog.set_level(logging.WARNING, logger="plugin.llm-openai")
+        await plugin.on_load(ctx)
+        messages = " ".join(record.getMessage() for record in caplog.records)
+        assert "legacy plugin.llm_openai.*" in messages
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_config_updated_ignores_non_providers_keys(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``config.updated`` whose key is outside ``providers.*`` is ignored."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    class _StubSDK:
+        def __init__(self, **_: Any) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr("openai.AsyncOpenAI", _StubSDK)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "openai-a", api_key="sk-a")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+        client_before = plugin._clients["openai-a"]
+
+        # ``providers.`` with no instance id — ignored.
+        ev_malformed = new_event(
+            "config.updated",
+            {"key": "providers.", "prefix_match_hint": "providers."},
+            session_id="kernel",
+            source="kernel-config-store",
+        )
+        await plugin.on_event(ev_malformed, ctx)
+        assert plugin._clients["openai-a"] is client_before
+
+        # Non-string key — ignored silently.
+        empty = new_event(
+            "config.updated",
+            {"key": 12345, "prefix_match_hint": ""},  # type: ignore[dict-item]
+            session_id="kernel",
+            source="kernel-config-store",
+        )
+        await plugin.on_event(empty, ctx)
+        assert plugin._clients["openai-a"] is client_before
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_hot_reload_preserves_in_flight_call(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rebuild must NOT close the previous client's pool (regression: #106 F1)."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
 
@@ -378,36 +673,34 @@ async def test_llm_openai_hot_reload_preserves_in_flight_call(tmp_path: Path, mo
 
     plugin = OpenAIProvider()
     bus = EventBus()
-    ctx = _make_ctx(bus, tmp_path, plugin)
-    await plugin.on_load(ctx)
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-real")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
 
-    # Swap the live client for a mock whose ``close()`` must never be
-    # awaited — if it were, the in-flight ``_dispatch`` would observe
-    # a dead pool.
-    never_close = MagicMock()
-    never_close.close = AsyncMock()
-    plugin._client = never_close
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
 
-    ev = new_event(
-        "config.updated",
-        {"key": "plugin.llm_openai.base_url", "prefix_match_hint": "plugin.llm_openai."},
-        session_id="kernel",
-        source="kernel-config-store",
-    )
-    await plugin.on_event(ev, ctx)
-    never_close.close.assert_not_awaited()
-    # A rebuild still produces a working new client.
-    assert plugin._client is not None
-    assert plugin._client is not never_close
-    await plugin.on_unload(ctx)
+        bus.subscribe("config.updated", _handler, source=plugin.name)
+
+        # Swap in a mock whose close() must never be awaited — if it
+        # were, an in-flight dispatch would observe a dead pool.
+        never_close = MagicMock()
+        never_close.close = AsyncMock()
+        plugin._clients["llm-openai"] = never_close
+
+        await store.set("providers.llm-openai.base_url", "https://new.example")
+        never_close.close.assert_not_awaited()
+        assert plugin._clients["llm-openai"] is not never_close
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
-async def test_subscribes_to_config_updated(tmp_path: Path) -> None:
-    """The plugin declares a subscription to ``config.updated`` for hot reload."""
+async def test_on_unload_tolerates_missing_clients(tmp_path: Path) -> None:
+    """Calling on_unload on a never-loaded plugin is a no-op."""
     plugin = OpenAIProvider()
-    assert "config.updated" in plugin.subscriptions()
-    assert "llm.call.request" in plugin.subscriptions()
-
-
-def _silence(_: Any) -> None:  # pragma: no cover - placeholder to keep Any imported.
-    return None
+    bus = EventBus()
+    ctx = _make_ctx(bus, tmp_path, plugin)
+    await plugin.on_unload(ctx)

--- a/tests/plugins/strategy_react/test_provider_selection.py
+++ b/tests/plugins/strategy_react/test_provider_selection.py
@@ -63,20 +63,21 @@ async def _drive_first_turn(tmp_path: Path) -> Event:
 
 
 async def test_picks_echo_when_no_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """No ``OPENAI_API_KEY`` → strategy falls back to the echo dev provider."""
+    """No ``OPENAI_API_KEY`` → strategy falls back to the ``llm-echo`` dev instance name."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     response = await _drive_first_turn(tmp_path)
     payload = response.payload
     assert payload["next"] == "llm"
-    assert payload["provider"] == "echo"
+    # D4b: fallback provider ids mirror the D4a-seeded instance names.
+    assert payload["provider"] == "llm-echo"
     assert payload["model"] == "echo"
 
 
 async def test_picks_openai_when_api_key_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``OPENAI_API_KEY`` present → strategy picks the openai provider."""
+    """``OPENAI_API_KEY`` present → strategy picks the ``llm-openai`` fallback instance."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     response = await _drive_first_turn(tmp_path)
     payload = response.payload
     assert payload["next"] == "llm"
-    assert payload["provider"] == "openai"
+    assert payload["provider"] == "llm-openai"
     assert payload["model"] == "gpt-4o-mini"

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -1,12 +1,14 @@
 """Tests for the ReAct strategy plugin.
 
-AC-bindings from ``specs/plugin-strategy_react.spec``:
+AC-bindings from ``specs/plugin-strategy_react.spec`` and
+``specs/plugin-instance-dispatch.spec``:
 
 * no assistant yet → ``test_no_assistant_yet_returns_llm``
 * pending tool_calls → ``test_assistant_with_tool_calls_returns_tool``
 * after tool result → ``test_after_tool_result_returns_llm``
 * assistant done → ``test_assistant_without_tool_calls_returns_done``
 * missing state → ``test_missing_state_raises``
+* model from instance → ``test_provider_and_model_reads_instance_config``
 """
 
 from __future__ import annotations
@@ -18,18 +20,26 @@ from typing import Any
 import pytest
 
 from yaya.kernel.bus import EventBus
+from yaya.kernel.config_store import ConfigStore
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.plugin import KernelContext
 from yaya.plugins.strategy_react import plugin as react_plugin
+from yaya.plugins.strategy_react.plugin import ReActStrategy
 
 
-def _make_ctx(bus: EventBus, tmp_path: Path) -> KernelContext:
+def _make_ctx(
+    bus: EventBus,
+    tmp_path: Path,
+    *,
+    store: ConfigStore | None = None,
+) -> KernelContext:
     return KernelContext(
         bus=bus,
         logger=logging.getLogger("plugin.strategy-react"),
         config={},
         state_dir=tmp_path,
         plugin_name=react_plugin.name,
+        config_store=store,
     )
 
 
@@ -40,9 +50,10 @@ async def _drive(
     payload: dict[str, Any],
     *,
     session_id: str,
+    store: ConfigStore | None = None,
 ) -> list[Event]:
     """Publish one strategy.decide.request and return the captured responses."""
-    ctx = _make_ctx(bus, tmp_path)
+    ctx = _make_ctx(bus, tmp_path, store=store)
     await plugin.on_load(ctx)
 
     async def _handler(ev: Event) -> None:
@@ -70,9 +81,9 @@ async def _drive(
 async def test_no_assistant_yet_returns_llm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """No assistant message → llm with provider + model + request_id.
 
-    Pins ``OPENAI_API_KEY`` so the strategy's env-sniff fallback (see
-    ``_provider_and_model``) resolves to the configured ``openai``
-    branch rather than the ``echo`` dev fallback.
+    Pins ``OPENAI_API_KEY`` so the strategy's env-sniff fallback (used
+    when ``ctx.providers`` is absent) resolves to the ``llm-openai``
+    branch.
     """
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     bus = EventBus()
@@ -86,7 +97,7 @@ async def test_no_assistant_yet_returns_llm(tmp_path: Path, monkeypatch: pytest.
     assert len(captured) == 1
     got = captured[0].payload
     assert got["next"] == "llm"
-    assert got["provider"] == "openai"
+    assert got["provider"] == "llm-openai"
     assert got["model"] == "gpt-4o-mini"
     assert "request_id" in got
 
@@ -176,3 +187,85 @@ async def test_missing_state_raises(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="state"):
         await react_plugin.on_event(req, ctx)
+
+
+async def test_provider_and_model_reads_instance_config(tmp_path: Path) -> None:
+    """AC-06: strategy reads ``model`` from the active instance's config."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.prod.plugin", "llm-openai")
+        await store.set("providers.prod.model", "gpt-4.1")
+        await store.set("provider", "prod")
+
+        ctx = _make_ctx(bus, tmp_path, store=store)
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert provider == "prod"
+        assert model == "gpt-4.1"
+    finally:
+        await store.close()
+
+
+async def test_provider_and_model_switches_on_active_change(tmp_path: Path) -> None:
+    """AC-02: flipping ``provider`` routes the next decision to the new instance."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.a.plugin", "llm-openai")
+        await store.set("providers.a.model", "gpt-a")
+        await store.set("providers.b.plugin", "llm-openai")
+        await store.set("providers.b.model", "gpt-b")
+        await store.set("provider", "a")
+
+        ctx = _make_ctx(bus, tmp_path, store=store)
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert (provider, model) == ("a", "gpt-a")
+
+        await store.set("provider", "b")
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert (provider, model) == ("b", "gpt-b")
+    finally:
+        await store.close()
+
+
+async def test_provider_and_model_falls_back_to_first_instance(tmp_path: Path) -> None:
+    """When ``provider`` is unset but instances exist, fall back to the first."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.only.plugin", "llm-openai")
+        await store.set("providers.only.model", "gpt-only")
+        ctx = _make_ctx(bus, tmp_path, store=store)
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert (provider, model) == ("only", "gpt-only")
+    finally:
+        await store.close()
+
+
+async def test_provider_and_model_echo_instance_gets_echo_model(tmp_path: Path) -> None:
+    """An echo-backed instance with no explicit model falls through to ``echo``."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.local-echo.plugin", "llm-echo")
+        await store.set("provider", "local-echo")
+        ctx = _make_ctx(bus, tmp_path, store=store)
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert (provider, model) == ("local-echo", "echo")
+    finally:
+        await store.close()
+
+
+async def test_provider_and_model_unknown_active_falls_back_to_first(tmp_path: Path) -> None:
+    """An ``active_id`` that does not resolve to an instance falls back to the first."""
+    bus = EventBus()
+    store = await ConfigStore.open(bus=bus, path=tmp_path / "config.db")
+    try:
+        await store.set("providers.only.plugin", "llm-openai")
+        await store.set("providers.only.model", "gpt-only")
+        await store.set("provider", "missing-id")
+        ctx = _make_ctx(bus, tmp_path, store=store)
+        provider, model = ReActStrategy._provider_and_model(ctx)
+        assert (provider, model) == ("only", "gpt-only")
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary
- Flip `llm_openai` and `llm_echo` to **instance-scoped dispatch**: one plugin process backs many configured records under `providers.<id>.*`. Dispatch filters `ev.payload["provider"]` (an *instance id*) against each plugin's owned set.
- Hot-reload per instance: `config.updated` on `providers.<id>.*` rebuilds only that instance's client; adding a new instance materialises a new client; re-pointing `plugin` meta or deleting the row drops it. Zero kernel / plugin restarts.
- `strategy_react` resolves `(provider, model)` from `ctx.providers.active_id` → `get_instance(...).config["model"]`. Env-sniff fallback uses the D4a-seeded instance names (`llm-openai` / `llm-echo`) verbatim.
- Legacy `plugin.<ns>.*` reads removed. D4a's bootstrap lift (#116) keeps existing keys live as `providers.<name>.*` rows on first upgrade.
- New owning spec `specs/instance-dispatch.spec` + mirror feature; `plugin-llm_openai.spec` and `kernel-config-store.spec` AC-14/AC-15 updated to match D4b semantics; plugin `AGENT.md` files and `docs/dev/plugin-protocol.md` dispatch pattern snippet updated.

## Per-plugin checklist
- [x] `llm_openai`: `self._clients: dict[str, AsyncOpenAI]` built from `ctx.providers.instances_for_plugin(self.name)`; dispatch filters by instance id; per-instance hot-reload on `providers.<id>.*`; no `await close()` on rebuild (preserves #106 fix); model read live from instance config.
- [x] `llm_echo`: `self._active_instances: set[str]` refreshed on `config.updated` under `providers.*`; dispatch filters on membership.
- [x] `strategy_react`: `_provider_and_model` reads `active_id` + instance model; env fallback mirrors D4a-seeded instance names.

## Integration / hot-reload tests
- [x] `tests/kernel/test_strategy_hot_provider.py::test_hot_switch_provider_between_decisions` — seeds two `providers.<id>` rows, flips `provider` key mid-loop, asserts second response carries the new instance id + its `model`.
- [x] `tests/kernel/test_strategy_hot_provider.py::test_llm_openai_rebuilds_client_on_config_updated` — one seeded instance, `providers.<id>.base_url` edit + `config.updated` rebuilds only that client; unrelated keys do not rebuild.
- [x] `tests/plugins/llm_openai/test_llm_openai.py` (15 tests): two-instance dispatch routing, add / remove / re-point lifecycle, per-instance rebuild isolation, env fallback, rate-limit error translation.
- [x] `tests/plugins/agent_tool/test_agent_tool_integration.py::test_agent_tool_bus_reentry_end_to_end` — full `AgentLoop + ReActStrategy + EchoLLM` round-trip via the new dispatch shape.

## Test plan
- [x] `just check` green (ruff + mypy + agent-spec lifecycle + feature-sync; owning spec `instance-dispatch.spec` passes boundary hard-fail).
- [x] `just test` green: **715 passed**, 0 failed.
- [x] Coverage gates: global 93.65% / kernel 95.05% / plugins/llm_openai 84.44% (floor 79.5%) / plugins/llm_echo 100% / plugins/strategy_react 95.35% — all ok.
- [ ] `gh pr checks --watch` green.

Closes #123

Spec: specs/instance-dispatch.spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)