### PR TITLE
feat: stream chat completions end to end (#168)

### DIFF
--- a/specs/plugin-llm_openai.spec
+++ b/specs/plugin-llm_openai.spec
@@ -102,10 +102,18 @@ Scenario: Error path — SDK rate-limit error translates to llm.call.error with 
   When a llm.call.request for provider openai is published
   Then a llm.call.error event is emitted with the error string and the originating request id
 
+Scenario: One llm.call.request produces N llm.call.delta events before the final response
+  Test:
+    Package: yaya
+    Filter: tests/plugins/llm_openai/test_llm_openai.py::test_create_streams_deltas_then_final_response
+  Level: unit
+  Given a configured llm-openai plugin whose stubbed client streams N content chunks
+  When a llm.call.request for provider openai is published
+  Then N llm.call.delta events are emitted in order carrying the originating request id
+  And a single llm.call.response event is emitted with the aggregated text and the originating request id
+
 ## Out of Scope
 
-- Streaming (`assistant.message.delta` chunks) — follows the adapter
-  work.
 - Token-budget accounting beyond what the SDK's `usage` object
   returns.
 - Automatic retry on transient failures — the strategy plugin

--- a/src/yaya/kernel/loop.py
+++ b/src/yaya/kernel/loop.py
@@ -58,11 +58,19 @@ Subscription scope
 ------------------
 The loop subscribes to: ``user.message.received``, ``user.interrupt``,
 ``strategy.decide.response``, ``llm.call.response``, ``llm.call.error``,
-``memory.result``, ``tool.call.result``. Each response handler simply
-hands the event to :class:`_RequestTracker`, which resolves the matching
-future by ``payload.request_id``. Responses whose id is not tracked are
-ignored (they may belong to a plugin bypassing the loop, or be late
-arrivals after a cancelled turn).
+``llm.call.delta``, ``memory.result``, ``tool.call.result``. Each
+response handler simply hands the event to :class:`_RequestTracker`,
+which resolves the matching future by ``payload.request_id``. Responses
+whose id is not tracked are ignored (they may belong to a plugin
+bypassing the loop, or be late arrivals after a cancelled turn).
+
+``llm.call.delta`` events are forwarded — not awaited. The tracker
+carries a parallel ``request_id → session_id`` map populated when the
+loop publishes an ``llm.call.request``; each incoming delta is
+re-emitted as ``assistant.message.delta`` on the owning session so
+adapters render the in-flight text. Deltas for unknown ids (late
+arrivals, cross-loop leaks) are dropped silently — same shape as the
+``_on_response`` path.
 
 Interrupt delivery latency
 --------------------------
@@ -222,6 +230,14 @@ class _RequestTracker:
     """
 
     _pending: dict[str, asyncio.Future[Event]] = field(default_factory=lambda: {})
+    _delta_sessions: dict[str, str] = field(default_factory=lambda: {})
+    """Parallel ``request_id → session_id`` map for delta routing (#168).
+
+    Populated by :meth:`track_delta_session` alongside :meth:`track`
+    when the loop publishes an ``llm.call.request``. Entries are
+    cleared on :meth:`resolve` and :meth:`discard` so a late delta
+    arriving after the response no longer has a forwarding target.
+    """
 
     def track(self, request_id: str) -> asyncio.Future[Event]:
         """Register ``request_id`` and return a fresh future to await on."""
@@ -229,6 +245,14 @@ class _RequestTracker:
         fut: asyncio.Future[Event] = loop.create_future()
         self._pending[request_id] = fut
         return fut
+
+    def track_delta_session(self, request_id: str, session_id: str) -> None:
+        """Record the session that owns ``request_id`` for streaming delta routing."""
+        self._delta_sessions[request_id] = session_id
+
+    def delta_session_for(self, request_id: str) -> str | None:
+        """Return the session id for a tracked request, or ``None`` if unknown."""
+        return self._delta_sessions.get(request_id)
 
     def resolve(self, ev: Event) -> None:
         """Resolve the awaiter whose request_id matches ``ev.payload``.
@@ -247,6 +271,7 @@ class _RequestTracker:
             )
             return
         fut = self._pending.pop(request_id, None)
+        self._delta_sessions.pop(request_id, None)
         if fut is None:
             _logger.debug(
                 "untracked response kind=%r request_id=%r (late arrival or cancelled turn)",
@@ -260,11 +285,13 @@ class _RequestTracker:
     def discard(self, request_id: str) -> None:
         """Forget a tracked request without resolving it (e.g. on timeout)."""
         self._pending.pop(request_id, None)
+        self._delta_sessions.pop(request_id, None)
 
     def cancel_all(self) -> None:
         """Cancel every pending future — called on :meth:`AgentLoop.stop`."""
         pending = self._pending
         self._pending = {}
+        self._delta_sessions = {}
         for fut in pending.values():
             if not fut.done():
                 fut.cancel()
@@ -352,6 +379,7 @@ class AgentLoop:
             self._bus.subscribe("strategy.decide.response", self._on_response, source=_SOURCE),
             self._bus.subscribe("llm.call.response", self._on_response, source=_SOURCE),
             self._bus.subscribe("llm.call.error", self._on_response, source=_SOURCE),
+            self._bus.subscribe("llm.call.delta", self._on_llm_delta, source=_SOURCE),
             self._bus.subscribe("memory.result", self._on_response, source=_SOURCE),
             self._bus.subscribe("tool.call.result", self._on_response, source=_SOURCE),
         ])
@@ -413,6 +441,43 @@ class AgentLoop:
     async def _on_response(self, ev: Event) -> None:
         """Route every response kind through the correlation tracker."""
         self._tracker.resolve(ev)
+
+    async def _on_llm_delta(self, ev: Event) -> None:
+        """Forward ``llm.call.delta`` as ``assistant.message.delta`` on the owning session.
+
+        The loop is the only subscriber that knows which session a
+        given ``request_id`` belongs to (the ``llm.call.request`` the
+        loop published carries that binding). Adapters therefore do
+        not need to subscribe to ``llm.call.*`` directly — streaming
+        flows through the single, session-scoped
+        ``assistant.message.delta`` channel they already consume
+        (#168).
+
+        Deltas whose ``request_id`` is unknown are dropped silently:
+        they are either late arrivals after the loop already resolved
+        the response (and cleared the tracker entry) or belong to a
+        provider bypassing the loop. Either way, forwarding them would
+        either confuse adapters or crash here — dropping is the only
+        correct choice.
+        """
+        request_id = ev.payload.get("request_id")
+        if not isinstance(request_id, str):
+            return
+        session_id = self._tracker.delta_session_for(request_id)
+        if session_id is None:
+            return
+        content_raw: Any = ev.payload.get("content", "")
+        content = content_raw if isinstance(content_raw, str) else ""
+        if not content:
+            return
+        await self._bus.publish(
+            new_event(
+                "assistant.message.delta",
+                {"content": content},
+                session_id=session_id,
+                source=_SOURCE,
+            )
+        )
 
     # -- turn body --------------------------------------------------------------
 
@@ -717,6 +782,12 @@ class AgentLoop:
                 (interrupt or supersession).
         """
         fut = self._tracker.track(req.id)
+        # Delta forwarding (#168) needs to know which session owns
+        # each in-flight LLM request so streaming chunks re-surface on
+        # the right WS connection. Stamping for every request kind is
+        # a cheap constant-size dict write; only ``llm.call.delta``
+        # reads it, so non-LLM requests just pay the insert.
+        self._tracker.track_delta_session(req.id, req.session_id)
         try:
             await self._bus.publish(req)
             return await asyncio.wait_for(fut, timeout=self._config.step_timeout_s)

--- a/src/yaya/plugins/llm_openai/AGENT.md
+++ b/src/yaya/plugins/llm_openai/AGENT.md
@@ -1,5 +1,5 @@
 ## Philosophy
-OpenAI LLM-provider plugin built on the official `openai.AsyncOpenAI` SDK (the only LLM SDK allowed by `AGENT.md` §4). **Instance-scoped** (D4b / #123): one plugin process backs many operator-configured records under `providers.<id>.*` — "OpenAI prod", "Azure OpenAI", "local-LM-Studio" each with its own `api_key`, `base_url`, `model`. Non-streaming chat completions at 0.1; streaming follows adapter work.
+OpenAI LLM-provider plugin built on the official `openai.AsyncOpenAI` SDK (the only LLM SDK allowed by `AGENT.md` §4). **Instance-scoped** (D4b / #123): one plugin process backs many operator-configured records under `providers.<id>.*` — "OpenAI prod", "Azure OpenAI", "local-LM-Studio" each with its own `api_key`, `base_url`, `model`. Chat completions stream (#168): `stream=True` + `stream_options={"include_usage": True}`; each content chunk produces an `llm.call.delta`, `<think>` spans are filtered chunk-boundary-safe via `_StreamThinkFilter`, and a trailing `llm.call.response` carries the aggregated text plus usage (or `usage=None` when the upstream ignores `stream_options`).
 
 ## External Reality
 - [`docs/dev/plugin-protocol.md`](../../../../docs/dev/plugin-protocol.md) (LLM-provider row + "Provider instances" section).

--- a/src/yaya/plugins/llm_openai/plugin.py
+++ b/src/yaya/plugins/llm_openai/plugin.py
@@ -9,10 +9,17 @@ therefore backs many operator-configured instances — e.g. "OpenAI
 prod", "Azure OpenAI", "local-LM-Studio" — each with its own
 ``api_key``, ``base_url``, and ``model`` fields.
 
-Non-streaming chat completions only at 0.1; streaming is tracked in
-the adapter-plugin spec. Every response event echoes ``request_id``
-so the agent loop's ``_RequestTracker`` correlates concurrent calls
-(lesson #15 in ``docs/wiki/lessons-learned.md``).
+Chat completions stream by default (#168): the plugin passes
+``stream=True`` with ``stream_options={"include_usage": True}`` and
+consumes the SDK's async iterator, emitting one ``llm.call.delta``
+per user-visible text chunk and a final ``llm.call.response`` with
+the aggregated content plus usage (when the upstream provides it).
+``<think>...</think>`` reasoning tags are filtered via a chunk-
+boundary-safe state machine (:class:`_StreamThinkFilter`) so partial
+tags never leak to adapters and the aggregated response matches the
+non-streaming behaviour from #149. Every response event echoes
+``request_id`` so the agent loop's ``_RequestTracker`` correlates
+concurrent calls (lesson #15 in ``docs/wiki/lessons-learned.md``).
 
 Hot-reload is per-instance: a ``config.updated`` event whose key sits
 under ``providers.<id>.`` rebuilds *only* that instance's client.
@@ -302,11 +309,33 @@ class OpenAIProvider:
             self._clients[inst.id] = client
 
     async def _dispatch(self, ev: Event, ctx: KernelContext, instance_id: str) -> None:
-        """Invoke chat completions and emit ``llm.call.response``.
+        """Stream chat completions and emit deltas + a final response.
+
+        The SDK is invoked with ``stream=True`` and
+        ``stream_options={"include_usage": True}``. Each chunk's
+        ``delta.content`` is fed through a
+        :class:`_StreamThinkFilter` so ``<think>...</think>`` spans
+        (even when split across chunk boundaries) are suppressed
+        from ``llm.call.delta`` events and from the aggregated
+        ``llm.call.response`` text — matching the non-streaming
+        behaviour that #149 introduced.
+
+        The final ``llm.call.response`` carries:
+
+        * ``text`` — aggregated post-filter content.
+        * ``tool_calls`` — list of accumulated tool calls. Chunks
+          deliver tool calls via ``delta.tool_calls`` indexed by
+          ``index``; we reassemble by index and normalise through
+          :func:`_tool_call_to_dict`.
+        * ``usage`` — ``{"input_tokens": int, "output_tokens": int}``
+          when the upstream supports ``stream_options.include_usage``
+          (OpenAI-native). ``None`` on providers that ignore the
+          option (some OpenAI-compatible endpoints).
 
         Model selection is a live read against
-        :attr:`ctx.providers` so ``yaya config set providers.<id>.model
-        gpt-4.1`` takes effect on the next turn without a rebuild.
+        :attr:`ctx.providers` so ``yaya config set
+        providers.<id>.model gpt-4.1`` takes effect on the next turn
+        without a rebuild.
         """
         client = self._clients[instance_id]
         model = self._resolve_model(ctx, instance_id, ev.payload)
@@ -317,6 +346,11 @@ class OpenAIProvider:
         create_kwargs: dict[str, Any] = {
             "model": model,
             "messages": messages,
+            "stream": True,
+            # Opt into the final usage chunk. OpenAI-native honors this;
+            # endpoints that don't understand ``stream_options`` should
+            # ignore it (and we tolerate a missing usage below).
+            "stream_options": {"include_usage": True},
         }
         if tools:
             create_kwargs["tools"] = tools
@@ -324,34 +358,30 @@ class OpenAIProvider:
         # The SDK typing union (ChatCompletion | AsyncStream[...]) widens
         # everything past this point to Any — that matches the tests'
         # stub-client pattern and the runtime shape we actually emit.
-        completion: Any = await client.chat.completions.create(**create_kwargs)  # pyright: ignore[reportUnknownVariableType]
+        stream: Any = await client.chat.completions.create(**create_kwargs)  # pyright: ignore[reportUnknownVariableType]
 
-        choices_raw: Any = completion.choices or []  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-        choices: list[Any] = list(choices_raw) if choices_raw else []  # pyright: ignore[reportUnknownArgumentType]
-        choice: Any = choices[0] if choices else None
-        message: Any = choice.message if choice is not None else None
-        raw_text: str = getattr(message, "content", "") or ""
-        # Strip inline ``<think>...</think>`` reasoning blocks that
-        # MiniMax / DeepSeek-R1 style models embed in ``content``.
-        # Replaying those tags verbatim in the next
-        # ``llm.call.request`` history leaves the model echoing only
-        # more reasoning on turn 2 with no visible output — the chat
-        # then looks single-round because ``assistant.message.done``
-        # falls back to turn 1's thinking-only text (#149).
-        text: str = _strip_reasoning_tags(raw_text)
-        raw_tool_calls_obj: Any = getattr(message, "tool_calls", None) or []
-        raw_tool_calls: list[Any] = list(raw_tool_calls_obj) if raw_tool_calls_obj else []
-        tool_calls = [_tool_call_to_dict(tc) for tc in raw_tool_calls]
+        think_filter = _StreamThinkFilter()
+        aggregated: list[str] = []
+        tool_call_buf: dict[int, dict[str, Any]] = {}
+        usage_obj: Any = None
 
-        usage_obj: Any = getattr(completion, "usage", None)  # pyright: ignore[reportUnknownArgumentType]
-        usage: dict[str, int] = {}
-        if usage_obj is not None:
-            input_tokens = getattr(usage_obj, "prompt_tokens", None)
-            output_tokens = getattr(usage_obj, "completion_tokens", None)
-            if input_tokens is not None:
-                usage["input_tokens"] = int(input_tokens)
-            if output_tokens is not None:
-                usage["output_tokens"] = int(output_tokens)
+        async for chunk in stream:  # pyright: ignore[reportUnknownVariableType]
+            usage_obj = await self._consume_chunk(ev, ctx, chunk, think_filter, aggregated, tool_call_buf, usage_obj)
+
+        # Drain any buffer the filter was sitting on when the stream ended.
+        tail_visible, tail_retained = think_filter.flush()
+        if tail_retained:
+            aggregated.append(tail_retained)
+        if tail_visible:
+            await ctx.emit(
+                "llm.call.delta",
+                {"request_id": ev.id, "content": tail_visible},
+                session_id=ev.session_id,
+            )
+
+        text = "".join(aggregated).strip() if think_filter.stripped_any else "".join(aggregated)
+        tool_calls = [_tool_call_to_dict(tc) for tc in tool_call_buf.values()]
+        usage = _extract_usage(usage_obj)
 
         await ctx.emit(
             "llm.call.response",
@@ -363,6 +393,53 @@ class OpenAIProvider:
             },
             session_id=ev.session_id,
         )
+
+    @staticmethod
+    async def _consume_chunk(
+        ev: Event,
+        ctx: KernelContext,
+        chunk: Any,
+        think_filter: _StreamThinkFilter,
+        aggregated: list[str],
+        tool_call_buf: dict[int, dict[str, Any]],
+        usage_obj: Any,
+    ) -> Any:
+        """Absorb one streamed chunk; return the (possibly updated) ``usage`` sentinel.
+
+        Extracted from :meth:`_dispatch` to keep its cyclomatic
+        complexity under the lint gate — the per-chunk work has its
+        own branching (usage trailer vs content chunk vs tool-call
+        chunk) that would otherwise inflate the async-for body.
+        """
+        chunk_usage: Any = getattr(chunk, "usage", None)
+        if chunk_usage is not None:
+            usage_obj = chunk_usage
+
+        choices_raw: Any = getattr(chunk, "choices", None) or []
+        choices: list[Any] = list(choices_raw) if choices_raw else []
+        if not choices:
+            return usage_obj
+        delta: Any = getattr(choices[0], "delta", None)
+        if delta is None:
+            return usage_obj
+
+        content_piece_any: Any = getattr(delta, "content", None)
+        if isinstance(content_piece_any, str) and content_piece_any:
+            visible, retained = think_filter.feed(content_piece_any)
+            if retained:
+                aggregated.append(retained)
+            if visible:
+                await ctx.emit(
+                    "llm.call.delta",
+                    {"request_id": ev.id, "content": visible},
+                    session_id=ev.session_id,
+                )
+
+        delta_tool_calls_any: Any = getattr(delta, "tool_calls", None) or []
+        if delta_tool_calls_any:
+            for partial in list(delta_tool_calls_any):
+                _merge_tool_call_chunk(tool_call_buf, partial)
+        return usage_obj
 
     @staticmethod
     def _resolve_model(ctx: KernelContext, instance_id: str, payload: dict[str, Any]) -> str:
@@ -413,6 +490,192 @@ class OpenAIProvider:
 
 
 _THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
+_THINK_OPEN = "<think>"
+_THINK_CLOSE = "</think>"
+
+
+class _StreamThinkFilter:
+    """Chunk-boundary-safe filter for inline ``<think>...</think>`` spans.
+
+    The non-streaming path uses :func:`_strip_reasoning_tags`, a
+    single regex pass. Streaming cannot: a chunk may arrive mid-tag
+    (``"<thi"`` / ``"nk>reasoning"`` / ``"</think>done"``) and
+    emitting any of those bytes to adapters would either flash raw
+    markers at the user or leak reasoning into the UI bubble.
+
+    State machine:
+
+    * ``OUTSIDE``: buffering until we are sure the trailing bytes are
+      not the start of ``<think>``. When we encounter ``<`` we hold
+      everything from that point until either the full ``<think>``
+      open tag is matched (→ ``INSIDE``) or enough following bytes
+      prove it is NOT a ``<think>`` open (→ flush the held bytes
+      back to ``visible``).
+    * ``INSIDE``: buffering and suppressing every byte until the
+      ``</think>`` close tag lands. On close, flip back to
+      ``OUTSIDE`` and continue — trailing bytes from the same chunk
+      are processed recursively so one chunk closing a span and
+      starting the next segment still emits the tail.
+
+    Returns on :meth:`feed` a pair ``(visible, retained)`` where
+    ``visible`` is what adapters should see immediately (``delta``
+    events) and ``retained`` is what the aggregated response text
+    should accumulate — the two are the same under normal operation
+    (we only emit bytes we plan to keep) but are returned separately
+    so future consumers can diverge (e.g. debug-log thought spans
+    while not emitting them).
+    """
+
+    __slots__ = ("_buf", "_in_think", "stripped_any")
+
+    def __init__(self) -> None:
+        self._buf: str = ""
+        self._in_think: bool = False
+        self.stripped_any: bool = False
+        """Whether any ``<think>`` span was observed — mirrors the
+        post-regex ``.strip()`` call in :func:`_strip_reasoning_tags`
+        so the aggregated output matches byte-for-byte on the common
+        MiniMax pattern."""
+
+    def feed(self, chunk: str) -> tuple[str, str]:
+        """Consume one streamed chunk and return ``(visible, retained)``."""
+        self._buf += chunk
+        visible_parts: list[str] = []
+        while self._buf:
+            if self._in_think:
+                if not self._step_inside():
+                    break
+                continue
+            if not self._step_outside(visible_parts):
+                break
+        visible = "".join(visible_parts)
+        return visible, visible
+
+    def _step_inside(self) -> bool:
+        """Advance while inside a ``<think>`` span; return True to keep stepping."""
+        close_idx = self._buf.find(_THINK_CLOSE)
+        if close_idx == -1:
+            # Retain only the trailing bytes that could still be a
+            # partial close tag (``</``, ``</t``, ...); drop the
+            # rest — it is safely inside the span.
+            keep = 0
+            for n in range(1, min(len(_THINK_CLOSE), len(self._buf) + 1)):
+                if _THINK_CLOSE.startswith(self._buf[-n:]):
+                    keep = n
+            self._buf = self._buf[-keep:] if keep else ""
+            return False
+        self._buf = self._buf[close_idx + len(_THINK_CLOSE) :]
+        self._in_think = False
+        self.stripped_any = True
+        return True
+
+    def _step_outside(self, visible_parts: list[str]) -> bool:
+        """Advance while outside a ``<think>`` span; return True to keep stepping."""
+        lt_idx = self._buf.find("<")
+        if lt_idx == -1:
+            visible_parts.append(self._buf)
+            self._buf = ""
+            return False
+        if lt_idx > 0:
+            visible_parts.append(self._buf[:lt_idx])
+            self._buf = self._buf[lt_idx:]
+        if len(self._buf) < len(_THINK_OPEN):
+            if _THINK_OPEN.startswith(self._buf):
+                return False  # wait for more bytes.
+            visible_parts.append(self._buf)
+            self._buf = ""
+            return False
+        if self._buf.startswith(_THINK_OPEN):
+            self._buf = self._buf[len(_THINK_OPEN) :]
+            self._in_think = True
+            return True
+        # Not a ``<think>`` open — emit the literal ``<`` and keep
+        # scanning from the next byte.
+        visible_parts.append(self._buf[0])
+        self._buf = self._buf[1:]
+        return True
+
+    def flush(self) -> tuple[str, str]:
+        """Drain any buffered bytes at end-of-stream.
+
+        If the stream ended mid-``<think>`` the held body is
+        discarded (matches the regex behaviour on unclosed tags — the
+        non-streaming path relies on ``re.DOTALL`` with a greedy
+        ``</think>`` match, which silently drops an unmatched open
+        tag's tail when the regex does not fire). If the stream
+        ended mid-``<`` (ambiguous partial prefix of ``<think>``),
+        flush the literal bytes since the tag never completed.
+        """
+        if self._in_think:
+            # Unclosed ``<think>`` — drop the body.
+            self._buf = ""
+            return "", ""
+        tail = self._buf
+        self._buf = ""
+        return tail, tail
+
+
+def _extract_usage(usage_obj: Any) -> dict[str, int] | None:
+    """Translate a provider ``usage`` sentinel to the kernel usage dict or ``None``.
+
+    OpenAI delivers ``usage`` on the trailing stream chunk only when
+    the request opted in via ``stream_options={"include_usage":
+    True}``. Some OpenAI-compatible endpoints silently drop the
+    option and never emit a usage sentinel — we tolerate that path by
+    returning ``None`` rather than forging zeros that a downstream
+    token-budget gauge could mistake for "this turn was free".
+    """
+    if usage_obj is None:
+        return None
+    input_tokens = getattr(usage_obj, "prompt_tokens", None)
+    output_tokens = getattr(usage_obj, "completion_tokens", None)
+    usage: dict[str, int] = {}
+    if input_tokens is not None:
+        usage["input_tokens"] = int(input_tokens)
+    if output_tokens is not None:
+        usage["output_tokens"] = int(output_tokens)
+    return usage
+
+
+def _merge_tool_call_chunk(buf: dict[int, dict[str, Any]], partial: Any) -> None:
+    """Fold one streamed ``delta.tool_calls`` entry into the buffer.
+
+    OpenAI streams tool calls across chunks: each chunk carries
+    ``delta.tool_calls[*]`` whose ``index`` field aligns entries
+    across chunks. ``function.name`` and ``function.arguments`` are
+    *concatenated* across chunks; ``id`` lands on the first chunk
+    for that index. We keep the accumulated entry in the SDK's
+    nested shape so :func:`_tool_call_to_dict` — already exercised
+    by the non-streaming path — handles normalisation unchanged.
+    """
+    index_raw: Any = getattr(partial, "index", None)
+    if not isinstance(index_raw, int):
+        # Some compatible endpoints may omit ``index`` and send one
+        # complete tool call per chunk. Bucket by id in that case so
+        # we still aggregate sensibly.
+        fallback_id_raw: Any = getattr(partial, "id", None) or ""
+        fallback_id = fallback_id_raw if isinstance(fallback_id_raw, str) else ""
+        index = -(len(buf) + 1) if not fallback_id else hash(fallback_id)
+    else:
+        index = index_raw
+
+    entry = buf.setdefault(
+        index,
+        {"id": "", "type": "function", "function": {"name": "", "arguments": ""}},
+    )
+    tc_id: Any = getattr(partial, "id", None)
+    if isinstance(tc_id, str) and tc_id and not entry["id"]:
+        entry["id"] = tc_id
+
+    fn_obj: Any = getattr(partial, "function", None)
+    if fn_obj is not None:
+        fn_name: Any = getattr(fn_obj, "name", None)
+        fn_args: Any = getattr(fn_obj, "arguments", None)
+        fn_dict = cast("dict[str, Any]", entry["function"])
+        if isinstance(fn_name, str) and fn_name:
+            fn_dict["name"] = fn_dict["name"] + fn_name if fn_dict["name"] else fn_name
+        if isinstance(fn_args, str) and fn_args:
+            fn_dict["arguments"] = fn_dict["arguments"] + fn_args
 
 
 def _strip_reasoning_tags(text: str) -> str:

--- a/src/yaya/plugins/llm_openai/plugin.py
+++ b/src/yaya/plugins/llm_openai/plugin.py
@@ -599,12 +599,17 @@ class _StreamThinkFilter:
         """Drain any buffered bytes at end-of-stream.
 
         If the stream ended mid-``<think>`` the held body is
-        discarded (matches the regex behaviour on unclosed tags — the
-        non-streaming path relies on ``re.DOTALL`` with a greedy
-        ``</think>`` match, which silently drops an unmatched open
-        tag's tail when the regex does not fire). If the stream
-        ended mid-``<`` (ambiguous partial prefix of ``<think>``),
-        flush the literal bytes since the tag never completed.
+        **dropped**. This deliberately diverges from the non-
+        streaming regex path (``_strip_reasoning_tags``) which keeps
+        an unclosed ``<think>`` verbatim — under streaming we cannot
+        show the user a half-reasoning span that was going to be
+        stripped by the closing tag, so dropping is safer for the UI.
+        Rare enough in practice (MiniMax always closes its ``<think>``
+        blocks) that the protocol-level divergence is acceptable.
+
+        If the stream ended mid-``<`` (ambiguous partial prefix of
+        ``<think>``), flush the literal bytes since the tag never
+        completed.
         """
         if self._in_think:
             # Unclosed ``<think>`` — drop the body.

--- a/src/yaya/plugins/web/src/__tests__/chat-shell.test.ts
+++ b/src/yaya/plugins/web/src/__tests__/chat-shell.test.ts
@@ -237,6 +237,61 @@ describe("YayaBubble ReAct thought folding (#167)", () => {
 	});
 });
 
+describe("YayaChat streaming deltas (#168)", () => {
+	it("accumulates successive assistant.delta frames into streamingMessage", () => {
+		const shell = makeShell();
+		shell.onFrame({ type: "assistant.delta", session_id: "ws-x", content: "Hel" });
+		shell.onFrame({ type: "assistant.delta", session_id: "ws-x", content: "lo" });
+		const s = shell.streamingMessage as AssistantChatMessage;
+		expect(s).not.toBeNull();
+		const text = s.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("");
+		expect(text).toBe("Hello");
+	});
+
+	it("clears streamingMessage on assistant.done after a stream of deltas", () => {
+		const shell = makeShell();
+		shell.onFrame({ type: "assistant.delta", session_id: "ws-x", content: "Hi" });
+		shell.onFrame({
+			type: "assistant.done",
+			session_id: "ws-x",
+			content: "Hi",
+			tool_calls: [],
+		});
+		expect(shell.streamingMessage).toBeNull();
+	});
+});
+
+describe("YayaBubble partial thought during streaming (#167 + #168)", () => {
+	async function renderBubble(role: "user" | "assistant", content: string): Promise<HTMLElement> {
+		const el = document.createElement("yaya-bubble") as HTMLElement & {
+			role: string;
+			content: string;
+			updateComplete: Promise<unknown>;
+		};
+		el.role = role;
+		el.content = content;
+		document.body.appendChild(el);
+		await el.updateComplete;
+		return el;
+	}
+
+	it("folds partial Thought emitted mid-stream without flashing raw prefix bytes", async () => {
+		// Mid-stream: chat-shell re-renders the bubble on every delta.
+		// splitThoughtFromFinal must collapse the Thought into <details>
+		// even though the Final Answer has not arrived yet, and must
+		// not surface the literal "Thought:" prefix in a raw .yaya-answer
+		// block that would flash at the user.
+		const el = await renderBubble("assistant", "Thought: thinking about it");
+		expect(el.querySelectorAll("details.yaya-thought")).toHaveLength(1);
+		expect(el.querySelector(".yaya-answer")).toBeNull();
+		expect(el.textContent).not.toContain("Thought: thinking about it");
+		el.remove();
+	});
+});
+
 describe("YayaChat toast lifecycle (bug #71 P3)", () => {
 	it("keeps error toasts until dismissed", () => {
 		const shell = makeShell();

--- a/tests/bdd/features/plugin-llm_openai.feature
+++ b/tests/bdd/features/plugin-llm_openai.feature
@@ -24,3 +24,9 @@ Feature: OpenAI LLM provider plugin
     Given a configured llm-openai plugin whose stubbed client raises a RateLimitError
     When a llm.call.request for provider openai is published
     Then a llm.call.error event is emitted with the error string and the originating request id
+
+  Scenario: One llm.call.request produces N llm.call.delta events before the final response
+    Given a configured llm-openai plugin whose stubbed client streams N content chunks
+    When a llm.call.request for provider openai is published
+    Then N llm.call.delta events are emitted in order carrying the originating request id
+    And a single llm.call.response event is emitted with the aggregated text and the originating request id

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -51,12 +51,36 @@ def _kernel_ctx(bus: EventBus, tmp_path: Path, plugin_name: str) -> KernelContex
     )
 
 
-def _fake_completion(text: str = "hi there") -> SimpleNamespace:
-    """Build a small object matching the SDK completion shape used here."""
-    message = SimpleNamespace(content=text, tool_calls=None)
-    choice = SimpleNamespace(message=message)
-    usage = SimpleNamespace(prompt_tokens=7, completion_tokens=3)
-    return SimpleNamespace(choices=[choice], usage=usage)
+def _fake_completion(text: str = "hi there", *, chunks: list[str] | None = None) -> Any:
+    """Return an async-iterator stub matching the streaming SDK shape (#168).
+
+    The plugin calls ``chat.completions.create`` with ``stream=True``
+    and iterates the result. Each yielded chunk carries a
+    ``choices[0].delta.content`` piece; the trailing chunk emits
+    ``usage`` per ``stream_options={"include_usage": True}``.
+    """
+    body = chunks if chunks is not None else [text]
+
+    async def _iter() -> Any:
+        for piece in body:
+            delta = SimpleNamespace(content=piece, tool_calls=None)
+            choice = SimpleNamespace(delta=delta)
+            yield SimpleNamespace(choices=[choice], usage=None)
+        yield SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3),
+        )
+
+    return _iter()
+
+
+def _streaming_create_mock(*, chunks: list[str] | None = None, text: str = "hi there") -> AsyncMock:
+    """Build an ``AsyncMock`` whose every call returns a fresh streaming iterator."""
+
+    async def _call(**_: Any) -> Any:
+        return _fake_completion(text=text, chunks=chunks)
+
+    return AsyncMock(side_effect=_call)
 
 
 def _last_payload(ctx: BDDContext) -> dict[str, Any]:
@@ -86,7 +110,7 @@ def _configured_openai(
     loop.run_until_complete(plugin.on_load(kernel_ctx))
 
     stub_client = MagicMock()
-    stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
+    stub_client.chat.completions.create = _streaming_create_mock()
     stub_client.close = AsyncMock(return_value=None)
     # D4b: instance-dispatch keyed by provider id. Register a stub
     # client under the id the scenario will publish against.
@@ -235,6 +259,74 @@ def _openai_error_string(ctx: BDDContext) -> None:
     assert errors, "no error event was captured"
     payload = errors[-1].payload
     assert "rate limited" in payload["error"]
+    assert payload["request_id"] == ctx.extras["last_request"].id
+
+
+# -- streaming (#168) --------------------------------------------------------
+
+
+_STREAM_CHUNKS: tuple[str, ...] = ("Hel", "lo, ", "world!")
+
+
+@given("a configured llm-openai plugin whose stubbed client streams N content chunks")
+def _streaming_openai(
+    ctx: BDDContext,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    kernel_ctx = _kernel_ctx(bus, tmp_path, plugin.name)
+    loop.run_until_complete(plugin.on_load(kernel_ctx))
+
+    stub_client = MagicMock()
+    stub_client.chat.completions.create = _streaming_create_mock(chunks=list(_STREAM_CHUNKS))
+    stub_client.close = AsyncMock(return_value=None)
+    plugin._clients["openai"] = stub_client
+
+    async def handler(ev: Event) -> None:
+        await plugin.on_event(ev, kernel_ctx)
+
+    captured: list[Event] = []
+    errors: list[Event] = []
+    deltas: list[Event] = []
+    bus.subscribe("llm.call.request", handler, source=plugin.name)
+    bus.subscribe("llm.call.response", lambda ev: _append_async(captured, ev), source="bdd")
+    bus.subscribe("llm.call.delta", lambda ev: _append_async(deltas, ev), source="bdd")
+    bus.subscribe("llm.call.error", lambda ev: _append_async(errors, ev), source="bdd")
+    ctx.bus = bus
+    ctx.extras.update({
+        "plugin": plugin,
+        "kernel_ctx": kernel_ctx,
+        "stub_client": stub_client,
+        "captured": captured,
+        "deltas": deltas,
+        "errors": errors,
+        "openai_provider": "openai",
+        "expected_chunks": list(_STREAM_CHUNKS),
+    })
+
+
+@then("N llm.call.delta events are emitted in order carrying the originating request id")
+def _streaming_deltas_in_order(ctx: BDDContext) -> None:
+    deltas = ctx.extras.get("deltas", [])
+    chunks = ctx.extras.get("expected_chunks", [])
+    assert [d.payload["content"] for d in deltas] == chunks
+    req_id = ctx.extras["last_request"].id
+    for d in deltas:
+        assert d.payload["request_id"] == req_id
+
+
+@then("a single llm.call.response event is emitted with the aggregated text and the originating request id")
+def _streaming_final_response(ctx: BDDContext) -> None:
+    responses = ctx.extras.get("captured", [])
+    assert len(responses) == 1
+    payload = responses[0].payload
+    chunks = ctx.extras.get("expected_chunks", [])
+    assert payload["text"] == "".join(chunks)
     assert payload["request_id"] == ctx.extras["last_request"].id
 
 

--- a/tests/kernel/test_loop.py
+++ b/tests/kernel/test_loop.py
@@ -1171,3 +1171,121 @@ async def test_turn_skips_provider_anchor_without_session_store() -> None:
     await bus.close()
     # Completing with no store wired should not raise — the test
     # passing is the assertion.
+
+
+# ---------------------------------------------------------------------------
+# #168: streaming — ``llm.call.delta`` → ``assistant.message.delta``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StreamingFakeLLM:
+    """Stub LLM provider that emits ``llm.call.delta`` chunks before responding."""
+
+    bus: EventBus
+    chunks: list[str]
+    text: str = ""
+
+    def subscribe(self) -> None:
+        self.bus.subscribe("llm.call.request", self._on_request, source="fake-llm-stream")
+
+    async def _on_request(self, ev: Event) -> None:
+        for chunk in self.chunks:
+            await self.bus.publish(
+                new_event(
+                    "llm.call.delta",
+                    {"request_id": ev.id, "content": chunk},
+                    session_id=ev.session_id,
+                    source="fake-llm-stream",
+                )
+            )
+        await self.bus.publish(
+            new_event(
+                "llm.call.response",
+                {
+                    "text": self.text or "".join(self.chunks),
+                    "tool_calls": [],
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                    "request_id": ev.id,
+                },
+                session_id=ev.session_id,
+                source="fake-llm-stream",
+            )
+        )
+
+
+async def test_loop_forwards_llm_delta_as_assistant_delta() -> None:
+    """An ``llm.call.delta`` for an in-flight request re-emits ``assistant.message.delta`` on the owning session."""
+    bus = EventBus()
+    strategy = FakeStrategy(
+        bus,
+        script=[
+            {"next": "llm", "provider": "fake", "model": "m"},
+            {"next": "done"},
+        ],
+    )
+    llm = StreamingFakeLLM(bus, chunks=["Hel", "lo"], text="Hello")
+    strategy.subscribe()
+    llm.subscribe()
+
+    deltas = EventRecorder(bus)
+    deltas.watch("assistant.message.delta")
+    dones = EventRecorder(bus)
+    dones.watch("assistant.message.done")
+
+    loop = AgentLoop(bus, LoopConfig(step_timeout_s=2.0))
+    await loop.start()
+
+    await bus.publish(
+        new_event(
+            "user.message.received",
+            {"text": "hi"},
+            session_id="s-stream",
+            source="fake-adapter",
+        )
+    )
+    await _settle(bus)
+    await loop.stop()
+    await bus.close()
+
+    contents = [e.payload["content"] for e in deltas.events]
+    assert contents == ["Hel", "lo"]
+    for e in deltas.events:
+        assert e.session_id == "s-stream"
+    assert len(dones.events) == 1
+    assert dones.events[0].payload["content"] == "Hello"
+
+
+async def test_loop_ignores_deltas_for_unknown_request_id() -> None:
+    """Deltas with untracked ``request_id`` are dropped silently."""
+    bus = EventBus()
+    loop = AgentLoop(bus, LoopConfig(step_timeout_s=2.0))
+    await loop.start()
+
+    deltas = EventRecorder(bus)
+    deltas.watch("assistant.message.delta")
+
+    # No ``llm.call.request`` was ever tracked — this delta is orphaned.
+    await bus.publish(
+        new_event(
+            "llm.call.delta",
+            {"request_id": "never-tracked", "content": "leaked"},
+            session_id="some-other-session",
+            source="bogus-plugin",
+        )
+    )
+    # A second delta with no ``request_id`` at all must also be a
+    # silent drop, not a crash.
+    await bus.publish(
+        new_event(
+            "llm.call.delta",
+            {"content": "oops"},
+            session_id="s-x",
+            source="bogus-plugin",
+        )
+    )
+    await _settle(bus)
+    await loop.stop()
+    await bus.close()
+
+    assert deltas.events == []

--- a/tests/plugins/llm_openai/test_llm_openai.py
+++ b/tests/plugins/llm_openai/test_llm_openai.py
@@ -60,12 +60,44 @@ def _fake_completion(
     *,
     input_tokens: int = 7,
     output_tokens: int = 3,
-) -> SimpleNamespace:
-    """Build a stub mirroring the SDK's chat.completion object shape."""
-    message = SimpleNamespace(content=text, tool_calls=None)
-    choice = SimpleNamespace(message=message)
-    usage = SimpleNamespace(prompt_tokens=input_tokens, completion_tokens=output_tokens)
-    return SimpleNamespace(choices=[choice], usage=usage)
+    chunks: list[str] | None = None,
+) -> Any:
+    """Return an async-iterator stub matching the SDK's streaming shape.
+
+    After #168 the plugin always passes ``stream=True``; each chunk
+    carries a ``choices[0].delta.content`` string. A trailing chunk
+    with empty ``choices`` and a populated ``usage`` mirrors OpenAI's
+    ``stream_options={"include_usage": True}`` behaviour.
+    """
+    body = chunks if chunks is not None else [text]
+
+    async def _iter() -> Any:
+        for piece in body:
+            delta = SimpleNamespace(content=piece, tool_calls=None)
+            choice = SimpleNamespace(delta=delta)
+            yield SimpleNamespace(choices=[choice], usage=None)
+        # Final usage chunk.
+        yield SimpleNamespace(
+            choices=[],
+            usage=SimpleNamespace(prompt_tokens=input_tokens, completion_tokens=output_tokens),
+        )
+
+    return _iter()
+
+
+def _streaming_create(**cfg: Any) -> AsyncMock:
+    """Build an ``AsyncMock`` whose return value yields a fresh stream per call.
+
+    ``chat.completions.create`` is awaitable in the SDK; we stub it as
+    an :class:`AsyncMock` whose ``side_effect`` returns a brand-new
+    async iterator each invocation so tests that publish multiple
+    requests get independent streams.
+    """
+
+    async def _call(**_: Any) -> Any:
+        return _fake_completion(**cfg)
+
+    return AsyncMock(side_effect=_call)
 
 
 async def _seed_instance(
@@ -99,7 +131,7 @@ async def test_successful_completion_emits_response(tmp_path: Path, monkeypatch:
         await plugin.on_load(ctx)
         # Swap the live client for a stub so we don't hit the network.
         stub_client = MagicMock()
-        stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
+        stub_client.chat.completions.create = _streaming_create()
         plugin._clients["llm-openai"] = stub_client
 
         async def _handler(ev: Event) -> None:
@@ -211,7 +243,7 @@ async def test_non_matching_provider_is_ignored(tmp_path: Path, monkeypatch: pyt
         await plugin.on_load(ctx)
 
         stub_client = MagicMock()
-        stub_client.chat.completions.create = AsyncMock(return_value=_fake_completion())
+        stub_client.chat.completions.create = _streaming_create()
         plugin._clients["llm-openai"] = stub_client
 
         async def _handler(ev: Event) -> None:
@@ -323,7 +355,7 @@ async def test_two_instances_route_to_distinct_clients(tmp_path: Path, monkeypat
             self._base = kwargs.get("base_url", "<default>")
             self.chat = SimpleNamespace(
                 completions=SimpleNamespace(
-                    create=AsyncMock(return_value=_fake_completion(text=f"from {self._base}")),
+                    create=_streaming_create(text=f"from {self._base}"),
                 ),
             )
 
@@ -829,6 +861,310 @@ def test_strip_reasoning_tags_multiple_blocks() -> None:
 
     raw = "<think>first</think> A <think>second</think> B"
     assert _strip_reasoning_tags(raw) == "A  B"
+
+
+def test_stream_think_filter_splits_open_tag_across_chunks() -> None:
+    """Chunks that split ``<think>`` and ``</think>`` across boundaries never leak markers."""
+    from yaya.plugins.llm_openai.plugin import _StreamThinkFilter
+
+    f = _StreamThinkFilter()
+    visible: list[str] = []
+    for chunk in ["pre ", "<thi", "nk>hidden reason", "ing</thi", "nk>", "post"]:
+        v, _ = f.feed(chunk)
+        visible.append(v)
+    tail, _ = f.flush()
+    visible.append(tail)
+    full = "".join(visible)
+    assert "think" not in full
+    assert full == "pre post"
+    assert f.stripped_any is True
+
+
+def test_stream_think_filter_handles_multiple_spans() -> None:
+    """Sequential ``<think>`` blocks interleaved with visible text pass the visible parts."""
+    from yaya.plugins.llm_openai.plugin import _StreamThinkFilter
+
+    f = _StreamThinkFilter()
+    visible, _ = f.feed("A <think>x</think> B <think>y</think> C")
+    tail, _ = f.flush()
+    assert visible + tail == "A  B  C"
+
+
+def test_stream_think_filter_passes_angle_text_that_is_not_think() -> None:
+    """A literal ``<`` that is not the start of ``<think>`` is emitted."""
+    from yaya.plugins.llm_openai.plugin import _StreamThinkFilter
+
+    f = _StreamThinkFilter()
+    out = f.feed("x<br>y")
+    tail, _ = f.flush()
+    assert out[0] + tail == "x<br>y"
+
+
+def test_stream_think_filter_drops_unclosed_tag_on_flush() -> None:
+    """A stream that ends mid-``<think>`` discards the body (matches regex behaviour)."""
+    from yaya.plugins.llm_openai.plugin import _StreamThinkFilter
+
+    f = _StreamThinkFilter()
+    pre, _ = f.feed("hello <think>still thinkin")
+    tail, _ = f.flush()
+    assert pre == "hello "
+    assert tail == ""
+
+
+async def test_create_streams_deltas_then_final_response(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each streamed chunk produces one llm.call.delta; the final llm.call.response aggregates them."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = _streaming_create(
+            chunks=["Hel", "lo, ", "world!"],
+            input_tokens=5,
+            output_tokens=9,
+        )
+        plugin._clients["llm-openai"] = stub_client
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+
+        deltas: list[Event] = []
+        responses: list[Event] = []
+
+        async def _delta(ev: Event) -> None:
+            deltas.append(ev)
+
+        async def _resp(ev: Event) -> None:
+            responses.append(ev)
+
+        bus.subscribe("llm.call.delta", _delta, source="observer")
+        bus.subscribe("llm.call.response", _resp, source="observer")
+
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "params": {},
+            },
+            session_id="sess-stream",
+            source="kernel",
+        )
+        await bus.publish(req)
+
+        # stream_options included in create kwargs.
+        kwargs = stub_client.chat.completions.create.await_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["stream_options"] == {"include_usage": True}
+
+        assert [d.payload["content"] for d in deltas] == ["Hel", "lo, ", "world!"]
+        for d in deltas:
+            assert d.payload["request_id"] == req.id
+
+        assert len(responses) == 1
+        payload = responses[0].payload
+        assert payload["text"] == "Hello, world!"
+        assert payload["tool_calls"] == []
+        assert payload["usage"] == {"input_tokens": 5, "output_tokens": 9}
+        assert payload["request_id"] == req.id
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_think_tags_stripped_across_chunk_boundaries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Streamed chunks that split ``<think>`` never leak tag bytes into deltas, and the aggregated response matches the non-streaming strip behaviour."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = _streaming_create(
+            chunks=["<thi", "nk>plan", "ning</thi", "nk>\n\n", "answer."],
+        )
+        plugin._clients["llm-openai"] = stub_client
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+
+        deltas: list[Event] = []
+        responses: list[Event] = []
+
+        async def _delta(ev: Event) -> None:
+            deltas.append(ev)
+
+        async def _resp(ev: Event) -> None:
+            responses.append(ev)
+
+        bus.subscribe("llm.call.delta", _delta, source="observer")
+        bus.subscribe("llm.call.response", _resp, source="observer")
+
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "params": {},
+            },
+            session_id="sess-think",
+            source="kernel",
+        )
+        await bus.publish(req)
+
+        # No delta may contain any think marker byte.
+        for d in deltas:
+            assert "think" not in d.payload["content"]
+            assert "<" not in d.payload["content"] or d.payload["content"] == "<"
+
+        assert len(responses) == 1
+        # Matches the non-streaming strip behaviour (``.strip()`` on
+        # the post-regex text) from #149.
+        assert responses[0].payload["text"] == "answer."
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_stream_error_emits_call_error_not_response(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception raised mid-stream surfaces as llm.call.error with no fabricated response."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        async def _broken_stream() -> Any:
+            delta = SimpleNamespace(content="ok so far", tool_calls=None)
+            yield SimpleNamespace(choices=[SimpleNamespace(delta=delta)], usage=None)
+            raise RuntimeError("connection dropped")
+
+        async def _call(**_: Any) -> Any:
+            return _broken_stream()
+
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = AsyncMock(side_effect=_call)
+        plugin._clients["llm-openai"] = stub_client
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+
+        responses: list[Event] = []
+        errors: list[Event] = []
+
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
+
+        async def _e(ev: Event) -> None:
+            errors.append(ev)
+
+        bus.subscribe("llm.call.response", _r, source="observer")
+        bus.subscribe("llm.call.error", _e, source="observer")
+
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [],
+                "params": {},
+            },
+            session_id="sess-mid-err",
+            source="kernel",
+        )
+        await bus.publish(req)
+
+        assert responses == []
+        assert len(errors) == 1
+        assert "connection dropped" in errors[0].payload["error"]
+        assert errors[0].payload["request_id"] == req.id
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
+
+
+async def test_stream_without_usage_support_returns_usage_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """OpenAI-compatible endpoints that drop ``stream_options`` yield a response with ``usage=None``."""
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    plugin = OpenAIProvider()
+    bus = EventBus()
+    store = await _make_store(tmp_path, bus)
+    try:
+        await _seed_instance(store, "llm-openai", api_key="sk-test")
+        ctx = _make_ctx(bus, tmp_path, plugin, store=store)
+        await plugin.on_load(ctx)
+
+        async def _no_usage_stream() -> Any:
+            delta = SimpleNamespace(content="hi there", tool_calls=None)
+            yield SimpleNamespace(choices=[SimpleNamespace(delta=delta)], usage=None)
+
+        async def _call(**_: Any) -> Any:
+            return _no_usage_stream()
+
+        stub_client = MagicMock()
+        stub_client.chat.completions.create = AsyncMock(side_effect=_call)
+        plugin._clients["llm-openai"] = stub_client
+
+        async def _handler(ev: Event) -> None:
+            await plugin.on_event(ev, ctx)
+
+        bus.subscribe("llm.call.request", _handler, source=plugin.name)
+
+        responses: list[Event] = []
+
+        async def _r(ev: Event) -> None:
+            responses.append(ev)
+
+        bus.subscribe("llm.call.response", _r, source="observer")
+
+        req = new_event(
+            "llm.call.request",
+            {
+                "provider": "llm-openai",
+                "model": "gpt-4o-mini",
+                "messages": [],
+                "params": {},
+            },
+            session_id="sess-no-usage",
+            source="kernel",
+        )
+        await bus.publish(req)
+
+        assert len(responses) == 1
+        payload = responses[0].payload
+        assert payload["text"] == "hi there"
+        assert payload["usage"] is None
+
+        await plugin.on_unload(ctx)
+    finally:
+        await store.close()
 
 
 def test_strip_reasoning_tags_only_thinking_collapses_to_empty() -> None:

--- a/tests/plugins/llm_openai/test_llm_openai.py
+++ b/tests/plugins/llm_openai/test_llm_openai.py
@@ -901,7 +901,13 @@ def test_stream_think_filter_passes_angle_text_that_is_not_think() -> None:
 
 
 def test_stream_think_filter_drops_unclosed_tag_on_flush() -> None:
-    """A stream that ends mid-``<think>`` discards the body (matches regex behaviour)."""
+    """A stream that ends mid-``<think>`` discards the body.
+
+    Deliberately diverges from the non-streaming regex (which keeps
+    unclosed spans verbatim); dropping is safer for the UI — a
+    half-rendered reasoning span would otherwise leak. See
+    ``_StreamThinkFilter.flush`` docstring for the rationale.
+    """
     from yaya.plugins.llm_openai.plugin import _StreamThinkFilter
 
     f = _StreamThinkFilter()


### PR DESCRIPTION
## Summary
- Turn on streaming in `llm-openai`: pass `stream=True` + `stream_options={"include_usage": True}`, iterate the async stream, emit one `llm.call.delta` per chunk, then a final `llm.call.response` with aggregated text + usage (or `usage=None` when the upstream ignores the option).
- New `_StreamThinkFilter` — a chunk-boundary-safe state machine that suppresses `<think>...</think>` spans even when split across arbitrary chunk boundaries, preserving #149's strip semantics.
- Agent loop now subscribes to `llm.call.delta`, correlates by `request_id` via a parallel session map on `_RequestTracker`, and re-emits each delta as `assistant.message.delta` on the owning session. Deltas for unknown ids drop silently (late arrivals, cross-loop leaks).
- Tape persistence unchanged — deltas are already in `_SKIP_KINDS`; only `assistant.message.done` lands on the tape.

No new public event kinds (both `llm.call.delta` and `assistant.message.delta` were already in the closed catalog). The web adapter's `_event_to_frame` and `chat-shell.ts`'s `applyDelta` were already wired; the browser picks up streaming without TS source changes.

## Edge cases handled
- `<think>` tag split across chunk boundaries (`"<thi" / "nk>reason" / "</thi" / "nk>"`) — no marker bytes leak to adapters.
- `</` partial close held at chunk boundary so `</think>` still closes the span.
- Stream ends mid-`<think>` → think body discarded (matches the regex path on malformed input).
- Exception raised mid-stream → `llm.call.error` with no fabricated response.
- OpenAI-compatible endpoints that drop `stream_options` → `llm.call.response.usage is None`.
- Deltas whose `request_id` is untracked (including `request_id` missing entirely) → silently dropped.
- Partial `Thought: ...` mid-stream still renders via `splitThoughtFromFinal` → folded `<details>`, no raw prefix flash.

## Test plan
- [x] `just check` (ruff + mypy + agent-spec lifecycle + .spec/.feature sync)
- [x] `just test` — 843 passed, global coverage 91.32%, all per-module gates green
- [x] `npx vitest run` under `src/yaya/plugins/web/` — 73 passed
- [x] New unit tests: streamed deltas + final response, `<think>` split across chunks, mid-stream error, missing usage, `_StreamThinkFilter` boundary cases
- [x] Loop tests: delta forwarding + unknown-id drop
- [x] BDD: new scenario `One llm.call.request produces N llm.call.delta events before the final response`
- [x] Frontend vitest: new `assistant.delta` accumulation + partial Thought folding tests