### PR TITLE
fix(strategy): parse bracketed tool-call blocks (#177)

### DIFF
--- a/specs/plugin-strategy_react.spec
+++ b/specs/plugin-strategy_react.spec
@@ -25,6 +25,12 @@ testable and deterministic.
   a `Thought: ... Final Answer: <text>` termination. Tool intent rides
   in free-form assistant text; the strategy does not consume
   `assistant.tool_calls`.
+- Accepts provider-style `[TOOL_CALL]` JSON blocks as a compatibility
+  input for tool intent. A block shaped as `{"tool": <name>,
+  "tool_input": <object>}` maps to the same `tool_call` decision as a
+  ReAct Action, and takes precedence over a nearby `Final Answer`
+  marker so mixed responses do not silently terminate before the tool
+  runs.
 - When the most-recent assistant message parses to a valid Action, the
   decision is `{"next": "tool", "tool_call": {"id", "name", "args"}}`
   with a synthesized id; only the first Action per turn is surfaced.
@@ -51,6 +57,8 @@ testable and deterministic.
 - src/yaya/plugins/strategy_react/AGENT.md
 - tests/plugins/strategy_react/__init__.py
 - tests/plugins/strategy_react/test_strategy_react.py
+- tests/bdd/features/plugin-strategy_react.feature
+- tests/bdd/test_plugins.py
 - specs/plugin-strategy_react.spec
 
 ### Forbidden
@@ -84,6 +92,17 @@ Scenario: Assistant message with a well-formed Action decides next step is tool 
   Given a strategy.decide.request whose last assistant message contains a ReAct Action and Action Input
   When the ReAct plugin handles the event
   Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
+  And the response echoes the originating request id
+
+Scenario: Assistant message with a bracketed tool-call block decides next step is tool
+  Test:
+    Package: yaya
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_assistant_with_tool_call_block_returns_tool
+  Level: unit
+  Given a strategy.decide.request whose last assistant message contains Final Answer prose and a [TOOL_CALL] block
+  When the ReAct plugin handles the event
+  Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
+  And the Final Answer prose does not terminate the turn before the tool runs
   And the response echoes the originating request id
 
 Scenario: Observation follows the last assistant message so the next step loops back to llm

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -5,9 +5,11 @@ prompt that constrains the LLM to emit either
 ``Thought: ... Action: <tool> Action Input: <json>`` triples or a
 ``Thought: ... Final Answer: <user-facing text>`` termination. The
 strategy parses the assistant's latest content for one of those two
-shapes:
+shapes, plus a compatibility ``[TOOL_CALL]`` block emitted by some
+providers or prompts:
 
 * A valid Action → ``{next: "tool"}`` with a synthesized tool_call.
+* A valid ``[TOOL_CALL]`` JSON block → the same ``{next: "tool"}``.
 * A Final Answer → ``{next: "done"}``.
 * Neither → append one corrective ``role="user"`` nudge and reroll.
   A second parse failure terminates the turn (no endless retries).
@@ -65,6 +67,10 @@ _ACTION_RE = re.compile(
 )
 _ACTION_INPUT_RE = re.compile(
     r"^Action Input:\s*(?P<body>.*?)(?=^Action:|^Final Answer:|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_TOOL_CALL_RE = re.compile(
+    r"^[ \t]*\[TOOL_CALL\]\s*(?P<body>.*?)^[ \t]*\[/TOOL_CALL\][ \t]*$",
     re.MULTILINE | re.DOTALL,
 )
 # Strip ``` ```json ... ``` ``` fences that some models wrap JSON in.
@@ -339,12 +345,18 @@ def _parse_assistant(text: str) -> ParseResult:
     * ``("action", tool_name, args_dict)`` — a well-formed
       ``Action:`` / ``Action Input:`` pair was found. Args are parsed
       as JSON; if Action Input is wrapped in a ```json`` fence the
-      fence is stripped first.
+      fence is stripped first. A ``[TOOL_CALL]`` JSON block with
+      ``{"tool": <name>, "tool_input": <args>}`` maps to the same
+      result and wins over a nearby ``Final Answer`` marker.
     * ``("error", reason)`` — neither shape is present or the JSON
       could not be parsed. The strategy will issue one corrective
       nudge and reroll; a second error terminates the turn.
     """
-    # A ``Final Answer`` always wins if present, even when an
+    tool_call = _parse_tool_call_block(text)
+    if tool_call is not None:
+        return tool_call
+
+    # A classical ``Final Answer`` wins if present, even when an
     # accidental ``Action`` appears earlier — the ReAct paper treats
     # Final Answer as strictly terminal.
     final = _FINAL_RE.search(text)
@@ -372,6 +384,42 @@ def _parse_assistant(text: str) -> ParseResult:
     if not isinstance(parsed, dict):
         return ("error", f"Action Input must be a JSON object, got {type(parsed).__name__}")
     return ("action", name, cast("dict[str, Any]", parsed))
+
+
+def _parse_tool_call_block(text: str) -> ParseResult | None:
+    """Parse a provider-style ``[TOOL_CALL]`` block if one is present."""
+    match = _TOOL_CALL_RE.search(text)
+    if match is None:
+        return None
+
+    body = match.group("body").strip()
+    fence = _CODE_FENCE_RE.match(body)
+    if fence is not None:
+        body = fence.group("inner").strip()
+
+    try:
+        parsed: Any = json.loads(body)
+    except ValueError as exc:
+        return ("error", f"TOOL_CALL body is not valid JSON ({exc!s})")
+    if not isinstance(parsed, dict):
+        return ("error", f"TOOL_CALL body must be a JSON object, got {type(parsed).__name__}")
+
+    payload = cast("dict[str, Any]", parsed)
+    tool_raw = payload.get("tool")
+    if not isinstance(tool_raw, str) or not tool_raw.strip():
+        return ("error", "TOOL_CALL field 'tool' must be a non-empty string")
+
+    args_raw: Any
+    if "tool_input" in payload:
+        args_raw = payload["tool_input"]
+    elif "args" in payload:
+        args_raw = payload["args"]
+    else:
+        args_raw = {}
+    if not isinstance(args_raw, dict):
+        return ("error", f"TOOL_CALL input must be a JSON object, got {type(args_raw).__name__}")
+
+    return ("action", tool_raw.strip(), cast("dict[str, Any]", args_raw))
 
 
 __all__ = ["ReActStrategy"]

--- a/tests/bdd/features/plugin-strategy_react.feature
+++ b/tests/bdd/features/plugin-strategy_react.feature
@@ -14,6 +14,13 @@ Feature: ReAct strategy plugin
     Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
     And the response echoes the originating request id
 
+  Scenario: Assistant message with a bracketed tool-call block decides next step is tool
+    Given a strategy.decide.request whose last assistant message contains Final Answer prose and a [TOOL_CALL] block
+    When the ReAct plugin handles the event
+    Then a strategy.decide.response is emitted with next tool and the parsed tool_call payload
+    And the Final Answer prose does not terminate the turn before the tool runs
+    And the response echoes the originating request id
+
   Scenario: Observation follows the last assistant message so the next step loops back to llm
     Given a strategy.decide.request whose state has an Observation user message after the last assistant message
     When the ReAct plugin handles the event

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -628,6 +628,33 @@ def _strategy_tool_call(ctx: BDDContext) -> None:
     }
 
 
+@given("a strategy.decide.request whose last assistant message contains Final Answer prose and a [TOOL_CALL] block")
+def _strategy_bracketed_tool_call(ctx: BDDContext) -> None:
+    assistant_text = (
+        "Final Answer: I will search Mercari Japan for XPS.\n"
+        "[TOOL_CALL]\n"
+        '{"tool": "mercari_jp_search", "tool_input": {"keyword": "XPS"}}\n'
+        "[/TOOL_CALL]"
+    )
+    _strategy_payload(
+        ctx,
+        {
+            "state": {
+                "step": 0,
+                "messages": [
+                    {"role": "user", "content": "帮我看看mercari上的xps"},
+                    {"role": "assistant", "content": assistant_text},
+                ],
+            }
+        },
+    )
+    ctx.extras["expected_tool_call"] = {
+        "id": "rx-0",
+        "name": "mercari_jp_search",
+        "args": {"keyword": "XPS"},
+    }
+
+
 @given("a strategy.decide.request whose state has an Observation user message after the last assistant message")
 def _strategy_after_tool(ctx: BDDContext) -> None:
     _strategy_payload(
@@ -713,6 +740,11 @@ def _strategy_next_tool(ctx: BDDContext) -> None:
     payload = _last_payload(ctx)
     assert payload["next"] == "tool"
     assert payload["tool_call"] == ctx.extras["expected_tool_call"]
+
+
+@then("the Final Answer prose does not terminate the turn before the tool runs")
+def _strategy_final_answer_does_not_preempt_tool(ctx: BDDContext) -> None:
+    assert _last_payload(ctx)["next"] == "tool"
 
 
 @then("a strategy.decide.response is emitted with next done")

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -9,6 +9,7 @@ AC-bindings:
 
 * no assistant yet → ``test_no_assistant_yet_returns_llm``
 * well-formed Action → ``test_assistant_with_react_action_returns_tool``
+* provider-style tool-call block → ``test_assistant_with_tool_call_block_returns_tool``
 * Final Answer → ``test_assistant_with_final_answer_returns_done``
 * post-Observation → ``test_post_observation_returns_llm``
 * malformed → nudge → ``test_malformed_assistant_triggers_nudge``
@@ -130,6 +131,37 @@ async def test_assistant_with_react_action_returns_tool(tmp_path: Path) -> None:
     got = captured[0].payload
     assert got["next"] == "tool"
     assert got["tool_call"] == {"id": "rx-2", "name": "bash", "args": {"cmd": ["echo", "x"]}}
+    assert "request_id" in got
+
+
+async def test_assistant_with_tool_call_block_returns_tool(tmp_path: Path) -> None:
+    """Provider-style tool-call block → tool even when prose says Final Answer."""
+    bus = EventBus()
+    assistant_text = (
+        "Final Answer: I will search Mercari Japan for XPS.\n"
+        "[TOOL_CALL]\n"
+        '{"tool": "mercari_jp_search", "tool_input": {"keyword": "XPS"}}\n'
+        "[/TOOL_CALL]"
+    )
+    captured = await _drive(
+        bus,
+        react_plugin,
+        tmp_path,
+        {
+            "state": {
+                "step": 7,
+                "messages": [
+                    {"role": "user", "content": "帮我看看mercari上的xps"},
+                    {"role": "assistant", "content": assistant_text},
+                ],
+            }
+        },
+        session_id="sess-tool-call-block",
+    )
+    assert len(captured) == 1
+    got = captured[0].payload
+    assert got["next"] == "tool"
+    assert got["tool_call"] == {"id": "rx-7", "name": "mercari_jp_search", "args": {"keyword": "XPS"}}
     assert "request_id" in got
 
 
@@ -260,6 +292,48 @@ def test_parse_assistant_action_input_in_code_fence() -> None:
 
     out = _parse_assistant('Thought: ok\nAction: bash\nAction Input: ```json\n{"cmd": ["echo", "hi"]}\n```')
     assert out == ("action", "bash", {"cmd": ["echo", "hi"]})
+
+
+def test_parse_assistant_tool_call_block() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant(
+        "Final Answer: I will search Mercari Japan.\n"
+        "[TOOL_CALL]\n"
+        '{"tool": "mercari_jp_search", "tool_input": {"keyword": "XPS"}}\n'
+        "[/TOOL_CALL]"
+    )
+    assert out == ("action", "mercari_jp_search", {"keyword": "XPS"})
+
+
+def test_parse_assistant_malformed_tool_call_block_reports_error() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant("Final Answer: I will search Mercari Japan.\n[TOOL_CALL]\nnot-json\n[/TOOL_CALL]")
+    assert out[0] == "error"
+    assert "TOOL_CALL" in out[1]
+
+
+def test_parse_assistant_tool_call_block_accepts_json_fence_and_args_alias() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant('[TOOL_CALL]\n```json\n{"tool": "bash", "args": {"cmd": ["echo", "x"]}}\n```\n[/TOOL_CALL]')
+    assert out == ("action", "bash", {"cmd": ["echo", "x"]})
+
+
+def test_parse_assistant_tool_call_block_defaults_missing_input_to_empty_object() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    out = _parse_assistant('[TOOL_CALL]\n{"tool": "bash"}\n[/TOOL_CALL]')
+    assert out == ("action", "bash", {})
+
+
+def test_parse_assistant_tool_call_block_rejects_bad_shape() -> None:
+    from yaya.plugins.strategy_react.plugin import _parse_assistant
+
+    assert _parse_assistant("[TOOL_CALL]\n[]\n[/TOOL_CALL]")[0] == "error"
+    assert _parse_assistant('[TOOL_CALL]\n{"tool": "", "tool_input": {}}\n[/TOOL_CALL]')[0] == "error"
+    assert _parse_assistant('[TOOL_CALL]\n{"tool": "bash", "tool_input": []}\n[/TOOL_CALL]')[0] == "error"
 
 
 def test_parse_assistant_missing_labels_reports_error() -> None:


### PR DESCRIPTION
## Summary

- Parse provider-style [TOOL_CALL] JSON blocks before Final Answer detection.
- Convert tool/tool_input and args payloads into the existing ReAct tool_call decision shape.
- Return a parse error for malformed tool-call blocks instead of silently finalizing.
- Add unit, BDD, feature/spec sync coverage for the mixed Mercari tool-call output.

## Verification

- uv run pytest tests/plugins/strategy_react/test_strategy_react.py
- uv run pytest tests/bdd/test_plugins.py
- just check
- just test
- Smoke: parsed the user sample into mercari_jp_search and fetched 3 live Mercari XPS candidates.

Closes #177