### PR TITLE
fix(kernel): project v1 tool envelope into observation (#181)

### DIFF
--- a/specs/kernel-agent-loop.spec
+++ b/specs/kernel-agent-loop.spec
@@ -26,6 +26,12 @@ tool, or memory plugin is built on top.
   kernel-side v1 dispatcher runs registered `Tool` subclasses. Legacy
   tools that subscribe directly to `tool.call.request` still receive
   the same event and may ignore the extra field.
+- `tool.call.result` projection into the ReAct `Observation:` message
+  handles both shapes: the v1 dispatcher's `{envelope: {brief, display}}`
+  (TextBlock / MarkdownBlock surface as text; JsonBlock surfaces as
+  `{brief, data}`) and the legacy `{value: ...}` shape emitted by
+  `tool_bash`. Failures preserve `kind` and `brief` from the envelope
+  so the LLM sees the tool-authored reason, not a generic "unknown".
 - Correlation via event id: each outbound request event is matched
   with its response by echoing the request's id as
   `payload.request_id`; untracked responses carrying no matching
@@ -106,6 +112,16 @@ Scenario: Error path — user.interrupt guard aborts the active turn for the ses
   When a user.interrupt event is published for the same active session
   Then the current turn aborts under the interrupt guard
   And no further tool.call.request is emitted for that turn
+
+Scenario: v1 tool envelope projects into the ReAct Observation
+  Test:
+    Package: yaya
+    Filter: tests/kernel/test_loop.py::test_loop_projects_v1_envelope_into_llm_request
+  Level: unit
+  Given an AgentLoop with a registered v1 Tool returning a TextBlock envelope
+  And a strategy that calls the tool then asks the LLM
+  When a user.message.received event arrives
+  Then the subsequent llm.call.request carries an Observation message with the tool's text
 
 Scenario: Correlation via request_id — untracked response without matching request_id is ignored
   Test:

--- a/src/yaya/kernel/loop.py
+++ b/src/yaya/kernel/loop.py
@@ -131,15 +131,33 @@ def _format_tool_result_for_llm(result_payload: dict[str, Any]) -> str:
 
     The caller wraps the returned string as
     ``role="user" content="Observation: <this>"`` before appending it
-    to the conversation. We prefer compact structured JSON so the
-    model can parse fields (stdout / stderr / error) reliably, but
-    fall back to the stdout-only shape when the tool returned a flat
-    ``value`` that already reads well as text.
+    to the conversation.
+
+    Two payload shapes reach this formatter:
+
+    * The v1 ``kernel.tool.dispatch`` shape — ``{id, ok, envelope, ...}``
+      where ``envelope`` is a serialised :class:`ToolOk` / :class:`ToolError`
+      (carries ``brief`` + a typed ``display`` block). Every v1 ``Tool``
+      subclass (mercari, mcp_bridge-derived tools, agent-tool) returns
+      through this path.
+    * The legacy ``on_event`` shape — ``{id, ok, value, ...}`` or
+      ``{id, ok, error, ...}``. Only ``tool_bash`` still emits this.
+
+    We extract a text rendition the LLM can actually read: the display
+    block's payload for v1, or the raw ``value`` for legacy. Returning
+    ``{"ok": true, "value": null}`` (the old default branch) silently
+    hid every v1 tool's output from the model and broke downstream
+    reasoning — see #181.
     """
     import json
 
     if result_payload.get("ok") is False:
-        return json.dumps({"ok": False, "error": result_payload.get("error", "unknown")})
+        return _format_failed_result(result_payload)
+
+    envelope_raw: Any = result_payload.get("envelope")
+    if isinstance(envelope_raw, dict):
+        return _format_v1_envelope(cast("dict[str, Any]", envelope_raw))
+
     value: Any = result_payload.get("value")
     if isinstance(value, dict):
         typed_value = cast("dict[str, Any]", value)
@@ -148,6 +166,83 @@ def _format_tool_result_for_llm(result_payload: dict[str, Any]) -> str:
     if isinstance(value, str):
         return value
     return json.dumps({"ok": True, "value": value})
+
+
+def _format_failed_result(result_payload: dict[str, Any]) -> str:
+    """Project an ``ok=False`` tool result into a compact error line.
+
+    Both shapes surface failures here: the v1 dispatcher emits
+    ``envelope`` with ``kind`` + ``brief`` + ``display``; legacy
+    ``tool_bash`` emits a flat ``error`` string. Prefer the v1 detail
+    when present so the LLM sees the tool-authored brief instead of a
+    generic "unknown".
+    """
+    import json
+
+    envelope_raw: Any = result_payload.get("envelope")
+    if isinstance(envelope_raw, dict):
+        envelope = cast("dict[str, Any]", envelope_raw)
+        failure: dict[str, Any] = {"ok": False}
+        kind = envelope.get("kind")
+        if isinstance(kind, str) and kind:
+            failure["kind"] = kind
+        brief = envelope.get("brief")
+        if isinstance(brief, str) and brief:
+            failure["error"] = brief
+        display = _display_payload(envelope.get("display"))
+        if display is not None:
+            failure["detail"] = display
+        if "error" not in failure and "detail" not in failure:
+            failure["error"] = "tool failed"
+        return json.dumps(failure)
+
+    return json.dumps({"ok": False, "error": result_payload.get("error", "unknown")})
+
+
+def _format_v1_envelope(envelope: dict[str, Any]) -> str:
+    """Project a v1 ``ToolOk`` envelope into an LLM-readable observation.
+
+    ``envelope.display`` is one of the built-in blocks:
+    ``TextBlock`` / ``MarkdownBlock`` carry ``text``; ``JsonBlock``
+    carries structured ``data``. When the display payload already reads
+    well as text we return it verbatim; structured JSON is re-serialised
+    with ``brief`` so the LLM has both a one-line summary and the full
+    content to cite.
+    """
+    import json
+
+    brief_raw: Any = envelope.get("brief")
+    brief = brief_raw if isinstance(brief_raw, str) else ""
+    display = _display_payload(envelope.get("display"))
+
+    if isinstance(display, str):
+        return f"{brief}\n{display}" if brief else display
+    if display is None:
+        return brief or json.dumps({"ok": True})
+    body: dict[str, Any] = {"ok": True, "data": display}
+    if brief:
+        body["brief"] = brief
+    return json.dumps(body)
+
+
+def _display_payload(display: Any) -> str | dict[str, Any] | None:
+    """Extract the readable payload from a ``DisplayBlock`` dump.
+
+    ``Tool.run`` serialises its display through ``model_dump(mode="json")``
+    so the block surfaces as a plain dict here. Text/Markdown blocks map
+    to their ``text`` string; JSON blocks map to their ``data`` dict.
+    Anything else is left to the caller's fallback.
+    """
+    if not isinstance(display, dict):
+        return None
+    typed = cast("dict[str, Any]", display)
+    text = typed.get("text")
+    if isinstance(text, str):
+        return text
+    data = typed.get("data")
+    if isinstance(data, dict):
+        return cast("dict[str, Any]", data)
+    return None
 
 
 def project_entries_to_messages(entries: list[Any]) -> list[Message]:

--- a/tests/bdd/features/kernel-agent-loop.feature
+++ b/tests/bdd/features/kernel-agent-loop.feature
@@ -38,6 +38,12 @@ Feature: Kernel AgentLoop fixed per-turn scheduler
     Then the current turn aborts under the interrupt guard
     And no further tool.call.request is emitted for that turn
 
+  Scenario: v1 tool envelope projects into the ReAct Observation
+    Given an AgentLoop with a registered v1 Tool returning a TextBlock envelope
+    And a strategy that calls the tool then asks the LLM
+    When a user.message.received event arrives
+    Then the subsequent llm.call.request carries an Observation message with the tool's text
+
   Scenario: Correlation via request_id — untracked response without matching request_id is ignored
     Given an AgentLoop with an in-flight outbound request tracked by its event id
     When a response event arrives carrying no matching request_id correlation

--- a/tests/bdd/test_kernel_agent_loop.py
+++ b/tests/bdd/test_kernel_agent_loop.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
@@ -25,6 +25,15 @@ from pytest_bdd import given, parsers, scenarios, then, when
 from yaya.kernel.bus import EventBus
 from yaya.kernel.events import Event, new_event
 from yaya.kernel.loop import AgentLoop, LoopConfig
+from yaya.kernel.tool import (
+    TextBlock,
+    Tool,
+    ToolOk,
+    ToolReturnValue,
+    install_dispatcher,
+    register_tool,
+    unregister_tool,
+)
 
 from .conftest import BDDContext
 
@@ -292,6 +301,7 @@ def _user_message_arrives(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> N
         done_events: list[Event] = []
         tool_start: list[Event] = []
         tool_result: list[Event] = []
+        llm_requests: list[Event] = []
         errors: list[Event] = []
         order: list[str] = []
 
@@ -307,12 +317,16 @@ def _user_message_arrives(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> N
             tool_result.append(ev)
             order.append("tool.call.result")
 
+        async def on_llm_request(ev: Event) -> None:
+            llm_requests.append(ev)
+
         async def on_kernel_error(ev: Event) -> None:
             errors.append(ev)
 
         bus.subscribe("assistant.message.done", on_done, source="probe")
         bus.subscribe("tool.call.start", on_tool_start, source="probe")
         bus.subscribe("tool.call.result", on_tool_result, source="probe")
+        bus.subscribe("llm.call.request", on_llm_request, source="probe")
         bus.subscribe("kernel.error", on_kernel_error, source="probe")
 
         await bus.publish(
@@ -330,6 +344,7 @@ def _user_message_arrives(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> N
         ctx.extras["done_events"] = done_events
         ctx.extras["tool_start"] = tool_start
         ctx.extras["tool_result"] = tool_result
+        ctx.extras["llm_requests"] = llm_requests
         ctx.extras["errors"] = errors
         ctx.extras["order"] = order
 
@@ -578,6 +593,71 @@ def _publish_untracked_response(ctx: BDDContext, loop: asyncio.AbstractEventLoop
         await bus.close()
 
     loop.run_until_complete(_drive())
+
+
+# ---------------------------------------------------------------------------
+# Scenario: v1 tool envelope → Observation message
+# ---------------------------------------------------------------------------
+
+
+class _BDDEnvelopeTool(Tool):
+    name: ClassVar[str] = "bdd_envelope_tool"
+    description: ClassVar[str] = "BDD-only v1 tool returning a TextBlock envelope."
+
+    who: str
+
+    async def run(self, ctx: Any) -> ToolReturnValue:
+        del ctx
+        return ToolOk(brief="greeted", display=TextBlock(text=f"hi {self.who}"))
+
+
+@given("an AgentLoop with a registered v1 Tool returning a TextBlock envelope")
+def _register_envelope_tool(ctx: BDDContext) -> None:
+    bus = EventBus()
+    ctx.bus = bus
+    install_dispatcher(bus)
+    register_tool(_BDDEnvelopeTool)
+    ctx.extras["envelope_tool_registered"] = True
+
+
+@given("a strategy that calls the tool then asks the LLM")
+def _strategy_tool_then_llm(ctx: BDDContext) -> None:
+    assert ctx.bus is not None
+    strategy = _FakeStrategy(
+        ctx.bus,
+        script=[
+            {
+                "next": "tool",
+                "tool_call": {"id": "t1", "name": _BDDEnvelopeTool.name, "args": {"who": "ada"}},
+            },
+            {"next": "llm", "provider": "fake", "model": "m"},
+            {"next": "done"},
+        ],
+    )
+    strategy.subscribe()
+    llm = _FakeLLM(ctx.bus, text="thanks")
+    llm.subscribe()
+    ctx.extras["strategy"] = strategy
+    ctx.extras["llm"] = llm
+
+
+@then("the subsequent llm.call.request carries an Observation message with the tool's text")
+def _llm_request_carries_observation(ctx: BDDContext, loop: asyncio.AbstractEventLoop) -> None:
+    llm_requests: list[Event] = ctx.extras["llm_requests"]
+    try:
+        assert llm_requests, "expected at least one llm.call.request after the tool step"
+        messages = llm_requests[0].payload.get("messages", [])
+        observations = [
+            m for m in messages if isinstance(m, dict) and str(m.get("content", "")).startswith("Observation:")
+        ]
+        assert observations, f"no Observation message in transcript: {messages!r}"
+        rendered = observations[-1]["content"]
+        assert "hi ada" in rendered, rendered
+        assert '"value": null' not in rendered, rendered
+    finally:
+        if ctx.extras.get("envelope_tool_registered"):
+            unregister_tool(_BDDEnvelopeTool.name)
+        del loop
 
 
 @then("the untracked response is ignored and the loop keeps awaiting the correlated reply")

--- a/tests/kernel/test_loop.py
+++ b/tests/kernel/test_loop.py
@@ -17,7 +17,7 @@ import pytest
 
 from yaya.kernel.bus import EventBus
 from yaya.kernel.events import Event, new_event
-from yaya.kernel.loop import AgentLoop, LoopConfig
+from yaya.kernel.loop import AgentLoop, LoopConfig, _format_tool_result_for_llm
 from yaya.kernel.tool import (
     TextBlock,
     Tool,
@@ -1366,3 +1366,161 @@ async def test_loop_ignores_deltas_for_unknown_request_id() -> None:
     await bus.close()
 
     assert deltas.events == []
+
+
+# ---------------------------------------------------------------------------
+# _format_tool_result_for_llm — regression guard for issue #181.
+# The v1 dispatcher emits ``{envelope: ...}``; legacy ``tool_bash`` emits
+# ``{value: ...}``. Both shapes must project into a readable observation so
+# the LLM does not see ``{"ok": true, "value": null}`` for every v1 tool.
+# ---------------------------------------------------------------------------
+
+
+def test_format_v1_envelope_json_block_includes_brief_and_data() -> None:
+    payload = {
+        "id": "rx-1",
+        "ok": True,
+        "envelope": {
+            "ok": True,
+            "brief": "found 2 candidate(s)",
+            "display": {"kind": "json", "data": {"items": [1, 2]}},
+        },
+        "request_id": "req-1",
+    }
+    observation = _format_tool_result_for_llm(payload)
+    assert '"brief": "found 2 candidate(s)"' in observation
+    assert '"items"' in observation
+    assert '"value": null' not in observation
+
+
+def test_format_v1_envelope_text_block_returns_readable_text() -> None:
+    payload = {
+        "id": "rx-2",
+        "ok": True,
+        "envelope": {
+            "ok": True,
+            "brief": "echoed",
+            "display": {"kind": "text", "text": "hello world"},
+        },
+        "request_id": "req-2",
+    }
+    observation = _format_tool_result_for_llm(payload)
+    assert "hello world" in observation
+    assert "echoed" in observation
+
+
+def test_format_v1_envelope_failure_surfaces_brief_and_kind() -> None:
+    payload = {
+        "id": "rx-3",
+        "ok": False,
+        "envelope": {
+            "ok": False,
+            "kind": "validation",
+            "brief": "invalid params for tool 'mercari_jp_search'",
+            "display": {"kind": "text", "text": "keyword: field required"},
+        },
+        "request_id": "req-3",
+    }
+    observation = _format_tool_result_for_llm(payload)
+    assert '"ok": false' in observation
+    assert "validation" in observation
+    assert "invalid params" in observation
+
+
+def test_format_legacy_bash_value_shape_unchanged() -> None:
+    payload = {
+        "id": "rx-4",
+        "ok": True,
+        "value": {"stdout": "hi\n", "stderr": "", "returncode": 0},
+        "request_id": "req-4",
+    }
+    observation = _format_tool_result_for_llm(payload)
+    assert '"stdout": "hi\\n"' in observation
+    assert '"returncode": 0' in observation
+
+
+def test_format_legacy_error_shape_unchanged() -> None:
+    payload = {
+        "id": "rx-5",
+        "ok": False,
+        "error": "timeout",
+        "request_id": "req-5",
+    }
+    observation = _format_tool_result_for_llm(payload)
+    assert '"error": "timeout"' in observation
+
+
+async def test_loop_projects_v1_envelope_into_llm_request() -> None:
+    """End-to-end: a registered v1 ``Tool`` reaches the LLM as readable data.
+
+    The loop appends ``Observation: <formatted>`` as a ``role="user"``
+    message when a ``next=tool`` step completes. This test registers a
+    v1 tool that returns a ``ToolOk`` with a ``TextBlock`` display,
+    then captures the ``llm.call.request`` that follows the tool step
+    and asserts the tool's text reached the transcript. Guards against
+    the issue #181 regression where the formatter hid v1 envelopes as
+    ``{"value": null}``.
+    """
+    bus = EventBus()
+    install_dispatcher(bus)
+
+    class _HelloTool(Tool):
+        name: ClassVar[str] = "hello_v1"
+        description: ClassVar[str] = "Return a friendly greeting."
+
+        who: str
+
+        async def run(self, ctx: Any) -> ToolReturnValue:
+            del ctx
+            return ToolOk(brief="greeted", display=TextBlock(text=f"hi {self.who}"))
+
+    register_tool(_HelloTool)
+    try:
+        strategy = FakeStrategy(
+            bus,
+            script=[
+                {
+                    "next": "tool",
+                    "tool_call": {"id": "t1", "name": "hello_v1", "args": {"who": "ada"}},
+                },
+                {"next": "llm", "provider": "fake", "model": "m"},
+                {"next": "done"},
+            ],
+        )
+        llm = FakeLLM(bus, text="thanks")
+        strategy.subscribe()
+        llm.subscribe()
+
+        llm_requests: list[Event] = []
+
+        async def _capture_llm(ev: Event) -> None:
+            llm_requests.append(ev)
+
+        bus.subscribe("llm.call.request", _capture_llm, source="probe")
+
+        recorder = EventRecorder(bus)
+        recorder.watch("assistant.message.done")
+
+        loop = AgentLoop(bus, LoopConfig(step_timeout_s=2.0))
+        await loop.start()
+        await bus.publish(
+            new_event(
+                "user.message.received",
+                {"text": "greet ada"},
+                session_id="s-1",
+                source="probe",
+            )
+        )
+        await _settle(bus)
+        await loop.stop()
+        await bus.close()
+    finally:
+        unregister_tool(_HelloTool.name)
+
+    assert llm_requests, "expected at least one llm.call.request after the tool step"
+    messages = llm_requests[0].payload.get("messages", [])
+    observations = [m for m in messages if isinstance(m, dict) and str(m.get("content", "")).startswith("Observation:")]
+    assert observations, messages
+    rendered = observations[-1]["content"]
+    assert "hi ada" in rendered, rendered
+    assert '"value": null' not in rendered, rendered


### PR DESCRIPTION
## Summary

After #180, v1 tools (mercari, mcp-bridge, agent-tool) dispatch and return an envelope — but `_format_tool_result_for_llm` only understood the legacy `{value: ...}` shape. Every v1 tool result was projected to the LLM as `Observation: {"ok": true, "value": null}`, so the model concluded "the search returned null" even when the tool found 20 items.

- Handle the v1 `{envelope: {brief, display}}` shape: TextBlock / MarkdownBlock → text; JsonBlock → `{brief, data}`.
- Surface `kind` + `brief` on failure so the LLM sees the tool-authored reason.
- Keep the legacy `{value: ...}` path for `tool_bash` unchanged.

## Test plan

- [x] `just check`
- [x] `just test` (new unit tests for each envelope shape + legacy; BDD e2e that `llm.call.request` after a v1 tool step carries a non-null Observation)
- [x] WS smoke pre-fix vs. post-fix: Mercari result body now reaches the LLM instead of a null placeholder

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)