### PR TITLE
fix(kernel): dispatch v1 tools from agent loop (#179)

### DIFF
--- a/docs/dev/plugin-protocol.md
+++ b/docs/dev/plugin-protocol.md
@@ -738,6 +738,9 @@ user.message.received
 
 Strategies control: which tools to offer, when to call memory, when to
 stop. Strategies **do not** change the ordering of the sequence —
+the loop emits tool requests with `schema_version="v1"` so registered
+`Tool` subclasses route through the kernel dispatcher while legacy
+subscribers still see the same bus event.
 that is the kernel's contract with adapters.
 
 ### Cross-turn history hydration
@@ -816,7 +819,7 @@ The bus auto-persister maps bus events onto tape entries:
 | `user.message.received` | `message` role=`user` | |
 | `assistant.message.delta` | *(skipped)* | Too chatty — deltas only |
 | `assistant.message.done` | `message` role=`assistant` | Final turn |
-| `tool.call.request` | `tool_call` | `{id, name, args}` |
+| `tool.call.request` | `tool_call` | `{id, name, args, schema_version?}` |
 | `tool.call.result` | `tool_result` | Correlated by `tool_call_id` |
 | `llm.call.delta` | *(skipped)* | Streaming chunk — too chatty |
 | `session.*` | *(skipped)* | Lifecycle mirrors the tape itself |

--- a/specs/kernel-agent-loop.spec
+++ b/specs/kernel-agent-loop.spec
@@ -22,6 +22,10 @@ tool, or memory plugin is built on top.
   tool call start/request/result, then assistant.message.done. The
   happy path produces an assistant message; the tool round-trip emits
   tool.call.start and tool.call.result before assistant.message.done.
+- Tool calls emitted by the loop carry `schema_version="v1"` so the
+  kernel-side v1 dispatcher runs registered `Tool` subclasses. Legacy
+  tools that subscribe directly to `tool.call.request` still receive
+  the same event and may ignore the extra field.
 - Correlation via event id: each outbound request event is matched
   with its response by echoing the request's id as
   `payload.request_id`; untracked responses carrying no matching
@@ -41,6 +45,8 @@ tool, or memory plugin is built on top.
 - src/yaya/kernel/events.py
 - src/yaya/kernel/AGENT.md
 - tests/kernel/test_loop.py
+- tests/bdd/features/kernel-agent-loop.feature
+- tests/bdd/test_kernel_agent_loop.py
 - docs/dev/plugin-protocol.md
 - specs/kernel-agent-loop.spec
 
@@ -77,6 +83,7 @@ Scenario: Tool round-trip emits tool.call.start and tool.call.result before assi
   When a user.message.received event arrives
   Then a tool.call.start event and a tool.call.result event are observed
   And they occur before assistant.message.done in the frozen event sequence
+  And the tool.call.request payload uses schema_version v1
 
 Scenario: Error path — max_iterations guard emits kernel.error and aborts the turn
   Test:

--- a/specs/kernel-registry.spec
+++ b/specs/kernel-registry.spec
@@ -54,6 +54,10 @@ a deterministic load-order tie-breaker, never a behavioral branch.
   unload task: the transient `unloading` status is claimed
   synchronously before the unload task is scheduled, so rival
   handlers observe the flip and short-circuit.
+- Registry startup installs the kernel v1 tool dispatcher before
+  `kernel.ready`, so plugins that register `Tool` subclasses during
+  `on_load` can service `tool.call.request` events carrying
+  `schema_version="v1"`.
 
 ## Boundaries
 
@@ -62,6 +66,8 @@ a deterministic load-order tie-breaker, never a behavioral branch.
 - src/yaya/kernel/__init__.py
 - src/yaya/kernel/AGENT.md
 - tests/kernel/test_registry.py
+- tests/bdd/features/kernel-registry.feature
+- tests/bdd/test_kernel_registry.py
 - specs/kernel-registry.spec
 
 ### Forbidden
@@ -126,6 +132,15 @@ Scenario: snapshot returns one entry per registered plugin with name, version, c
   When registry.snapshot() is called
   Then three entries are returned carrying name, version, category, status fields in first-seen load order
   And the failing plugin's status is "failed"
+
+Scenario: Registry startup installs the v1 tool dispatcher
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_registry.py::test_registry_installs_v1_tool_dispatcher
+  Level: unit
+  Given a plugin that registers a v1 Tool during on_load
+  When registry is started and a v1 tool.call.request is published
+  Then a tool.call.result event is emitted by the kernel dispatcher
 
 Scenario: install shells to uv pip via subprocess_exec and re-runs discovery
   Test:

--- a/src/yaya/kernel/loop.py
+++ b/src/yaya/kernel/loop.py
@@ -734,7 +734,7 @@ class AgentLoop:
 
         req = new_event(
             "tool.call.request",
-            {"id": tool_id, "name": name, "args": args},
+            {"schema_version": "v1", "id": tool_id, "name": name, "args": args},
             session_id=session_id,
             source=_SOURCE,
         )

--- a/src/yaya/kernel/registry.py
+++ b/src/yaya/kernel/registry.py
@@ -69,6 +69,7 @@ from yaya.kernel.logging import get_plugin_logger
 from yaya.kernel.plugin import Category, KernelContext, Plugin
 from yaya.kernel.providers import PROVIDERS_PREFIX, PROVIDERS_SEEDED_MARKER
 from yaya.kernel.session import Session
+from yaya.kernel.tool import install_dispatcher
 
 if TYPE_CHECKING:  # pragma: no cover - type-only import, breaks an import cycle.
     from yaya.kernel.bus import EventBus, Subscription
@@ -282,6 +283,7 @@ class PluginRegistry:
             self._on_plugin_error,
             source=_SOURCE,
         )
+        install_dispatcher(self._bus)
 
         await self._discover_and_load()
 

--- a/tests/bdd/features/kernel-agent-loop.feature
+++ b/tests/bdd/features/kernel-agent-loop.feature
@@ -22,6 +22,7 @@ Feature: Kernel AgentLoop fixed per-turn scheduler
     When a user.message.received event arrives
     Then a tool.call.start event and a tool.call.result event are observed
     And they occur before assistant.message.done in the frozen event sequence
+    And the tool.call.request payload uses schema_version v1
 
   Scenario: Error path — max_iterations guard emits kernel.error and aborts the turn
     Given an AgentLoop configured with max_iterations=3

--- a/tests/bdd/features/kernel-registry.feature
+++ b/tests/bdd/features/kernel-registry.feature
@@ -43,6 +43,11 @@ Feature: Kernel plugin registry — discovery, lifecycle, and failure isolation
     Then three entries are returned carrying name, version, category, status fields in first-seen load order
     And the failing plugin's status is "failed"
 
+  Scenario: Registry startup installs the v1 tool dispatcher
+    Given a plugin that registers a v1 Tool during on_load
+    When registry is started and a v1 tool.call.request is published
+    Then a tool.call.result event is emitted by the kernel dispatcher
+
   Scenario: install shells to uv pip via subprocess_exec and re-runs discovery
     Given an uv binary available on PATH
     When registry.install("yaya-tool-bash") is called

--- a/tests/bdd/test_kernel_agent_loop.py
+++ b/tests/bdd/test_kernel_agent_loop.py
@@ -352,6 +352,13 @@ def _tool_before_done(ctx: BDDContext) -> None:
     assert order.index("tool.call.result") < order.index("assistant.message.done")
 
 
+@then("the tool.call.request payload uses schema_version v1")
+def _tool_request_uses_v1_schema(ctx: BDDContext) -> None:
+    tool: _FakeTool = ctx.extras["tool"]
+    assert tool.calls, "no tool.call.request seen"
+    assert tool.calls[0]["schema_version"] == "v1"
+
+
 # ---------------------------------------------------------------------------
 # Scenario 3: max_iterations guard
 # ---------------------------------------------------------------------------

--- a/tests/bdd/test_kernel_registry.py
+++ b/tests/bdd/test_kernel_registry.py
@@ -30,6 +30,7 @@ from yaya.kernel.bus import EventBus
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.plugin import Category, KernelContext
 from yaya.kernel.registry import PluginRegistry, PluginStatus
+from yaya.kernel.tool import TextBlock, Tool, ToolOk, ToolReturnValue, register_tool, unregister_tool
 
 from .conftest import BDDContext
 
@@ -827,6 +828,104 @@ def _rivals_short_circuit(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> N
     registry: PluginRegistry = ctx.extras["registry"]
     statuses = {row["name"]: row["status"] for row in registry.snapshot()}
     assert statuses["flaky-tool"] == "failed"
+    _teardown(ctx, loop)
+
+
+# ---------------------------------------------------------------------------
+# Scenario — registry startup installs the v1 tool dispatcher
+# ---------------------------------------------------------------------------
+
+
+class _BDDRegistryV1Tool(Tool):
+    """BDD-only v1 Tool, registered via a plugin's on_load hook."""
+
+    name: ClassVar[str] = "bdd_registry_v1_echo"
+    description: ClassVar[str] = "Echo through the registry-installed v1 dispatcher."
+
+    text: str
+
+    async def run(self, ctx: KernelContext) -> ToolReturnValue:
+        del ctx
+        return ToolOk(brief="echoed", display=TextBlock(text=self.text))
+
+
+class _V1RegisteringPlugin:
+    """Plugin that registers a v1 ``Tool`` subclass during ``on_load``."""
+
+    name = "bdd-v1-tool-plugin"
+    version = "0.1.0"
+    category = Category.TOOL
+    requires: ClassVar[list[str]] = []
+
+    def subscriptions(self) -> list[str]:
+        return []
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        del ctx
+        register_tool(_BDDRegistryV1Tool)
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        del ev, ctx
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        del ctx
+        unregister_tool(_BDDRegistryV1Tool.name)
+
+
+@given("a plugin that registers a v1 Tool during on_load")
+def _plugin_registers_v1_tool(ctx: BDDContext, tmp_path: Path) -> None:
+    plugin = _V1RegisteringPlugin()
+    ctx.extras["plugin"] = plugin
+    ctx.extras["tmp_path"] = tmp_path
+    ctx.extras["tool_results"] = []
+    ctx.extras["entry_points"] = [_FakeEntryPoint("v1-tool", plugin)]
+
+
+@when("registry is started and a v1 tool.call.request is published")
+def _start_registry_and_publish_v1_request(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> None:
+    bus = EventBus()
+    ctx.bus = bus
+    results: list[Event] = ctx.extras["tool_results"]
+    bus.subscribe("tool.call.result", _collector(results), source="bdd-observer")
+
+    eps = ctx.extras["entry_points"]
+    patcher = patch("yaya.kernel.registry.entry_points", side_effect=_fake_entry_points(eps))
+    patcher.start()
+    ctx.extras["patchers"] = [patcher]
+
+    registry = PluginRegistry(bus, state_dir=ctx.extras["tmp_path"])
+    ctx.extras["registry"] = registry
+
+    async def _run() -> None:
+        await registry.start()
+        await bus.publish(
+            new_event(
+                "tool.call.request",
+                {
+                    "schema_version": "v1",
+                    "id": "bdd-call-1",
+                    "name": _BDDRegistryV1Tool.name,
+                    "args": {"text": "ok"},
+                },
+                session_id="s",
+                source="kernel",
+            )
+        )
+        for _ in range(200):
+            if results:
+                return
+            await asyncio.sleep(0.005)
+        raise AssertionError("no tool.call.result observed")
+
+    loop.run_until_complete(_run())
+
+
+@then("a tool.call.result event is emitted by the kernel dispatcher")
+def _tool_result_emitted(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> None:
+    results: list[Event] = ctx.extras["tool_results"]
+    assert len(results) == 1, f"expected 1 tool.call.result, got {len(results)}"
+    payload = results[0].payload
+    assert payload["id"] == "bdd-call-1"
     _teardown(ctx, loop)
 
 

--- a/tests/kernel/test_loop.py
+++ b/tests/kernel/test_loop.py
@@ -11,13 +11,22 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
 from yaya.kernel.bus import EventBus
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.loop import AgentLoop, LoopConfig
+from yaya.kernel.tool import (
+    TextBlock,
+    Tool,
+    ToolOk,
+    ToolReturnValue,
+    install_dispatcher,
+    register_tool,
+    unregister_tool,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -113,6 +122,19 @@ class FakeTool:
                 source="fake-tool",
             )
         )
+
+
+class EchoV1Tool(Tool):
+    """Registered v1 tool used to prove AgentLoop routes through the dispatcher."""
+
+    name: ClassVar[str] = "v1_echo"
+    description: ClassVar[str] = "Echo a value through the v1 tool dispatcher."
+
+    x: int
+
+    async def run(self, ctx: Any) -> ToolReturnValue:
+        del ctx
+        return ToolOk(brief="echoed", display=TextBlock(text=str(self.x)))
 
 
 @dataclass
@@ -268,11 +290,66 @@ async def test_tool_roundtrip() -> None:
     assert order.index("tool.call.result") < order.index("assistant.message.done")
     assert tool.calls == [
         {
+            "schema_version": "v1",
             "id": "t1",
             "name": "echo",
             "args": {"x": 1},
         }
     ]
+
+
+async def test_tool_roundtrip_dispatches_registered_v1_tool() -> None:
+    """AgentLoop tool.call.request must carry schema_version so v1 tools run."""
+    bus = EventBus()
+    install_dispatcher(bus)
+    register_tool(EchoV1Tool)
+    strategy = FakeStrategy(
+        bus,
+        script=[
+            {
+                "next": "tool",
+                "tool_call": {"id": "v1-1", "name": "v1_echo", "args": {"x": 7}},
+            },
+            {"next": "done"},
+        ],
+    )
+    strategy.subscribe()
+
+    tool_results: list[Event] = []
+    errors: list[Event] = []
+
+    async def on_tool_result(ev: Event) -> None:
+        tool_results.append(ev)
+
+    async def on_kernel_error(ev: Event) -> None:
+        errors.append(ev)
+
+    bus.subscribe("tool.call.result", on_tool_result, source="probe")
+    bus.subscribe("kernel.error", on_kernel_error, source="probe")
+
+    loop = AgentLoop(bus, LoopConfig(step_timeout_s=0.05))
+    try:
+        await loop.start()
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "run v1"},
+                session_id="s-v1-tool",
+                source="fake-adapter",
+            )
+        )
+        await asyncio.sleep(0.1)
+        await _settle(bus)
+    finally:
+        await loop.stop()
+        await bus.close()
+        unregister_tool(EchoV1Tool.name)
+
+    assert errors == []
+    assert len(tool_results) == 1
+    assert tool_results[0].payload["id"] == "v1-1"
+    assert tool_results[0].payload["ok"] is True
+    assert tool_results[0].payload["envelope"]["display"] == {"kind": "text", "text": "7"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kernel/test_registry.py
+++ b/tests/kernel/test_registry.py
@@ -29,6 +29,7 @@ from yaya.kernel.registry import (
     PluginStatus,
     validate_install_source,
 )
+from yaya.kernel.tool import TextBlock, Tool, ToolOk, ToolReturnValue, register_tool, unregister_tool
 
 # ---------------------------------------------------------------------------
 # Stub plugins.
@@ -84,6 +85,38 @@ class _FailingPlugin:
 
     async def on_unload(self, ctx: KernelContext) -> None:
         self.on_unload_calls += 1
+
+
+class _RegistryV1Tool(Tool):
+    name: ClassVar[str] = "registry_v1_echo"
+    description: ClassVar[str] = "Echo through a registry-installed v1 dispatcher."
+
+    text: str
+
+    async def run(self, ctx: KernelContext) -> ToolReturnValue:
+        del ctx
+        return ToolOk(brief="echoed", display=TextBlock(text=self.text))
+
+
+class _V1ToolPlugin:
+    name = "v1-tool-plugin"
+    version = "0.1.0"
+    category = Category.TOOL
+    requires: ClassVar[list[str]] = []
+
+    def subscriptions(self) -> list[str]:
+        return []
+
+    async def on_load(self, ctx: KernelContext) -> None:
+        del ctx
+        register_tool(_RegistryV1Tool)
+
+    async def on_event(self, ev: Event, ctx: KernelContext) -> None:
+        del ev, ctx
+
+    async def on_unload(self, ctx: KernelContext) -> None:
+        del ctx
+        unregister_tool(_RegistryV1Tool.name)
 
 
 class _FakeEntryPoint:
@@ -262,6 +295,43 @@ async def test_snapshot_lists_every_plugin_with_status(tmp_path: Path) -> None:
     # Every row has the mandated keys.
     for row in rows:
         assert set(row.keys()) == {"name", "version", "category", "status"}
+
+    await registry.stop()
+    await bus.close()
+
+
+async def test_registry_installs_v1_tool_dispatcher(tmp_path: Path) -> None:
+    """Registry boot wires the kernel v1 dispatcher before kernel.ready."""
+    bus = EventBus()
+    results: list[Event] = []
+    bus.subscribe("tool.call.result", _collector(results), source="observer")
+
+    plugin = _V1ToolPlugin()
+    with patch(
+        "yaya.kernel.registry.entry_points",
+        side_effect=_fake_entry_points([_FakeEntryPoint("v1-tool", plugin)]),
+    ):
+        registry = PluginRegistry(bus, state_dir=tmp_path)
+        await registry.start()
+
+    await bus.publish(
+        new_event(
+            "tool.call.request",
+            {
+                "schema_version": "v1",
+                "id": "call-1",
+                "name": _RegistryV1Tool.name,
+                "args": {"text": "ok"},
+            },
+            session_id="s",
+            source="kernel",
+        )
+    )
+    await _drain_until(lambda: len(results) == 1, bus)
+
+    assert results[0].payload["id"] == "call-1"
+    assert results[0].payload["ok"] is True
+    assert results[0].payload["envelope"]["display"] == {"kind": "text", "text": "ok"}
 
     await registry.stop()
     await bus.close()


### PR DESCRIPTION
## Summary

- AgentLoop now stamps `schema_version="v1"` on `tool.call.request` so registered `Tool` subclasses run through the kernel dispatcher (fixes `mercari_jp_search` step_timeout in Chat UI).
- Registry wires the v1 tool dispatcher during `start()` before `kernel.ready`, so plugins that `register_tool(...)` in `on_load` can service the very first request.
- Legacy bash still works via its own `tool.call.request` subscription.

## Test plan

- [x] `just check` green
- [x] `just test` green (new unit + BDD regressions for loop + registry)
- [ ] Playwright smoke: Chat UI → Mercari search returns a `tool.call.result` before timeout

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)