### PR TITLE
feat(plugins/web): sidebar + hero density to match kimi (#135)

### DIFF
--- a/src/yaya/plugins/web/src/app.css
+++ b/src/yaya/plugins/web/src/app.css
@@ -236,7 +236,7 @@ yaya-app {
 	min-width: 32px;
 	min-height: 32px;
 	padding: 4px 8px;
-	border-radius: 6px;
+	border-radius: var(--yaya-radius-md);
 }
 
 .yaya-sidebar-toggle:hover {
@@ -301,14 +301,15 @@ yaya-app {
 	align-items: center;
 	gap: 10px;
 	width: 100%;
-	padding: 8px 10px;
+	min-height: 36px;
+	padding: 8px 12px;
 	background: transparent;
 	border: 0;
 	color: var(--yaya-text-primary);
 	font-size: 14px;
 	text-align: left;
 	cursor: pointer;
-	border-radius: 8px;
+	border-radius: var(--yaya-radius-md);
 }
 
 .yaya-new-chat {
@@ -377,9 +378,9 @@ yaya-app {
 	color: var(--yaya-text-primary);
 	cursor: pointer;
 	font-size: 14px;
-	padding: 6px 8px;
-	border-radius: 8px;
-	min-height: 32px;
+	padding: 6px 10px;
+	border-radius: var(--yaya-radius-md);
+	min-height: 36px;
 }
 
 .yaya-sidebar-settings:hover {
@@ -409,21 +410,21 @@ yaya-app {
 }
 
 .yaya-hero-title {
-	font-size: 48px;
+	font-size: 56px;
 	font-weight: 700;
-	letter-spacing: -0.02em;
+	letter-spacing: -0.025em;
 	color: var(--yaya-text-primary);
 }
 
 .yaya-hero-sub {
 	color: var(--yaya-text-secondary);
-	font-size: 15px;
+	font-size: 16px;
 }
 
 .yaya-chips {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
+	gap: 10px;
 	margin-top: 16px;
 	justify-content: center;
 }
@@ -474,7 +475,7 @@ yaya-app {
 	padding: 8px 14px;
 	cursor: pointer;
 	color: var(--yaya-text-secondary);
-	border-bottom: 2px solid transparent;
+	border-bottom: 3px solid transparent;
 	font-size: 14px;
 }
 
@@ -576,7 +577,7 @@ yaya-app {
 	font-size: 13px;
 	padding: 4px 6px;
 	min-height: 32px;
-	border-radius: 6px;
+	border-radius: var(--yaya-radius-md);
 }
 
 .yaya-link:hover {
@@ -743,7 +744,7 @@ yaya-app {
 
 .yaya-reveal {
 	border: 1px solid var(--yaya-border);
-	border-radius: 4px;
+	border-radius: var(--yaya-radius-sm);
 	padding: 4px 8px;
 	background: var(--yaya-main-bg);
 	color: var(--yaya-text-secondary);
@@ -871,7 +872,7 @@ yaya-settings-modal {
 	line-height: 1;
 	cursor: pointer;
 	padding: 4px 8px;
-	border-radius: 6px;
+	border-radius: var(--yaya-radius-md);
 }
 
 .yaya-settings-dialog-close:hover {


### PR DESCRIPTION
## Summary
Final PR of the 3-part kimi.com visual alignment stack (after #132 tokens and #134 components). Layout-only tweaks:

- **Sidebar rows** (`nav-item`, `history-item`, `new-chat`, `sidebar-settings`): `min-height` 32→36, padding 8/10→8/12, radius 8→`--yaya-radius-md`. Collapsed-rail mode still pinned at 32px via the existing `is-collapsed` override.
- **Hero**: title 48→56px, letter-spacing -0.02→-0.025. Sub-hero 15→16. Chips gap 8→10.
- **Settings tabs**: active underline 2→3px so the KMBlue indicator reads as primary nav.
- **Small-radii normalization**: sidebar-toggle / link / settings-dialog-close 6px→`--yaya-radius-md`; reveal 4px→`--yaya-radius-sm`.

## Test plan
- [x] `just check && just test` green (766 tests, all per-module coverage gates pass)
- [ ] Visual smoke: larger hero title; sidebar rows visibly taller with breathing room; collapsed-rail unchanged; focus halos still fire inside the taller inputs

Closes #135