### PR TITLE
feat(mercari_jp): category/brand/condition filters (#191)

### DIFF
--- a/specs/plugin-mercari_jp.spec
+++ b/specs/plugin-mercari_jp.spec
@@ -23,6 +23,10 @@ access.
   candidates, score reasons, and warnings.
 - Candidate ranking is deterministic and happens before the LLM writes
   user-facing recommendations.
+- The search surface accepts optional native Mercari narrowing fields
+  (`category_ids`, `brand_ids`, `item_condition`, `shipping_payer`) and
+  maps them onto the Mercapi JSON payload. Unset fields preserve the
+  pre-#191 payload shape so no existing caller regresses.
 
 ## Boundaries
 
@@ -73,6 +77,15 @@ Scenario: Empty Mercapi results stay successful and explain search drift
   Given Mercapi returns a Mercari search response with no product candidates
   When the mercari_jp_search tool runs
   Then it returns an empty candidate list with warnings containing Mercari coverage and Japanese keyword guidance
+
+Scenario: Filter fields map onto the Mercapi payload
+  Test:
+    Package: yaya
+    Filter: tests/plugins/mercari_jp/test_plugin.py::test_filter_fields_land_on_mercapi_payload
+  Level: unit
+  Given a search request with category, brand, item_condition, and shipping_payer filters set
+  When the Mercapi payload is built
+  Then the payload carries the expected category, brand, condition, and shipping-payer IDs
 
 ## Out of Scope
 

--- a/src/yaya/plugins/mercari_jp/AGENT.md
+++ b/src/yaya/plugins/mercari_jp/AGENT.md
@@ -23,6 +23,23 @@ the kernel.
 - Use deterministic parsing and scoring; the LLM writes user-facing
   recommendations from the returned JSON.
 
+## Filters (#191)
+Beyond keyword/price/sort/status, the tool now surfaces Mercari's
+native narrowing fields. All optional; unset fields round-trip as
+empty lists so the Mercari payload stays identical to pre-#191:
+
+- `category_ids: list[int]` — Mercari `categoryId` (e.g. 7 = スマホ).
+- `brand_ids: list[int]` — Mercari `brandId`.
+- `item_condition` — `new` / `like_new` / `no_scratches`
+  `small_scratches` / `scratches` / `poor`. Maps 1:1 to Mercari's
+  `itemConditionId` 1..6 via `_ITEM_CONDITION_IDS` in `search.py`.
+- `shipping_payer` — `seller` (送料込み) or `buyer`.
+
+Name/brand lookup from free-form strings to ids is deliberately
+out-of-scope; future work lives in a separate `mercari_jp_category_lookup`
+tool and an optional `mercari_jp_item_detail(item_id)` tool for seller
+ratings / shipping details.
+
 ## Interaction
 - `plugin.py` owns the plugin lifecycle and tool registration.
 - `search.py` owns request models, Mercapi-compatible request signing,

--- a/src/yaya/plugins/mercari_jp/plugin.py
+++ b/src/yaya/plugins/mercari_jp/plugin.py
@@ -65,6 +65,34 @@ class MercariJpSearchTool(Tool):
         description="Sort mode.",
     )
     limit: int = Field(default=20, ge=1, le=50, description="Maximum candidates to return.")
+    category_ids: list[int] = Field(
+        default_factory=lambda: [],
+        description=(
+            "Mercari category ID filter (combines with OR). Use the numeric IDs "
+            "Mercari exposes in its public search URL (e.g. 7 = スマホ・タブレット・パソコン, "
+            "5 = ファッション). Leave empty to search across all categories."
+        ),
+    )
+    brand_ids: list[int] = Field(
+        default_factory=lambda: [],
+        description="Mercari brand ID filter (combines with OR). Leave empty to search across all brands.",
+    )
+    item_condition: Literal["new", "like_new", "no_scratches", "small_scratches", "scratches", "poor"] | None = Field(
+        default=None,
+        description=(
+            "Required item condition bucket. 'new' = 新品, 'like_new' = 未使用に近い, "
+            "'no_scratches' = 目立った傷や汚れなし, 'small_scratches' = やや傷や汚れあり, "
+            "'scratches' = 傷や汚れあり, 'poor' = 全体的に状態が悪い. Omit to accept any condition."
+        ),
+    )
+    shipping_payer: Literal["seller", "buyer"] | None = Field(
+        default=None,
+        description=(
+            "Who pays shipping. 'seller' = 送料込み (buyer pays nothing extra). "
+            "Prefer this when the user asks for 'free shipping' or 送料込み. "
+            "Omit to accept either."
+        ),
+    )
 
     @override
     async def run(self, ctx: KernelContext) -> ToolReturnValue:
@@ -122,6 +150,10 @@ class MercariJpSearchTool(Tool):
             status=self.status,
             sort=self.sort,
             limit=self.limit,
+            category_ids=self.category_ids,
+            brand_ids=self.brand_ids,
+            item_condition=self.item_condition,
+            shipping_payer=self.shipping_payer,
         )
 
 

--- a/src/yaya/plugins/mercari_jp/search.py
+++ b/src/yaya/plugins/mercari_jp/search.py
@@ -45,6 +45,40 @@ class MercapiRejectedError(MercariSearchError):
     """Raised when Mercari refuses the request or serves an anti-bot response."""
 
 
+ItemCondition = Literal[
+    "new",
+    "like_new",
+    "no_scratches",
+    "small_scratches",
+    "scratches",
+    "poor",
+]
+"""User-facing condition tokens mapped to Mercari's 1..6 ``itemConditionId``.
+
+Order mirrors :data:`_CONDITION_LABELS`: 1=新品 (``new``) through
+6=全体的に状態が悪い (``poor``). The tool surface uses English tokens so
+LLMs pick the right bucket without knowing Japanese labels.
+"""
+
+_ITEM_CONDITION_IDS: dict[ItemCondition, int] = {
+    "new": 1,
+    "like_new": 2,
+    "no_scratches": 3,
+    "small_scratches": 4,
+    "scratches": 5,
+    "poor": 6,
+}
+
+ShippingPayer = Literal["seller", "buyer"]
+"""Who pays shipping. Maps to Mercari's ``shippingPayerId``: 2 = seller
+("送料込み"), 1 = buyer. Most buyers prefer ``seller``."""
+
+_SHIPPING_PAYER_IDS: dict[ShippingPayer, int] = {
+    "seller": 2,
+    "buyer": 1,
+}
+
+
 class MercariSearchRequest(BaseModel):
     """Structured search request for Mercari JP search.
 
@@ -58,6 +92,15 @@ class MercariSearchRequest(BaseModel):
         status: Desired sale status.
         sort: Desired sort mode.
         limit: Maximum normalized candidates returned to the caller.
+        category_ids: Mercari ``categoryId`` filter; combines with ``OR``.
+            Kept id-based because category name → id resolution belongs
+            in a separate lookup tool (future #191 follow-up).
+        brand_ids: Mercari ``brandId`` filter; combines with ``OR``.
+        item_condition: Single condition bucket. Maps to Mercari's
+            ``itemConditionId`` (1 = new … 6 = poor).
+        shipping_payer: ``seller`` or ``buyer``. Maps to Mercari's
+            ``shippingPayerId``. Users asking for "送料込み" want
+            ``seller``.
     """
 
     keyword: str = Field(min_length=1)
@@ -69,6 +112,10 @@ class MercariSearchRequest(BaseModel):
     status: Literal["on_sale", "sold_out", "all"] = "on_sale"
     sort: Literal["recommended", "newest", "price_asc", "price_desc"] = "recommended"
     limit: int = Field(default=20, ge=1, le=50)
+    category_ids: list[int] = Field(default_factory=lambda: [])
+    brand_ids: list[int] = Field(default_factory=lambda: [])
+    item_condition: ItemCondition | None = None
+    shipping_payer: ShippingPayer | None = None
 
     @property
     def query_term(self) -> str:
@@ -172,8 +219,25 @@ def build_mercari_search_url(request: MercariSearchRequest) -> str:
 
 
 def build_mercapi_search_payload(request: MercariSearchRequest) -> dict[str, Any]:
-    """Build the JSON search payload used by take-kun/mercapi."""
+    """Build the JSON search payload used by take-kun/mercapi.
+
+    Filter fields map to Mercari's search schema:
+
+    * ``categoryId`` / ``brandId`` accept lists; a list of one is how
+      Mercari's web UI narrows to a single category or brand.
+    * ``itemConditionId`` is also a list even though our surface
+      accepts a single bucket (``item_condition``) — matches the
+      upstream API shape, keeps the door open for a multi-select.
+    * ``shippingPayerId`` is a list of the same numeric IDs the mobile
+      app sends (1 = buyer, 2 = seller).
+    """
     sort_by, sort_order = _mercapi_sort(request.sort)
+    condition_ids: list[int] = []
+    if request.item_condition is not None:
+        condition_ids.append(_ITEM_CONDITION_IDS[request.item_condition])
+    shipping_payer_ids: list[int] = []
+    if request.shipping_payer is not None:
+        shipping_payer_ids.append(_SHIPPING_PAYER_IDS[request.shipping_payer])
     return {
         "userId": "",
         "pageSize": 120,
@@ -187,13 +251,13 @@ def build_mercapi_search_payload(request: MercariSearchRequest) -> dict[str, Any
             "order": sort_order,
             "status": _mercapi_status(request.status),
             "sizeId": [],
-            "categoryId": [],
-            "brandId": [],
+            "categoryId": [str(cid) for cid in request.category_ids],
+            "brandId": [str(bid) for bid in request.brand_ids],
             "sellerId": [],
             "priceMin": request.min_price_jpy or 0,
             "priceMax": request.max_price_jpy or 0,
-            "itemConditionId": [],
-            "shippingPayerId": [],
+            "itemConditionId": [str(cid) for cid in condition_ids],
+            "shippingPayerId": [str(pid) for pid in shipping_payer_ids],
             "shippingFromArea": [],
             "shippingMethod": [],
             "colorId": [],

--- a/tests/bdd/features/plugin-mercari_jp.feature
+++ b/tests/bdd/features/plugin-mercari_jp.feature
@@ -16,3 +16,8 @@ Feature: Mercari Japan search plugin
     Given Mercapi returns a Mercari search response with no product candidates
     When the mercari_jp_search tool runs
     Then it returns an empty candidate list with warnings containing Mercari coverage and Japanese keyword guidance
+
+  Scenario: Filter fields map onto the Mercapi payload
+    Given a search request with category, brand, item_condition, and shipping_payer filters set
+    When the Mercapi payload is built
+    Then the payload carries the expected category, brand, condition, and shipping-payer IDs

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -437,6 +437,37 @@ def _mercari_empty_result(ctx: BDDContext) -> None:
     assert any("keyword" in warning for warning in data["warnings"])
 
 
+@given("a search request with category, brand, item_condition, and shipping_payer filters set")
+def _mercari_filter_request(ctx: BDDContext) -> None:
+    from yaya.plugins.mercari_jp.search import MercariSearchRequest
+
+    ctx.extras["mercari_filter_request"] = MercariSearchRequest(
+        keyword="iPhone 15",
+        category_ids=[7, 1346],
+        brand_ids=[9999],
+        item_condition="new",
+        shipping_payer="seller",
+    )
+
+
+@when("the Mercapi payload is built")
+def _mercari_build_payload(ctx: BDDContext) -> None:
+    from yaya.plugins.mercari_jp.search import build_mercapi_search_payload
+
+    request = ctx.extras["mercari_filter_request"]
+    ctx.extras["mercari_filter_payload"] = build_mercapi_search_payload(request)
+
+
+@then("the payload carries the expected category, brand, condition, and shipping-payer IDs")
+def _mercari_payload_carries_filters(ctx: BDDContext) -> None:
+    payload = ctx.extras["mercari_filter_payload"]
+    cond = payload["searchCondition"]
+    assert cond["categoryId"] == ["7", "1346"]
+    assert cond["brandId"] == ["9999"]
+    assert cond["itemConditionId"] == ["1"]
+    assert cond["shippingPayerId"] == ["2"]
+
+
 # -- memory-sqlite ----------------------------------------------------------
 
 

--- a/tests/plugins/mercari_jp/test_plugin.py
+++ b/tests/plugins/mercari_jp/test_plugin.py
@@ -314,6 +314,62 @@ def test_mercari_search_url_and_request_filters() -> None:
     assert desc_payload["searchCondition"]["order"] == "ORDER_DESC"
 
 
+def test_filter_fields_land_on_mercapi_payload() -> None:
+    """#191 — category / brand / condition / shipping_payer map to Mercari's schema.
+
+    Mercari takes string IDs in its JSON lists; condition and shipping_payer
+    surface as single-item lists even though the tool accepts a single bucket
+    so downstream widening to multi-select is a no-op.
+    """
+    payload = build_mercapi_search_payload(
+        MercariSearchRequest(
+            keyword="iPhone 15",
+            category_ids=[7, 1346],
+            brand_ids=[9999],
+            item_condition="new",
+            shipping_payer="seller",
+        )
+    )
+    cond = payload["searchCondition"]
+    assert cond["categoryId"] == ["7", "1346"]
+    assert cond["brandId"] == ["9999"]
+    assert cond["itemConditionId"] == ["1"]
+    assert cond["shippingPayerId"] == ["2"]
+
+
+def test_filter_defaults_preserve_legacy_payload_shape() -> None:
+    """Unset filters must round-trip empty lists, same as before #191."""
+    payload = build_mercapi_search_payload(MercariSearchRequest(keyword="iPhone"))
+    cond = payload["searchCondition"]
+    assert cond["categoryId"] == []
+    assert cond["brandId"] == []
+    assert cond["itemConditionId"] == []
+    assert cond["shippingPayerId"] == []
+
+
+def test_item_condition_buckets_cover_1_through_6() -> None:
+    """Every token in the public surface maps to a unique 1..6 Mercari id."""
+    mapping: dict[str, list[str]] = {}
+    for token in ("new", "like_new", "no_scratches", "small_scratches", "scratches", "poor"):
+        payload = build_mercapi_search_payload(
+            MercariSearchRequest(keyword="x", item_condition=token)  # pyright: ignore[reportArgumentType]
+        )
+        mapping[token] = payload["searchCondition"]["itemConditionId"]
+    assert mapping["new"] == ["1"]
+    assert mapping["like_new"] == ["2"]
+    assert mapping["no_scratches"] == ["3"]
+    assert mapping["small_scratches"] == ["4"]
+    assert mapping["scratches"] == ["5"]
+    assert mapping["poor"] == ["6"]
+
+
+def test_shipping_payer_tokens_map_to_mercari_ids() -> None:
+    seller = build_mercapi_search_payload(MercariSearchRequest(keyword="x", shipping_payer="seller"))
+    buyer = build_mercapi_search_payload(MercariSearchRequest(keyword="x", shipping_payer="buyer"))
+    assert seller["searchCondition"]["shippingPayerId"] == ["2"]
+    assert buyer["searchCondition"]["shippingPayerId"] == ["1"]
+
+
 async def test_plugin_registers_unregisters_and_reports_health(tmp_path: Path) -> None:
     """Plugin lifecycle owns the mercari_jp_search v1 tool registration."""
     plugin = MercariJpPlugin()


### PR DESCRIPTION
## Summary

Extends \`mercari_jp_search\` so the agent can actually narrow results beyond free-form keyword. Four new optional fields surface on the v1 tool schema and land on Mercari's native search filters:

- \`category_ids: list[int]\` → Mercari \`categoryId\`
- \`brand_ids: list[int]\` → Mercari \`brandId\`
- \`item_condition\`: \`new\` / \`like_new\` / \`no_scratches\` / \`small_scratches\` / \`scratches\` / \`poor\` → Mercari's 1..6 \`itemConditionId\`
- \`shipping_payer\`: \`seller\` (送料込み) / \`buyer\` → Mercari's \`shippingPayerId\` 2 / 1

Unset fields serialise as empty lists, so the Mercapi payload is byte-for-byte identical to pre-#191 for existing callers.

**Scope note**: the \`mercari_jp_item_detail\` tool from the original issue is deferred to a follow-up. The Mercari item endpoint shape is not verifiable without a live request, and I would rather not ship a detail tool that maps to the wrong endpoint. Filters alone give #192 enough signal to fix the recommendation contract.

## Test plan

- [x] Unit: filter payload shape, legacy empty-list shape, each condition/shipping token mapped
- [x] BDD: new scenario in \`plugin-mercari_jp.feature\` + spec
- [x] \`just check\`, \`just test\`
- [ ] WS smoke: "Find a new-condition iPhone 15 case under ¥1000" carries \`item_condition: \"new\"\` + \`max_price_jpy: 1000\`

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)