### PR TITLE
refactor(plugins/strategy_react): rewrite as real ReAct (#151)

### DIFF
--- a/specs/plugin-strategy_react.spec
+++ b/specs/plugin-strategy_react.spec
@@ -19,21 +19,29 @@ testable and deterministic.
   `strategy.decide.response` per request, echoing the originating
   event's `id` back as `request_id` so the loop's `_RequestTracker`
   can correlate.
-- When the most-recent assistant message carries a non-empty
-  `tool_calls` list, the decision is `{"next": "tool", "tool_call":
-  <first>}`; the kernel runs tool calls sequentially, so only the
-  first is surfaced per turn.
+- Implements classical ReAct (Yao et al. 2022): the strategy injects a
+  system prompt via `messages_prepend` that constrains the LLM to emit
+  either a `Thought: ... Action: <tool> Action Input: <json>` triple or
+  a `Thought: ... Final Answer: <text>` termination. Tool intent rides
+  in free-form assistant text; the strategy does not consume
+  `assistant.tool_calls`.
+- When the most-recent assistant message parses to a valid Action, the
+  decision is `{"next": "tool", "tool_call": {"id", "name", "args"}}`
+  with a synthesized id; only the first Action per turn is surfaced.
+- When the most-recent assistant message parses to a Final Answer the
+  decision is `{"next": "done"}`.
 - When no assistant message has been produced yet on the turn, the
   decision is `{"next": "llm", "provider": <configured>, "model":
-  <configured>}` using the hardcoded `openai` / `gpt-4o-mini`
-  defaults — `ctx.config` is consulted first for when registry P3
-  plumbs per-plugin config.
-- When the most-recent assistant message exists and has no pending
-  tool_calls AND no unconsumed tool result, the turn ends with
-  `{"next": "done"}`.
-- After a tool result lands, the decision loops back to
-  `{"next": "llm", ...}` so the LLM can read the tool output and
-  continue the turn.
+  <configured>, "messages_prepend": [<ReAct system prompt>]}`.
+- After any message lands on top of the last assistant message (an
+  Observation appended by the loop, for example), the decision loops
+  back to `{"next": "llm", ...}` so the LLM can read the observation
+  and continue the turn.
+- When the assistant message fails to parse into either shape, the
+  strategy appends one corrective `role="user"` nudge (marked with
+  `[yaya:react-format-nudge] `) via `messages_append` and re-rolls.
+  A second consecutive parse failure terminates the turn with
+  `{"next": "done"}` — no endless retries.
 
 ## Boundaries
 
@@ -68,32 +76,32 @@ Scenario: No assistant message yet decides next step is llm with configured prov
   Then a strategy.decide.response is emitted with next llm and the configured provider and model
   And the response echoes the originating request id
 
-Scenario: Pending tool_calls on the assistant message decide next step is tool with first tool call
+Scenario: Assistant message with a well-formed Action decides next step is tool with the parsed tool_call
   Test:
     Package: yaya
-    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_assistant_with_tool_calls_returns_tool
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_assistant_with_react_action_returns_tool
   Level: unit
-  Given a strategy.decide.request whose last assistant message carries a non-empty tool_calls list
+  Given a strategy.decide.request whose last assistant message contains a ReAct Action and Action Input
   When the ReAct plugin handles the event
-  Then a strategy.decide.response is emitted with next tool and the first pending tool_call payload
+  Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
   And the response echoes the originating request id
 
-Scenario: Tool result just landed decides next step loops back to llm for another pass
+Scenario: Observation follows the last assistant message so the next step loops back to llm
   Test:
     Package: yaya
-    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_after_tool_result_returns_llm
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_post_observation_returns_llm
   Level: unit
-  Given a strategy.decide.request whose last_tool_result is populated after an assistant step
+  Given a strategy.decide.request whose state has an Observation user message after the last assistant message
   When the ReAct plugin handles the event
   Then a strategy.decide.response is emitted with next llm and the configured provider and model
   And the response echoes the originating request id
 
-Scenario: Assistant message without tool_calls or pending tool result decides next step is done
+Scenario: Assistant message with a Final Answer label decides next step is done
   Test:
     Package: yaya
-    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_assistant_without_tool_calls_returns_done
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_assistant_with_final_answer_returns_done
   Level: unit
-  Given a strategy.decide.request whose last assistant message has no tool_calls and no pending tool result
+  Given a strategy.decide.request whose last assistant message contains a Final Answer label
   When the ReAct plugin handles the event
   Then a strategy.decide.response is emitted with next done
   And the response echoes the originating request id

--- a/src/yaya/kernel/loop.py
+++ b/src/yaya/kernel/loop.py
@@ -119,13 +119,14 @@ _SOURCE = "kernel"
 
 
 def _format_tool_result_for_llm(result_payload: dict[str, Any]) -> str:
-    """Serialise a ``tool.call.result`` payload for an OpenAI ``tool`` message.
+    """Serialise a ``tool.call.result`` payload for a ReAct Observation.
 
-    OpenAI's ``role: "tool"`` message expects a plain ``content``
-    string. We prefer a compact structured JSON so the model can parse
-    fields (stdout / stderr / error) reliably, but fall back to the
-    stdout-only shape when the tool returned a flat ``value`` that
-    already reads well as text.
+    The caller wraps the returned string as
+    ``role="user" content="Observation: <this>"`` before appending it
+    to the conversation. We prefer compact structured JSON so the
+    model can parse fields (stdout / stderr / error) reliably, but
+    fall back to the stdout-only shape when the tool returned a flat
+    ``value`` that already reads well as text.
     """
     import json
 

--- a/src/yaya/kernel/loop.py
+++ b/src/yaya/kernel/loop.py
@@ -104,7 +104,7 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 from yaya.kernel.bus import EventBus, Subscription
-from yaya.kernel.events import Event, Message, ToolCall, new_event
+from yaya.kernel.events import Event, Message, new_event
 from yaya.kernel.payload import (
     payload_dict,
     payload_int,
@@ -398,7 +398,19 @@ class AgentLoop:
             state.last_tool_result = {"memory_hits": hits}
             return False
         if next_step == "llm":
-            response = await self._call_llm(session_id, decision, state.messages)
+            # A strategy may append corrective or priming messages to
+            # ``state.messages`` before the LLM call (e.g. ReAct's
+            # format-nudge on a parse failure). Apply those first so
+            # the outgoing history reflects them.
+            for m in payload_list_of_dicts(decision.payload, "messages_append"):
+                state.messages.append(cast("Message", m))
+            # ``messages_prepend`` carries transient priming context
+            # (e.g. ReAct's system prompt) that the strategy does NOT
+            # want persisted in ``state.messages``. It rides only on
+            # this single request.
+            prepend = payload_list_of_dicts(decision.payload, "messages_prepend")
+            outgoing: list[Message] = [cast("Message", m) for m in prepend] + list(state.messages)
+            response = await self._call_llm(session_id, decision, outgoing)
             if response.kind == "llm.call.error":
                 await self._emit_kernel_error(
                     session_id,
@@ -407,42 +419,36 @@ class AgentLoop:
                 return True
             state.last_llm_text = payload_str(response.payload, "text") or state.last_llm_text
             state.last_tool_calls = payload_list_of_dicts(response.payload, "tool_calls")
-            # The LLM has now consumed any pending tool or memory
-            # result; clear it so the next strategy decision doesn't
-            # loop forever treating the stale result as "still pending"
-            # (#147).
+            # Clear any pending tool/memory result now that the LLM
+            # has had a chance to consume it (#147).
             state.last_tool_result = None
-            # Preserve tool_calls on the appended message so the strategy
-            # (and any memory plugin replaying messages) can see the
-            # LLM's function-call intent — not just the reasoning text.
-            # Without this the assistant entry only carried ``content``
-            # and the strategy decided ``done`` even when the LLM had
-            # emitted a tool_call (#147).
+            # ReAct strategy drives tool intent through free-form
+            # ``Thought: / Action: / Action Input:`` text inside the
+            # assistant ``content``, not through OpenAI's structured
+            # ``tool_calls`` field. Persisting ``tool_calls`` here
+            # would confuse a text-only replay, so the appended
+            # assistant message carries ``content`` only.
             assistant_msg: Message = {
                 "role": "assistant",
                 "content": state.last_llm_text,
             }
-            if state.last_tool_calls:
-                assistant_msg["tool_calls"] = [cast("ToolCall", tc) for tc in state.last_tool_calls]
             state.messages.append(assistant_msg)
             return False
         if next_step == "tool":
             tool_call = payload_dict(decision.payload, "tool_call")
             result = await self._call_tool(session_id, tool_call)
             state.last_tool_result = dict(result.payload)
-            # Append an OpenAI-style tool message so the next LLM call
-            # sees the tool's output. ``name`` is optional per the
-            # OpenAI spec but MiniMax-M2 and similar providers fall
-            # silent on turn 2 without it (#149).
-            tool_call_id = str(tool_call.get("id", ""))
-            tool_name = str(tool_call.get("name", ""))
+            # ReAct protocol: tool results come back as a ``role="user"``
+            # message whose content begins with ``Observation:`` — the
+            # canonical ReAct shape the system prompt tells the model
+            # to expect. No ``role="tool"`` / ``tool_call_id`` — those
+            # belong to OpenAI function calling, which we no longer
+            # use here.
+            observation = _format_tool_result_for_llm(result.payload)
             tool_msg: Message = {
-                "role": "tool",
-                "tool_call_id": tool_call_id,
-                "content": _format_tool_result_for_llm(result.payload),
+                "role": "user",
+                "content": f"Observation: {observation}",
             }
-            if tool_name:
-                tool_msg["name"] = tool_name
             state.messages.append(tool_msg)
             return False
         await self._emit_kernel_error(

--- a/src/yaya/plugins/strategy_react/AGENT.md
+++ b/src/yaya/plugins/strategy_react/AGENT.md
@@ -14,11 +14,13 @@ ReAct strategy plugin — observe → think → act. Drives `strategy.decide.req
 - No third-party AI agent frameworks (AGENT.md §4). Stdlib + `yaya.kernel.*` only.
 
 ## Interaction (patterns)
+- Classical ReAct (Yao et al. 2022): the strategy injects a system prompt via `decision.messages_prepend` constraining the LLM to emit `Thought: / Action: / Action Input: <json>` triples or `Thought: / Final Answer: <text>` termination. Tool intent rides in free-form assistant text; `assistant.tool_calls` is **not** consumed.
 - Next-step rules (evaluated top-down):
-  1. Most-recent assistant msg carries `tool_calls` → `{"next": "tool", "tool_call": <first>}`.
-  2. Assistant msg exists without tool_calls, no pending tool result → `{"next": "done"}`.
-  3. Assistant just consumed a tool result → `{"next": "llm", provider, model}` for another pass.
-  4. No assistant msg yet → `{"next": "llm", provider, model}`.
+  1. No assistant msg yet → `{"next": "llm", provider, model, messages_prepend: [system ReAct prompt]}`.
+  2. Any message lands after the last assistant (e.g. `role=user content="Observation: ..."` appended by the loop) → `{"next": "llm", ...}` for another pass.
+  3. Last assistant parses to a valid Action → `{"next": "tool", "tool_call": {"id": "rx-<step>", "name", "args"}}`.
+  4. Last assistant parses to a Final Answer → `{"next": "done"}`.
+  5. Parse failure → append one `[yaya:react-format-nudge] ` corrective user msg via `messages_append` and re-roll. A second consecutive failure terminates with `{"next": "done"}`.
 - Do NOT emit `memory.*` requests from this strategy at 0.1 — memory is out of scope for the seed ReAct.
 - Do NOT keep per-session state here; the loop's `state` snapshot is the source of truth.
 

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -1,25 +1,34 @@
-"""ReAct strategy plugin implementation.
+"""ReAct strategy plugin — text-based Thought/Action/Observation loop.
 
-The strategy inspects the :class:`yaya.kernel.events.AgentLoopState`
-snapshot the loop hands it and picks the next step. It carries no
-per-session state of its own — the loop's ``state.messages`` +
-``state.last_tool_result`` is the authoritative context, so repeated
-turns remain deterministic.
+Classical ReAct (Yao et al. 2022): the strategy authors a system
+prompt that constrains the LLM to emit either
+``Thought: ... Action: <tool> Action Input: <json>`` triples or a
+``Thought: ... Final Answer: <user-facing text>`` termination. The
+strategy parses the assistant's latest content for one of those two
+shapes:
 
-After #123 (D4b) the ``(provider, model)`` pair is resolved per
-decision from :attr:`ctx.providers`: the active instance id comes
-from ``ctx.providers.active_id`` (the ``provider`` kernel-level
-config key), and the model is read live from that instance's
-``config["model"]`` field. Switching ``provider`` to a different
-instance id at runtime takes effect on the next
-``strategy.decide.request`` without a kernel restart. When
-``ctx.providers`` is absent (tests that skip the config store) the
-plugin falls back to an env sniff over ``OPENAI_API_KEY``.
+* A valid Action → ``{next: "tool"}`` with a synthesized tool_call.
+* A Final Answer → ``{next: "done"}``.
+* Neither → append one corrective ``role="user"`` nudge and reroll.
+  A second parse failure terminates the turn (no endless retries).
+
+Unlike the previous function-calling implementation, this strategy
+does **not** consume ``assistant.tool_calls`` — tool intent rides in
+free-form text only. Tool results come back as ``role="user"``
+messages whose content starts with ``Observation: …`` (the canonical
+ReAct shape). The loop assembles that shape; this module just reads
+it.
+
+Provider / model resolution is unchanged from D4b: active instance
+id + its ``config["model"]`` from :attr:`ctx.providers`, falling
+back to an env sniff when no config store is wired in.
 """
 
 from __future__ import annotations
 
+import json
 import os
+import re
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from yaya.kernel.events import Event
@@ -29,32 +38,44 @@ from yaya.kernel.tool import all_tool_specs
 if TYPE_CHECKING:  # pragma: no cover - type-only import.
     from yaya.kernel.providers import ProvidersView
 
-# Fallback provider ids used only when ``ctx.providers`` is absent.
-# They mirror the seeded instance ids the D4a bootstrap writes
-# (``providers.llm-openai.plugin = llm-openai`` etc.) so the fallback
-# name matches what a real kernel would resolve to.
 _FALLBACK_OPENAI_PROVIDER = "llm-openai"
 _FALLBACK_ECHO_PROVIDER = "llm-echo"
 _DEFAULT_MODEL = "gpt-4o-mini"
-# The bundled echo provider needs no model id — pick a stable
-# placeholder so the ``llm.call.request`` payload type-checks.
 _FALLBACK_ECHO_MODEL = "echo"
 
 _NAME = "strategy-react"
 _VERSION = "0.1.0"
 
+# Marker prefix on the corrective user message. The strategy scans
+# recent messages for this marker to detect whether we've already
+# used our one retry — presence means "don't nudge again, terminate".
+_RETRY_MARKER = "[yaya:react-format-nudge] "
+
+# Regexes for ReAct labels. Anchored with ``re.MULTILINE`` so each
+# label sits at the start of its own line, matching the prompt the
+# strategy authors. ``DOTALL`` on ``Final Answer`` / ``Action Input``
+# lets them span paragraphs.
+_FINAL_RE = re.compile(
+    r"^Final Answer:\s*(?P<answer>.+?)(?:\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_ACTION_RE = re.compile(
+    r"^Action:\s*(?P<name>[^\n]+?)\s*$",
+    re.MULTILINE,
+)
+_ACTION_INPUT_RE = re.compile(
+    r"^Action Input:\s*(?P<body>.*?)(?=^Action:|^Final Answer:|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+# Strip ``` ```json ... ``` ``` fences that some models wrap JSON in.
+_CODE_FENCE_RE = re.compile(
+    r"^```(?:json)?\s*(?P<inner>.*?)\s*```\s*\Z",
+    re.DOTALL,
+)
+
 
 class ReActStrategy:
-    """Bundled ReAct strategy plugin.
-
-    Implements :class:`yaya.kernel.plugin.Plugin` via duck typing — the
-    protocol is ``@runtime_checkable`` so the registry's ``isinstance``
-    guard accepts any object with the required attributes and methods.
-
-    Thread model: single asyncio event loop. The plugin keeps no
-    mutable state across events; every decision is computed from the
-    incoming ``state`` snapshot.
-    """
+    """Bundled ReAct strategy plugin."""
 
     name: str = _NAME
     version: str = _VERSION
@@ -75,30 +96,15 @@ class ReActStrategy:
         )
 
     async def on_event(self, ev: Event, ctx: KernelContext) -> None:
-        """Decide the next step for the turn described by ``ev.payload.state``.
-
-        The loop always publishes ``strategy.decide.request`` with a
-        ``state`` key (see ``yaya.kernel.loop.AgentLoop._decide``); a
-        request missing that key is a protocol violation and raises so
-        the registry's failure accounting surfaces a ``plugin.error``.
-        """
+        """Decide the next step for the turn described by ``ev.payload.state``."""
         if ev.kind != "strategy.decide.request":
             return
         raw_state = ev.payload.get("state")
         if not isinstance(raw_state, dict):
-            # Protocol violation: the loop always publishes with a 'state' key.
             raise ValueError("strategy.decide.request missing 'state' payload")  # noqa: TRY004
 
         provider, model = self._provider_and_model(ctx)
         decision = _decide(cast("dict[str, Any]", raw_state), provider=provider, model=model)
-        # Stamp the loaded tool specs onto every LLM-step decision so
-        # the kernel loop can forward them to the provider. Without
-        # this the LLM has no tool schemas and falls back to
-        # hallucinating command output as plain text (#147).
-        if decision.get("next") == "llm":
-            specs = all_tool_specs()
-            if specs:
-                decision["tools"] = specs
         decision["request_id"] = ev.id
         await ctx.emit(
             "strategy.decide.response",
@@ -109,41 +115,21 @@ class ReActStrategy:
     async def on_unload(self, ctx: KernelContext) -> None:
         """No-op — the strategy holds no resources."""
 
-    # -- helpers --------------------------------------------------------------
-
     @staticmethod
     def _provider_and_model(ctx: KernelContext) -> tuple[str, str]:
-        """Return the effective ``(provider, model)`` pair.
-
-        Resolution order:
-
-        1. ``ctx.providers.active_id`` (the kernel-level ``provider``
-           key) → use that instance id and its ``config["model"]``.
-        2. When no active instance but at least one instance is
-           configured → first instance id, its ``config["model"]``.
-        3. No providers view at all (tests without a config store):
-           env sniff — ``OPENAI_API_KEY`` set → ``(llm-openai,
-           gpt-4o-mini)``, else ``(llm-echo, echo)``.
-        """
+        """Return the effective ``(provider, model)`` pair."""
         providers = ctx.providers
         if providers is not None:
             resolved = ReActStrategy._resolve_from_providers(providers)
             if resolved is not None:
                 return resolved
-        # Fallback: no config store or no configured instance. Pick a
-        # seeded name matching what D4a bootstrap would stamp.
         if os.environ.get("OPENAI_API_KEY"):
             return _FALLBACK_OPENAI_PROVIDER, _DEFAULT_MODEL
         return _FALLBACK_ECHO_PROVIDER, _FALLBACK_ECHO_MODEL
 
     @staticmethod
     def _resolve_from_providers(providers: ProvidersView) -> tuple[str, str] | None:
-        """Resolve ``(provider, model)`` from a live :class:`ProvidersView`.
-
-        Returns ``None`` when the view is empty — callers then fall
-        through to the env-driven fallback so a test stack without a
-        config store still lands on a deterministic pair.
-        """
+        """Resolve ``(provider, model)`` from a live :class:`ProvidersView`."""
         active_id = providers.active_id
         instance = None
         if active_id is not None:
@@ -163,105 +149,203 @@ class ReActStrategy:
         return instance.id, model
 
 
-def _next_pending_tool_call(
-    messages: list[dict[str, Any]],
-    last_assistant: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Return the first tool_call on ``last_assistant`` without a tool reply.
-
-    Walks the messages after ``last_assistant`` and collects the
-    ``tool_call_id``s that already carry a ``role="tool"`` response.
-    Any tool_call whose id is NOT in that set is still pending — we
-    return the first such entry so the loop dispatches it next.
-    Without this pairing the strategy would re-dispatch the first
-    tool_call on every iteration and hit ``max_iterations_exceeded``
-    after a single bash call (#147).
-    """
-    tool_calls_raw: Any = last_assistant.get("tool_calls")
-    if not isinstance(tool_calls_raw, list) or not tool_calls_raw:
-        return None
-    assistant_idx = next(i for i, m in enumerate(messages) if m is last_assistant)
-    satisfied: set[str] = set()
-    for m in messages[assistant_idx + 1 :]:
-        if m.get("role") == "tool":
-            satisfied.add(str(m.get("tool_call_id") or ""))
-    # Iterate the narrowed list. After the isinstance check above
-    # mypy sees ``list[Any]`` and happily reads entries as ``Any``;
-    # pyright keeps the element type unknown so we cast inside the
-    # loop before use.
-    for entry in tool_calls_raw:  # pyright: ignore[reportUnknownVariableType]
-        if not isinstance(entry, dict):
-            continue
-        tc = cast("dict[str, Any]", entry)
-        tc_id = str(tc.get("id") or "")
-        if tc_id and tc_id in satisfied:
-            continue
-        return tc
-    return None
+# ---------------------------------------------------------------------------
+# Pure decision function.
+# ---------------------------------------------------------------------------
 
 
 def _decide(state: dict[str, Any], *, provider: str, model: str) -> dict[str, Any]:
     """Compute the next step from a loop state snapshot.
 
-    Pure function so it is trivially unit-testable without a bus.
-
-    Args:
-        state: The ``AgentLoopState`` dict from ``strategy.decide.request``.
-        provider: Configured LLM provider id (e.g. ``"openai"``).
-        model: Configured model string.
-
-    Returns:
-        A decision payload (less ``request_id``, which the caller adds)
-        per ``docs/dev/plugin-protocol.md``. ``next`` is one of
-        ``"llm" | "tool" | "done"``. Memory steps are not emitted by
-        this seed strategy — the loop supports them, but ReAct 0.1 does
-        not use them.
+    See module docstring for the ReAct protocol this function
+    implements. The caller (``on_event``) stamps ``request_id`` on
+    the returned payload before emitting — this stays pure for
+    testing.
     """
     messages_raw: list[Any] = list(state.get("messages") or [])
     messages: list[dict[str, Any]] = [cast("dict[str, Any]", m) for m in messages_raw if isinstance(m, dict)]
 
-    last_tool_result = state.get("last_tool_result")
-
-    # Find the most recent assistant message (if any).
     last_assistant: dict[str, Any] | None = None
-    for msg in reversed(messages):
+    last_assistant_idx: int = -1
+    for i, msg in enumerate(messages):
         if msg.get("role") == "assistant":
             last_assistant = msg
-            break
+            last_assistant_idx = i
 
-    # A tool just ran → feed its result back into the LLM for another pass.
-    if last_tool_result is not None and last_assistant is None:
-        # Shouldn't happen (we always have an assistant turn before a
-        # tool call), but defensively ask the LLM to interpret it.
-        return {"next": "llm", "provider": provider, "model": model}
+    # First turn — nothing to parse yet.
+    if last_assistant is None:
+        return _llm_decision(provider, model)
 
-    # Find any pending tool_calls on the last assistant message that
-    # have not yet produced a ``role="tool"`` reply further down the
-    # message list. Without this pairing step the strategy would
-    # repeatedly invoke the first tool_call — even after its result
-    # was already appended — and hit ``max_iterations_exceeded`` on
-    # the very first bash call (#147).
-    if last_assistant is not None:
-        pending = _next_pending_tool_call(messages, last_assistant)
-        if pending is not None:
-            return {"next": "tool", "tool_call": pending}
-        tool_calls_raw: Any = last_assistant.get("tool_calls")
-        if isinstance(tool_calls_raw, list) and tool_calls_raw:
-            # Every tool_call has a tool reply → push the results
-            # back to the LLM for summarisation or chaining.
-            return {"next": "llm", "provider": provider, "model": model}
-        # Assistant finished and has nothing to run → done.
-        if last_tool_result is None:
-            return {"next": "done"}
-        # Non-tool source (e.g. memory) surfaced a result without
-        # touching ``tool_calls`` — give the LLM a chance to consume
-        # it. Tool results coming from the loop's tool path clear
-        # ``last_tool_result`` after the follow-up LLM call so this
-        # branch doesn't loop forever.
-        return {"next": "llm", "provider": provider, "model": model}
+    # There are messages after the last assistant (e.g. an Observation
+    # appended by the loop after a tool call). The assistant already
+    # produced its action and has nothing more to say yet — hand back
+    # to the LLM for the next Thought/Action or Final Answer.
+    if last_assistant_idx < len(messages) - 1:
+        return _llm_decision(provider, model)
 
-    # No assistant message yet → ask the LLM.
-    return {"next": "llm", "provider": provider, "model": model}
+    # Parse the assistant's most recent message.
+    content = last_assistant.get("content") or ""
+    if not isinstance(content, str):
+        content = str(content)
+    parsed = _parse_assistant(content)
+
+    if parsed[0] == "final":
+        return {"next": "done"}
+
+    if parsed[0] == "action":
+        _, name, args = parsed
+        step = int(state.get("step") or 0)
+        return {
+            "next": "tool",
+            "tool_call": {
+                "id": f"rx-{step}",
+                "name": str(name),
+                "args": cast("dict[str, Any]", args),
+            },
+        }
+
+    # Parse error. Decide whether we've already nudged once.
+    if _has_recent_retry_marker(messages):
+        # Second failure in a row — give up without spinning the loop.
+        return {"next": "done"}
+
+    reason = str(parsed[1]) if len(parsed) >= 2 else "unparsable response"
+    nudge = (
+        f"{_RETRY_MARKER}Your last message did not follow the ReAct format. "
+        f"{reason}. Please resend using either "
+        "'Thought: ...\\nAction: <tool>\\nAction Input: <json>' "
+        "or 'Thought: ...\\nFinal Answer: <your reply>'."
+    )
+    return {
+        **_llm_decision(provider, model),
+        "messages_append": [{"role": "user", "content": nudge}],
+    }
+
+
+def _llm_decision(provider: str, model: str) -> dict[str, Any]:
+    """Build the common ``next="llm"`` decision with the ReAct system prompt."""
+    system_prompt = _build_system_prompt(all_tool_specs())
+    return {
+        "next": "llm",
+        "provider": provider,
+        "model": model,
+        "messages_prepend": [{"role": "system", "content": system_prompt}],
+    }
+
+
+def _has_recent_retry_marker(messages: list[dict[str, Any]]) -> bool:
+    """Return True if any of the last few user messages carry the nudge marker."""
+    for msg in messages[-4:]:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.startswith(_RETRY_MARKER):
+            return True
+    return False
+
+
+def _build_system_prompt(tool_specs: list[dict[str, Any]]) -> str:
+    """Compose the ReAct system prompt from the live tool registry.
+
+    Tool specs come in the OpenAI function-calling shape via
+    :func:`~yaya.kernel.tool.all_tool_specs`: each entry is
+    ``{"type": "function", "function": {"name", "description",
+    "parameters"}}``. We render a compact bullet list that the model
+    can reason about without requiring structured tool support on
+    the provider side.
+    """
+    lines: list[str] = [
+        "You are yaya, an assistant that solves tasks by reasoning in the ReAct style.",
+        "",
+        "You have access to the following tools:",
+    ]
+    if not tool_specs:
+        lines.append("- (no tools available)")
+    else:
+        for spec in tool_specs:
+            fn_raw = spec.get("function")
+            if not isinstance(fn_raw, dict):
+                continue
+            fn = cast("dict[str, Any]", fn_raw)
+            name = str(fn.get("name", "?"))
+            desc = str(fn.get("description", "")).strip()
+            params_raw = fn.get("parameters")
+            params: dict[str, Any] = cast("dict[str, Any]", params_raw) if isinstance(params_raw, dict) else {}
+            params_json = json.dumps(params, separators=(",", ":"))
+            if len(params_json) > 240:
+                params_json = params_json[:237] + "..."
+            lines.append(f"- {name}: {desc}")
+            lines.append(f"  schema: {params_json}")
+    lines += [
+        "",
+        "Respond using this EXACT format on each turn. Do not add prose",
+        "outside the labels. Do not use <think> tags; put all reasoning",
+        "after the 'Thought:' label.",
+        "",
+        "Thought: <reason about what to do next>",
+        "Action: <one tool name from the list above>",
+        "Action Input: <a JSON object matching that tool's schema>",
+        "",
+        "After each Action I will give you:",
+        "Observation: <the tool's result as JSON or text>",
+        "",
+        "Continue the Thought/Action/Action Input cycle as needed. When",
+        "you have enough information, emit instead:",
+        "",
+        "Thought: <final reasoning>",
+        "Final Answer: <the user-facing answer>",
+        "",
+        "Never emit both an Action and a Final Answer in the same turn.",
+    ]
+    return "\n".join(lines)
+
+
+ParseResult = tuple[Any, ...]
+
+
+def _parse_assistant(text: str) -> ParseResult:
+    """Classify an assistant message into ``final`` / ``action`` / ``error``.
+
+    Returns one of:
+
+    * ``("final", answer_text)`` — a ``Final Answer:`` was found. The
+      strategy terminates the turn.
+    * ``("action", tool_name, args_dict)`` — a well-formed
+      ``Action:`` / ``Action Input:`` pair was found. Args are parsed
+      as JSON; if Action Input is wrapped in a ```json`` fence the
+      fence is stripped first.
+    * ``("error", reason)`` — neither shape is present or the JSON
+      could not be parsed. The strategy will issue one corrective
+      nudge and reroll; a second error terminates the turn.
+    """
+    # A ``Final Answer`` always wins if present, even when an
+    # accidental ``Action`` appears earlier — the ReAct paper treats
+    # Final Answer as strictly terminal.
+    final = _FINAL_RE.search(text)
+    if final is not None:
+        return ("final", final.group("answer").strip())
+
+    action = _ACTION_RE.search(text)
+    action_input = _ACTION_INPUT_RE.search(text)
+    if action is None or action_input is None:
+        return ("error", "missing Action / Action Input")
+
+    name = action.group("name").strip()
+    if not name:
+        return ("error", "Action name is empty")
+
+    body = action_input.group("body").strip()
+    fence = _CODE_FENCE_RE.match(body)
+    if fence is not None:
+        body = fence.group("inner").strip()
+
+    try:
+        parsed: Any = json.loads(body)
+    except ValueError as exc:
+        return ("error", f"Action Input is not valid JSON ({exc!s})")
+    if not isinstance(parsed, dict):
+        return ("error", f"Action Input must be a JSON object, got {type(parsed).__name__}")
+    return ("action", name, cast("dict[str, Any]", parsed))
 
 
 __all__ = ["ReActStrategy"]

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -56,7 +56,7 @@ _RETRY_MARKER = "[yaya:react-format-nudge] "
 # strategy authors. ``DOTALL`` on ``Final Answer`` / ``Action Input``
 # lets them span paragraphs.
 _FINAL_RE = re.compile(
-    r"^Final Answer:\s*(?P<answer>.+?)(?:\Z)",
+    r"^Final Answer:\s*(?P<answer>.+?)(?=^Action:|^Thought:|^Final Answer:|\Z)",
     re.MULTILINE | re.DOTALL,
 )
 _ACTION_RE = re.compile(

--- a/tests/bdd/features/plugin-strategy_react.feature
+++ b/tests/bdd/features/plugin-strategy_react.feature
@@ -8,20 +8,20 @@ Feature: ReAct strategy plugin
     Then a strategy.decide.response is emitted with next llm and the configured provider and model
     And the response echoes the originating request id
 
-  Scenario: Pending tool_calls on the assistant message decide next step is tool with first tool call
-    Given a strategy.decide.request whose last assistant message carries a non-empty tool_calls list
+  Scenario: Assistant message with a well-formed Action decides next step is tool with the parsed tool_call
+    Given a strategy.decide.request whose last assistant message contains a ReAct Action and Action Input
     When the ReAct plugin handles the event
-    Then a strategy.decide.response is emitted with next tool and the first pending tool_call payload
+    Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
     And the response echoes the originating request id
 
-  Scenario: Tool result just landed decides next step loops back to llm for another pass
-    Given a strategy.decide.request whose last_tool_result is populated after an assistant step
+  Scenario: Observation follows the last assistant message so the next step loops back to llm
+    Given a strategy.decide.request whose state has an Observation user message after the last assistant message
     When the ReAct plugin handles the event
     Then a strategy.decide.response is emitted with next llm and the configured provider and model
     And the response echoes the originating request id
 
-  Scenario: Assistant message without tool_calls or pending tool result decides next step is done
-    Given a strategy.decide.request whose last assistant message has no tool_calls and no pending tool result
+  Scenario: Assistant message with a Final Answer label decides next step is done
+    Given a strategy.decide.request whose last assistant message contains a Final Answer label
     When the ReAct plugin handles the event
     Then a strategy.decide.response is emitted with next done
     And the response echoes the originating request id

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -407,24 +407,29 @@ def _strategy_no_assistant(ctx: BDDContext) -> None:
     ctx.extras["strategy_openai_api_key"] = "sk-test"
 
 
-@given("a strategy.decide.request whose last assistant message carries a non-empty tool_calls list")
+@given("a strategy.decide.request whose last assistant message contains a ReAct Action and Action Input")
 def _strategy_tool_call(ctx: BDDContext) -> None:
-    tool_call = {"id": "tc-1", "name": "bash", "args": {"cmd": ["echo", "x"]}}
+    assistant_text = 'Thought: I need to echo x.\nAction: bash\nAction Input: {"cmd": ["echo", "x"]}\n'
     _strategy_payload(
         ctx,
         {
             "state": {
+                "step": 0,
                 "messages": [
                     {"role": "user", "content": "run something"},
-                    {"role": "assistant", "content": "", "tool_calls": [tool_call]},
-                ]
+                    {"role": "assistant", "content": assistant_text},
+                ],
             }
         },
     )
-    ctx.extras["expected_tool_call"] = tool_call
+    ctx.extras["expected_tool_call"] = {
+        "id": "rx-0",
+        "name": "bash",
+        "args": {"cmd": ["echo", "x"]},
+    }
 
 
-@given("a strategy.decide.request whose last_tool_result is populated after an assistant step")
+@given("a strategy.decide.request whose state has an Observation user message after the last assistant message")
 def _strategy_after_tool(ctx: BDDContext) -> None:
     _strategy_payload(
         ctx,
@@ -432,16 +437,19 @@ def _strategy_after_tool(ctx: BDDContext) -> None:
             "state": {
                 "messages": [
                     {"role": "user", "content": "go"},
-                    {"role": "assistant", "content": "thinking", "tool_calls": []},
+                    {
+                        "role": "assistant",
+                        "content": 'Thought: try it.\nAction: bash\nAction Input: {"cmd": ["echo", "x"]}\n',
+                    },
+                    {"role": "user", "content": 'Observation: {"stdout": "x"}'},
                 ],
-                "last_tool_result": {"id": "tc", "ok": True, "value": {"stdout": "x"}},
             }
         },
     )
     ctx.extras["strategy_openai_api_key"] = "sk-test"
 
 
-@given("a strategy.decide.request whose last assistant message has no tool_calls and no pending tool result")
+@given("a strategy.decide.request whose last assistant message contains a Final Answer label")
 def _strategy_done(ctx: BDDContext) -> None:
     _strategy_payload(
         ctx,
@@ -449,7 +457,7 @@ def _strategy_done(ctx: BDDContext) -> None:
             "state": {
                 "messages": [
                     {"role": "user", "content": "hi"},
-                    {"role": "assistant", "content": "hello back"},
+                    {"role": "assistant", "content": "Thought: greet.\nFinal Answer: hello back"},
                 ]
             }
         },
@@ -501,7 +509,7 @@ def _strategy_next_llm(ctx: BDDContext) -> None:
     assert payload["model"] == "gpt-4o-mini"
 
 
-@then("a strategy.decide.response is emitted with next tool and the first pending tool_call payload")
+@then("a strategy.decide.response is emitted with next tool and the parsed tool_call payload")
 def _strategy_next_tool(ctx: BDDContext) -> None:
     payload = _last_payload(ctx)
     assert payload["next"] == "tool"

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -291,6 +291,14 @@ def test_parse_assistant_final_wins_over_action() -> None:
     mixed = "Thought: confused\nAction: bash\nAction Input: {}\nFinal Answer: done"
     out = _parse_assistant(mixed)
     assert out[0] == "final"
+    assert out[1] == "done"
+
+    # Final Answer that precedes an Action should NOT swallow the
+    # trailing Action/Action Input lines into the answer body.
+    final_then_action = "Final Answer: hi\nAction: bash\nAction Input: {}"
+    out2 = _parse_assistant(final_then_action)
+    assert out2[0] == "final"
+    assert out2[1] == "hi"
 
 
 async def test_missing_state_raises(tmp_path: Path) -> None:

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -1,14 +1,19 @@
-"""Tests for the ReAct strategy plugin.
+"""Tests for the ReAct strategy plugin (text Thought/Action/Observation).
 
-AC-bindings from ``specs/plugin-strategy_react.spec`` and
-``specs/plugin-instance-dispatch.spec``:
+Classical ReAct — the strategy parses ``Thought: / Action: /
+Action Input:`` triples (or ``Thought: / Final Answer:``) from the
+assistant's free-form text. It does NOT look at
+``assistant.tool_calls``; tool intent rides in prose only (#151).
+
+AC-bindings:
 
 * no assistant yet → ``test_no_assistant_yet_returns_llm``
-* pending tool_calls → ``test_assistant_with_tool_calls_returns_tool``
-* after tool result → ``test_after_tool_result_returns_llm``
-* assistant done → ``test_assistant_without_tool_calls_returns_done``
-* missing state → ``test_missing_state_raises``
-* model from instance → ``test_provider_and_model_reads_instance_config``
+* well-formed Action → ``test_assistant_with_react_action_returns_tool``
+* Final Answer → ``test_assistant_with_final_answer_returns_done``
+* post-Observation → ``test_post_observation_returns_llm``
+* malformed → nudge → ``test_malformed_assistant_triggers_nudge``
+* second malformed → terminate → ``test_second_malformed_terminates``
+* parser robustness → ``test_parse_assistant_*``
 """
 
 from __future__ import annotations
@@ -102,33 +107,34 @@ async def test_no_assistant_yet_returns_llm(tmp_path: Path, monkeypatch: pytest.
     assert "request_id" in got
 
 
-async def test_assistant_with_tool_calls_returns_tool(tmp_path: Path) -> None:
-    """Assistant with tool_calls → tool with the first call."""
+async def test_assistant_with_react_action_returns_tool(tmp_path: Path) -> None:
+    """Well-formed ReAct Action → tool with synthesized call id."""
     bus = EventBus()
-    tool_call = {"id": "tc-1", "name": "bash", "args": {"cmd": ["echo", "x"]}}
+    react_text = 'Thought: I should echo the value.\nAction: bash\nAction Input: {"cmd": ["echo", "x"]}'
     captured = await _drive(
         bus,
         react_plugin,
         tmp_path,
         {
             "state": {
+                "step": 2,
                 "messages": [
                     {"role": "user", "content": "run something"},
-                    {"role": "assistant", "content": "", "tool_calls": [tool_call]},
+                    {"role": "assistant", "content": react_text},
                 ],
             }
         },
-        session_id="sess-tool-1",
+        session_id="sess-action-1",
     )
     assert len(captured) == 1
     got = captured[0].payload
     assert got["next"] == "tool"
-    assert got["tool_call"] == tool_call
+    assert got["tool_call"] == {"id": "rx-2", "name": "bash", "args": {"cmd": ["echo", "x"]}}
     assert "request_id" in got
 
 
-async def test_after_tool_result_returns_llm(tmp_path: Path) -> None:
-    """Assistant then tool result → back to llm."""
+async def test_post_observation_returns_llm(tmp_path: Path) -> None:
+    """Assistant Action followed by an Observation user msg → llm for next turn."""
     bus = EventBus()
     captured = await _drive(
         bus,
@@ -136,14 +142,18 @@ async def test_after_tool_result_returns_llm(tmp_path: Path) -> None:
         tmp_path,
         {
             "state": {
+                "step": 3,
                 "messages": [
                     {"role": "user", "content": "go"},
-                    {"role": "assistant", "content": "thinking", "tool_calls": []},
+                    {
+                        "role": "assistant",
+                        "content": "Thought: run it.\nAction: bash\nAction Input: {}",
+                    },
+                    {"role": "user", "content": 'Observation: {"ok": true}'},
                 ],
-                "last_tool_result": {"id": "tc", "ok": True, "value": {"stdout": "x"}},
             }
         },
-        session_id="sess-after-tool",
+        session_id="sess-post-obs",
     )
     assert len(captured) == 1
     got = captured[0].payload
@@ -151,8 +161,8 @@ async def test_after_tool_result_returns_llm(tmp_path: Path) -> None:
     assert "request_id" in got
 
 
-async def test_assistant_without_tool_calls_returns_done(tmp_path: Path) -> None:
-    """Assistant with no tool_calls and no pending tool result → done."""
+async def test_assistant_with_final_answer_returns_done(tmp_path: Path) -> None:
+    """``Final Answer:`` in the last assistant → done."""
     bus = EventBus()
     captured = await _drive(
         bus,
@@ -162,16 +172,125 @@ async def test_assistant_without_tool_calls_returns_done(tmp_path: Path) -> None
             "state": {
                 "messages": [
                     {"role": "user", "content": "hi"},
-                    {"role": "assistant", "content": "hello back"},
+                    {
+                        "role": "assistant",
+                        "content": "Thought: greet back.\nFinal Answer: hello!",
+                    },
                 ],
             }
         },
-        session_id="sess-done-1",
+        session_id="sess-final",
     )
     assert len(captured) == 1
     got = captured[0].payload
     assert got["next"] == "done"
     assert "request_id" in got
+
+
+async def test_malformed_assistant_triggers_nudge(tmp_path: Path) -> None:
+    """Assistant text without an Action/Final Answer → llm + corrective nudge."""
+    bus = EventBus()
+    captured = await _drive(
+        bus,
+        react_plugin,
+        tmp_path,
+        {
+            "state": {
+                "messages": [
+                    {"role": "user", "content": "compute"},
+                    {"role": "assistant", "content": "I'll just answer directly: 42"},
+                ],
+            }
+        },
+        session_id="sess-nudge",
+    )
+    assert len(captured) == 1
+    got = captured[0].payload
+    assert got["next"] == "llm"
+    append = got.get("messages_append")
+    assert isinstance(append, list) and len(append) == 1
+    nudge = append[0]
+    assert nudge["role"] == "user"
+    assert nudge["content"].startswith("[yaya:react-format-nudge] ")
+
+
+async def test_second_malformed_terminates(tmp_path: Path) -> None:
+    """If a nudge is already in the recent history, a second parse failure → done."""
+    bus = EventBus()
+    captured = await _drive(
+        bus,
+        react_plugin,
+        tmp_path,
+        {
+            "state": {
+                "messages": [
+                    {"role": "user", "content": "compute"},
+                    {"role": "assistant", "content": "garbage"},
+                    {
+                        "role": "user",
+                        "content": "[yaya:react-format-nudge] please resend",
+                    },
+                    {"role": "assistant", "content": "still garbage"},
+                ],
+            }
+        },
+        session_id="sess-terminate",
+    )
+    assert len(captured) == 1
+    got = captured[0].payload
+    assert got["next"] == "done"
+
+
+def test_parse_assistant_final_answer() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant("Thought: done\nFinal Answer: the answer is 42")
+    assert out == ("final", "the answer is 42")
+
+
+def test_parse_assistant_well_formed_action() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant('Thought: ok\nAction: bash\nAction Input: {"cmd": ["ls"]}')
+    assert out == ("action", "bash", {"cmd": ["ls"]})
+
+
+def test_parse_assistant_action_input_in_code_fence() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant('Thought: ok\nAction: bash\nAction Input: ```json\n{"cmd": ["echo", "hi"]}\n```')
+    assert out == ("action", "bash", {"cmd": ["echo", "hi"]})
+
+
+def test_parse_assistant_missing_labels_reports_error() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant("just some prose with no labels at all")
+    assert out[0] == "error"
+
+
+def test_parse_assistant_invalid_json_reports_error() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant("Thought: x\nAction: bash\nAction Input: not-json")
+    assert out[0] == "error"
+
+
+def test_parse_assistant_non_object_input_rejected() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant('Thought: x\nAction: bash\nAction Input: ["cmd","ls"]')
+    assert out[0] == "error"
+    assert "JSON object" in out[1]
+
+
+def test_parse_assistant_final_wins_over_action() -> None:
+    """Paper treats Final Answer as strictly terminal."""
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    mixed = "Thought: confused\nAction: bash\nAction Input: {}\nFinal Answer: done"
+    out = _parse_assistant(mixed)
+    assert out[0] == "final"
 
 
 async def test_missing_state_raises(tmp_path: Path) -> None:
@@ -271,66 +390,7 @@ async def test_provider_and_model_unknown_active_falls_back_to_first(tmp_path: P
         await store.close()
 
 
-# ---------------------------------------------------------------------------
-# Tool-call pairing (#147) — strategy must detect satisfied tool_calls so it
-# doesn't re-invoke the same tool on every loop iteration.
-# ---------------------------------------------------------------------------
-
-
-async def test_satisfied_tool_call_routes_to_llm_not_tool(tmp_path: Path) -> None:
-    """Once a tool reply is appended, next should be ``llm`` — not the same tool again."""
-    bus = EventBus()
-    captured = await _drive(
-        bus,
-        react_plugin,
-        tmp_path,
-        {
-            "state": {
-                "messages": [
-                    {"role": "user", "content": "run"},
-                    {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [{"id": "tc-1", "name": "bash", "args": {}}],
-                    },
-                    {"role": "tool", "tool_call_id": "tc-1", "content": '{"ok": true}'},
-                ],
-            }
-        },
-        session_id="sess-satisfied",
-    )
-    assert len(captured) == 1
-    got = captured[0].payload
-    assert got["next"] == "llm"
-    assert "request_id" in got
-
-
-async def test_unsatisfied_tool_call_picks_first_pending(tmp_path: Path) -> None:
-    """With two tool_calls and only one satisfied, pick the pending one."""
-    bus = EventBus()
-    captured = await _drive(
-        bus,
-        react_plugin,
-        tmp_path,
-        {
-            "state": {
-                "messages": [
-                    {"role": "user", "content": "run"},
-                    {
-                        "role": "assistant",
-                        "content": "",
-                        "tool_calls": [
-                            {"id": "tc-1", "name": "bash", "args": {}},
-                            {"id": "tc-2", "name": "bash", "args": {"cmd": ["pwd"]}},
-                        ],
-                    },
-                    {"role": "tool", "tool_call_id": "tc-1", "content": '{"ok": true}'},
-                ],
-            }
-        },
-        session_id="sess-pending",
-    )
-    assert len(captured) == 1
-    got = captured[0].payload
-    assert got["next"] == "tool"
-    assert got["tool_call"]["id"] == "tc-2"
+# Tool-call pairing tests (previously here) were function-calling
+# specific and no longer apply — ReAct pairing is handled implicitly
+# by "message after last assistant → llm" (covered by
+# test_post_observation_returns_llm).


### PR DESCRIPTION
## Summary
- Replace the function-calling dispatch with a classical ReAct loop (Thought / Action / Action Input JSON / Final Answer). Strategy now authors a system prompt, parses assistant text, and synthesizes `rx-<step>` tool_call ids. `assistant.tool_calls` is no longer consumed.
- Kernel loop drains `decision.messages_prepend` (transient, injected into the outgoing llm.call.request) and `decision.messages_append` (persistent, added to state.messages). Tool results are rendered as `role=user content="Observation: ..."`.
- BDD + unit tests + spec + feature + AGENT.md mirror the new semantics. `just check && just test` green, all per-module coverage gates pass (strategy_react at 96.05%).

Closes #151

## Test plan
- [x] `just check` passes (ruff + mypy --strict + pyright + agent-spec lifecycle)
- [x] `just test` passes (774 passed, 91.58% global)
- [ ] Playwright MiniMax smoke: `run bash: echo react-works` — tool runs, assistant emits `Final Answer: ...`, no `max_iterations_exceeded`