### PR TITLE
fix(cli/serve): open browser at the web adapter's port (#195)

### DIFF
--- a/src/yaya/cli/commands/serve.py
+++ b/src/yaya/cli/commands/serve.py
@@ -108,6 +108,22 @@ def _has_web_adapter(snapshot: list[dict[str, str]]) -> bool:
     )
 
 
+def _web_adapter_port(registry: PluginRegistry) -> int | None:
+    """Return the port the loaded web adapter is listening on.
+
+    The kernel's ``bound_port`` is not an HTTP port — it's a kernel
+    config construct with no listener behind it. The browser must
+    open the web adapter's uvicorn port instead (#195). Tolerates a
+    missing or not-yet-bound adapter by returning ``None`` so the
+    caller can skip the browser launch.
+    """
+    for plugin in registry.loaded_plugins(Category.ADAPTER):
+        port = getattr(plugin, "bound_port", None)
+        if isinstance(port, int) and port > 0:
+            return port
+    return None
+
+
 def _make_session_store(cfg: KernelConfig) -> SessionStore:
     """Build the :class:`SessionStore` for ``yaya serve``.
 
@@ -368,22 +384,27 @@ async def run_serve(  # noqa: C901 — linear lifecycle, each branch is a distin
                 "`yaya doctor` verifies the bus round-trip in the meantime."
             )
 
+        web_port = _web_adapter_port(registry) if web_present else None
+        web_url = f"http://{_BIND_HOST}:{web_port}/" if web_port is not None else None
+        status_lines = [
+            f"[green]yaya kernel live[/] (pid {os.getpid()})",
+        ]
+        if web_url is not None:
+            status_lines.append(f"[bold]web UI:[/] {web_url}")
+        elif web_present:
+            # Adapter loaded but port not yet reported — rare; warn so
+            # the user knows where to look manually.
+            status_lines.append("[yellow]web adapter loaded but has not reported its bound port yet.[/]")
+        status_lines.append("press Ctrl+C to stop.")
         emit_ok(
             state,
-            text=(
-                f"[green]yaya kernel live[/] on "
-                f"[bold]{_BIND_HOST}:{bound_port}[/] (pid {os.getpid()})\n"
-                "[dim]note: the web adapter may bind a different port; "
-                "check http://127.0.0.1:<adapter-port>/api/health or set "
-                "YAYA_WEB_PORT to pin it.[/]\n"
-                "press Ctrl+C to stop."
-            ),
+            text="\n".join(status_lines),
             action="serve.started",
-            addr=f"{_BIND_HOST}:{bound_port}",
+            addr=web_url if web_url is not None else f"{_BIND_HOST}:{bound_port}",
             pid=os.getpid(),
         )
 
-        if not no_open and web_present:
+        if not no_open and web_url is not None:
             # Best-effort; ``webbrowser.open`` can block for seconds on
             # macOS (launching Safari), so run it on the default
             # executor instead of stalling the event loop.
@@ -394,7 +415,7 @@ async def run_serve(  # noqa: C901 — linear lifecycle, each branch is a distin
                 await asyncio.get_running_loop().run_in_executor(
                     None,
                     webbrowser.open,
-                    f"http://{_BIND_HOST}:{bound_port}/",
+                    web_url,
                 )
             except Exception as exc:
                 warn(f"[yellow]failed to open browser:[/] {exc}")

--- a/src/yaya/plugins/web/plugin.py
+++ b/src/yaya/plugins/web/plugin.py
@@ -168,6 +168,17 @@ class WebAdapter:
         self._static_cm: Any = None
         self._static_path: Path | None = None
 
+    @property
+    def bound_port(self) -> int | None:
+        """Return the port uvicorn is listening on, or None before ``on_load``.
+
+        Exposed so the CLI (``yaya serve``) can open the browser at the
+        correct URL without duplicating the resolve logic. Kernel's
+        ``bound_port`` is a separate, non-HTTP construct; the real user-
+        facing address is this one.
+        """
+        return self._bound_port
+
     # -- ABI --------------------------------------------------------------------
 
     def subscriptions(self) -> list[str]:

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -246,6 +246,74 @@ async def test_run_serve_opens_browser_when_web_adapter_present(
 
 
 @pytest.mark.asyncio
+async def test_run_serve_opens_browser_at_web_adapter_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#195: browser URL is the adapter's uvicorn port, not the kernel's bound_port.
+
+    Before #195, ``serve`` opened ``http://127.0.0.1:{bound_port}/`` where
+    ``bound_port`` was the kernel config port — nothing listens there, so
+    the user saw "Unable to connect". The adapter's uvicorn runs on a
+    separate port resolved in ``_resolve_port``.
+    """
+    from yaya.cli.commands import serve as serve_mod
+
+    monkeypatch.setattr(serve_mod, "_has_web_adapter", lambda _snapshot: True)
+    # Pin the adapter port to a known sentinel that has no chance of
+    # colliding with the kernel's auto-picked port.
+    monkeypatch.setattr(serve_mod, "_web_adapter_port", lambda _registry: 54321)
+    calls: list[str] = []
+    monkeypatch.setattr(serve_mod.webbrowser, "open", lambda url: calls.append(url))
+
+    shutdown = asyncio.Event()
+    state = CLIState(json_output=True)
+    task = asyncio.create_task(
+        run_serve(
+            state,
+            port=0,
+            no_open=False,
+            strategy="react",
+            dev=False,
+            shutdown_event=shutdown,
+        )
+    )
+    await asyncio.sleep(0.2)
+    shutdown.set()
+    await asyncio.wait_for(task, timeout=5.0)
+    assert calls == ["http://127.0.0.1:54321/"], calls
+
+
+@pytest.mark.asyncio
+async def test_run_serve_skips_browser_when_adapter_has_no_bound_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#195: if the adapter reports no port, skip the browser launch entirely."""
+    from yaya.cli.commands import serve as serve_mod
+
+    monkeypatch.setattr(serve_mod, "_has_web_adapter", lambda _snapshot: True)
+    monkeypatch.setattr(serve_mod, "_web_adapter_port", lambda _registry: None)
+    calls: list[str] = []
+    monkeypatch.setattr(serve_mod.webbrowser, "open", lambda url: calls.append(url))
+
+    shutdown = asyncio.Event()
+    state = CLIState(json_output=True)
+    task = asyncio.create_task(
+        run_serve(
+            state,
+            port=0,
+            no_open=False,
+            strategy="react",
+            dev=False,
+            shutdown_event=shutdown,
+        )
+    )
+    await asyncio.sleep(0.2)
+    shutdown.set()
+    await asyncio.wait_for(task, timeout=5.0)
+    assert calls == [], f"browser was opened without a known port: {calls!r}"
+
+
+@pytest.mark.asyncio
 async def test_run_serve_warns_when_no_adapter(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/plugins/web/test_web_adapter.py
+++ b/tests/plugins/web/test_web_adapter.py
@@ -346,12 +346,26 @@ async def test_on_unload_stops_server(tmp_path: Path) -> None:
     await plugin.on_load(ctx)
     assert plugin._server_task is not None
     assert not plugin._server_task.done()
+    # #195: the public ``bound_port`` property surfaces the real uvicorn port
+    # so the CLI can open the browser at the correct URL without peeking
+    # at the private attribute.
+    assert plugin.bound_port == port
 
     await plugin.on_unload(ctx)
     # After unload the task must be done (completed or cancelled) and
     # the internal reference must be cleared.
     assert plugin._server is None
     assert plugin._server_task is None
+
+
+async def test_bound_port_is_none_before_on_load() -> None:
+    """#195: bound_port is None until on_load resolves the port.
+
+    The CLI relies on the None-vs-int distinction to decide whether
+    to skip the browser launch.
+    """
+    plugin = WebAdapter(port=9999)
+    assert plugin.bound_port is None
 
 
 async def test_plugin_inventory_is_seeded_at_load(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

\`yaya serve\` opened the browser to the kernel's \`bound_port\` — nothing listens on that port, the user saw "Unable to connect". The web adapter runs its own uvicorn on a separate port resolved inside \`_resolve_port\`.

- \`WebAdapter.bound_port\` property exposes the real uvicorn port.
- \`serve\` looks it up via \`registry.loaded_plugins(Category.ADAPTER)\` and opens THAT URL.
- Status output now prints the web UI URL when known; no URL printed + no browser opened when the adapter is absent or hasn't bound yet.

## Test plan

- [x] New unit: browser opens at sentinel adapter port (not kernel port)
- [x] New unit: when adapter reports no port, browser is not opened
- [x] New unit: \`bound_port\` is \`None\` before \`on_load\`, matches the pinned port after
- [x] \`just check\`, \`just test\`
- [ ] Manual: \`yaya serve\` opens the tab at the real adapter URL

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)