### PR TITLE
feat(strategy_react): mercari shopping output contract (#192)

### DIFF
--- a/specs/plugin-strategy_react.spec
+++ b/specs/plugin-strategy_react.spec
@@ -48,6 +48,12 @@ testable and deterministic.
   `[yaya:react-format-nudge] `) via `messages_append` and re-rolls.
   A second consecutive parse failure terminates the turn with
   `{"next": "done"}` — no endless retries.
+- When `mercari_jp_search` is present in the tool registry, the system
+  prompt appends a Shopping Output Contract pinning the Final Answer
+  to a single markdown table (`| Rank | Title | Price (JPY) |
+  Condition | Why it fits | Link |`, exactly 3 rows), requiring each
+  `Why it fits` to cite a user-stated constraint. Absent the tool the
+  contract is omitted so generic chats are unaffected.
 
 ## Boundaries
 
@@ -133,6 +139,15 @@ Scenario: Error path — strategy.decide.request missing state payload raises fo
   Given a strategy.decide.request whose payload omits the state key entirely
   When the ReAct plugin handles the event
   Then the handler raises ValueError so the kernel synthesizes a plugin.error
+
+Scenario: Shopping output contract appears only when mercari_jp_search is registered
+  Test:
+    Package: yaya
+    Filter: tests/plugins/strategy_react/test_strategy_react.py::test_system_prompt_adds_shopping_contract_when_mercari_tool_present
+  Level: unit
+  Given the live tool registry contains mercari_jp_search
+  When the ReAct system prompt is composed
+  Then it pins the Final Answer to the required 3-row markdown table shape
 
 ## Out of Scope
 

--- a/src/yaya/plugins/strategy_react/plugin.py
+++ b/src/yaya/plugins/strategy_react/plugin.py
@@ -276,6 +276,42 @@ def _has_recent_retry_marker(messages: list[dict[str, Any]]) -> bool:
     return False
 
 
+_MERCARI_SEARCH_TOOL = "mercari_jp_search"
+"""Tool name that triggers the Mercari shopping output contract (#192)."""
+
+
+def _shopping_contract_lines() -> list[str]:
+    """Output contract appended when the Mercari search tool is installed.
+
+    Stops the model from drifting between 3-vs-5 rows, generic reasons,
+    and format variations across turns — pins the final answer to a
+    single markdown table shape that the user and downstream clients
+    can rely on. Triggered only when ``mercari_jp_search`` is in the
+    tool registry so generic chats are unaffected.
+    """
+    return [
+        "",
+        "Shopping output contract (applies when you called mercari_jp_search):",
+        "- Your Final Answer MUST be a single markdown table with these",
+        "  columns, in this order:",
+        "  | Rank | Title | Price (JPY) | Condition | Why it fits | Link |",
+        "- Produce exactly 3 rows, ranked 1..3. If the tool returned fewer",
+        "  than 3 candidates, include all of them and add one short",
+        "  apology line below the table listing up to 3 alternative",
+        "  keywords the user could try.",
+        "- Each 'Why it fits' cell MUST cite at least one constraint the",
+        "  user actually stated — price ceiling, condition, brand,",
+        "  keyword, Japanese term, free shipping, etc. Generic phrases",
+        "  like 'good price', 'available', or 'new' without a concrete",
+        "  reference to the user's ask are not acceptable.",
+        "- The three 'Why it fits' cells MUST NOT be identical.",
+        "- 'Link' is the raw Mercari URL from the tool result; do not",
+        "  wrap it in extra text.",
+        "- Put nothing above or below the table except (when relevant)",
+        "  the single apology + alternatives line.",
+    ]
+
+
 def _build_system_prompt(tool_specs: list[dict[str, Any]]) -> str:
     """Compose the ReAct system prompt from the live tool registry.
 
@@ -286,6 +322,7 @@ def _build_system_prompt(tool_specs: list[dict[str, Any]]) -> str:
     can reason about without requiring structured tool support on
     the provider side.
     """
+    tool_names: set[str] = set()
     lines: list[str] = [
         "You are yaya, an assistant that solves tasks by reasoning in the ReAct style.",
         "",
@@ -300,6 +337,7 @@ def _build_system_prompt(tool_specs: list[dict[str, Any]]) -> str:
                 continue
             fn = cast("dict[str, Any]", fn_raw)
             name = str(fn.get("name", "?"))
+            tool_names.add(name)
             desc = str(fn.get("description", "")).strip()
             params_raw = fn.get("parameters")
             params: dict[str, Any] = cast("dict[str, Any]", params_raw) if isinstance(params_raw, dict) else {}
@@ -340,6 +378,8 @@ def _build_system_prompt(tool_specs: list[dict[str, Any]]) -> str:
         "",
         "Never emit both an Action and a Final Answer in the same turn.",
     ]
+    if _MERCARI_SEARCH_TOOL in tool_names:
+        lines.extend(_shopping_contract_lines())
     return "\n".join(lines)
 
 

--- a/tests/bdd/features/plugin-strategy_react.feature
+++ b/tests/bdd/features/plugin-strategy_react.feature
@@ -37,3 +37,8 @@ Feature: ReAct strategy plugin
     Given a strategy.decide.request whose payload omits the state key entirely
     When the ReAct plugin handles the event
     Then the handler raises ValueError so the kernel synthesizes a plugin.error
+
+  Scenario: Shopping output contract appears only when mercari_jp_search is registered
+    Given the live tool registry contains mercari_jp_search
+    When the ReAct system prompt is composed
+    Then it pins the Final Answer to the required 3-row markdown table shape

--- a/tests/bdd/test_plugins.py
+++ b/tests/bdd/test_plugins.py
@@ -757,6 +757,39 @@ def _strategy_raises(ctx: BDDContext) -> None:
     assert isinstance(ctx.extras.get("raised"), ValueError)
 
 
+# -- strategy_react #192 shopping contract ---------------------------------
+
+
+@given("the live tool registry contains mercari_jp_search")
+def _strategy_tool_registry_has_mercari(ctx: BDDContext) -> None:
+    ctx.extras["strategy_tool_specs"] = [
+        {
+            "type": "function",
+            "function": {
+                "name": "mercari_jp_search",
+                "description": "Search Mercari Japan.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+@when("the ReAct system prompt is composed")
+def _strategy_build_prompt(ctx: BDDContext) -> None:
+    from yaya.plugins.strategy_react.plugin import _build_system_prompt
+
+    ctx.extras["strategy_prompt"] = _build_system_prompt(ctx.extras["strategy_tool_specs"])
+
+
+@then("it pins the Final Answer to the required 3-row markdown table shape")
+def _strategy_prompt_pins_contract(ctx: BDDContext) -> None:
+    prompt = ctx.extras["strategy_prompt"]
+    assert "Shopping output contract" in prompt
+    assert "| Rank | Title | Price (JPY) | Condition | Why it fits | Link |" in prompt
+    assert "exactly 3 rows" in prompt
+    assert "cite at least one constraint" in prompt
+
+
 # -- tool-bash --------------------------------------------------------------
 
 

--- a/tests/plugins/strategy_react/test_strategy_react.py
+++ b/tests/plugins/strategy_react/test_strategy_react.py
@@ -499,3 +499,53 @@ def test_system_prompt_forbids_content_in_thought() -> None:
     # Old loose phrasing must be gone.
     assert "<final reasoning>" not in prompt
     assert "<reason about what to do next>" not in prompt
+
+
+def test_system_prompt_adds_shopping_contract_when_mercari_tool_present() -> None:
+    """When mercari_jp_search is installed, the ReAct prompt pins the output contract.
+
+    Regression for #192: the model used to drift between 3-vs-5 rows and
+    generic "available" reasons. The system prompt now hard-pins the
+    markdown table shape and requires each why_it_fits to cite a
+    user-stated constraint.
+    """
+    from yaya.plugins.strategy_react.plugin import _build_system_prompt
+
+    mercari_spec = {
+        "type": "function",
+        "function": {
+            "name": "mercari_jp_search",
+            "description": "Search Mercari Japan.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    prompt = _build_system_prompt([mercari_spec])
+
+    assert "Shopping output contract" in prompt
+    # Table columns pinned in the exact order the UI renders them.
+    assert "| Rank | Title | Price (JPY) | Condition | Why it fits | Link |" in prompt
+    # Row count invariant.
+    assert "exactly 3 rows" in prompt
+    # Non-generic reason invariant — key phrases.
+    assert "cite at least one constraint" in prompt
+    # The contract must NOT leak into Thought (that lives in the earlier block).
+    assert prompt.index("Shopping output contract") > prompt.index("Final Answer:")
+
+
+def test_system_prompt_omits_shopping_contract_without_mercari_tool() -> None:
+    """Generic chats (no mercari_jp_search tool) must not see the contract."""
+    from yaya.plugins.strategy_react.plugin import _build_system_prompt
+
+    other_spec = {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    prompt_with_other = _build_system_prompt([other_spec])
+    prompt_empty = _build_system_prompt([])
+
+    assert "Shopping output contract" not in prompt_with_other
+    assert "Shopping output contract" not in prompt_empty


### PR DESCRIPTION
## Summary

Pins the Final Answer shape whenever \`mercari_jp_search\` is registered. This replaces the original "new skill plugin" idea: it was always a prompt-engineering problem, not a plugin-category one. 20 lines of prompt + tests > a new plugin with slot extraction + format enforcer.

- When the tool registry contains \`mercari_jp_search\`, the ReAct system prompt appends a Shopping Output Contract.
- Contract hard-pins: single markdown table, exact column order, exactly 3 rows (apology + alternatives when <3), non-generic \`Why it fits\` citing a user constraint, no duplicate reasons, raw Mercari links.
- Absent the tool, the contract is omitted so generic chats stay untouched.

Pairs with #193 (filters): the model sees it has narrowing knobs and real data, and is now told how to present them.

## Test plan

- [x] Unit: contract present when mercari tool registered, absent otherwise, contract appears after Final Answer in prompt order
- [x] BDD scenario + feature + step defs (\`plugin-strategy_react\`)
- [x] \`just check\`, \`just test\`
- [ ] WS smoke: "Find 3 cheapest iPhone 15 on Mercari JP" returns a 3-row table with distinct \`Why it fits\` each citing "cheapest"

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)